### PR TITLE
github/workflows: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           curl -H \
             "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" \
-          | jq .value \
+          | jq -r .value \
         )
 
         # sign all package distributions using the OIDC identity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,10 @@ jobs:
 
         # retrieve the OIDC identity
         identity_token=$( \
-          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" \
-            | jq .value \
+          curl -H \
+            "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" \
+          | jq .value \
         )
 
         # sign all package distributions using the OIDC identity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types:
+      - published
 
 name: release
 
@@ -9,24 +9,10 @@ jobs:
   pypi:
     name: upload release to PyPI
     runs-on: ubuntu-latest
-    permissions:
-      # NOTE: Needed to create GitHub releases.
-      contents: write
     steps:
     - uses: actions/checkout@v2
 
     - uses: actions/setup-python@v2
-
-    - name: create release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: ${{ contains(github.ref, 'pre') || contains(github.ref, 'rc') }}
 
     - name: deps
       run: python -m pip install -U setuptools build wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,9 @@ jobs:
 
     - name: sign
       run: |
-        # use the latest sigstore release, rather than the current dev changes
-        python -m pip install sigstore
+        # use the latest development changes for sigstore, at least
+        # until things are stabilized further
+        make dev && source env/bin/activate
 
         # retrieve the OIDC identity
         identity_token=$( \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/setup-python@v2
 
     - name: deps
-      run: python -m pip install -U setuptools build wheel
+      run: python -m pip install -U build
 
     - name: build
       run: python -m build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         # use the latest development changes for sigstore, at least
         # until things are stabilized further
-        make dev && source env/bin/activate
+        python -m pip install .
 
         # retrieve the OIDC identity
         identity_token=$( \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: release
+
+jobs:
+  pypi:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      # NOTE: Needed to create GitHub releases.
+      contents: write
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+
+    - name: create release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: ${{ contains(github.ref, 'pre') || contains(github.ref, 'rc') }}
+
+    - name: deps
+      run: python -m pip install -U setuptools build wheel
+
+    - name: build
+      run: python -m build
+
+    - name: publish
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   pypi:
-    name: upload release to PyPI
+    name: Build, sign and publish release to PyPI
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
 
 name: release
 
+# Needed to access the workflow's OIDC identity.
+permissions:
+  id-token: write
+
 jobs:
   pypi:
     name: upload release to PyPI
@@ -19,6 +23,20 @@ jobs:
 
     - name: build
       run: python -m build
+
+    - name: sign
+      run: |
+        # use the latest sigstore release, rather than the current dev changes
+        python -m pip install sigstore
+
+        # retrieve the OIDC identity
+        identity_token=$( \
+          curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" \
+            | jq .value \
+        )
+
+        # sign all package distributions using the OIDC identity
+        python -m sigstore sign --identity-token=${identity_token} dist/*
 
     - name: publish
       uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
This adds a release workflow for automating the creation of GitHub and PyPI releases whenever we release a new version of `sigstore-python`.