### PR TITLE
Sign releases with ambient credentials via Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,16 +30,8 @@ jobs:
         # until things are stabilized further
         python -m pip install .
 
-        # retrieve the OIDC identity
-        identity_token=$( \
-          curl -H \
-            "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" \
-          | jq -r .value \
-        )
-
-        # sign all package distributions using the OIDC identity
-        python -m sigstore sign --identity-token=${identity_token} dist/*
+        # sign all package distributions using the ambient OIDC identity
+        python -m sigstore sign dist/*
 
     - name: publish
       uses: pypa/gh-action-pypi-publish@master

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -45,8 +45,8 @@ def _sign(files, identity_token, ctfe_pem):
     # 3) Interactive OAuth flow
     if not identity_token:
         identity_token = detect_credential()
-        if not identity_token:
-            identity_token = get_identity_token()
+    if not identity_token:
+        identity_token = get_identity_token()
 
     ctfe_pem = ctfe_pem.read()
     for file in files:

--- a/sigstore/_internal/oidc/ambient.py
+++ b/sigstore/_internal/oidc/ambient.py
@@ -79,8 +79,11 @@ def detect_github() -> Optional[str]:
             "GitHub: missing or insufficient OIDC token permissions?"
         )
 
-    req_url = f"{req_url}&audience=sigstore"
-    resp = requests.get(req_url, headers={"Authorization": f"bearer {req_token}"})
+    resp = requests.get(
+        req_url,
+        params={"audience": "sigstore"},
+        headers={"Authorization": f"bearer {req_token}"},
+    )
     try:
         resp.raise_for_status()
     except requests.HTTPError as http_error:

--- a/sigstore/_internal/oidc/ambient.py
+++ b/sigstore/_internal/oidc/ambient.py
@@ -79,6 +79,7 @@ def detect_github() -> Optional[str]:
             "GitHub: missing or insufficient OIDC token permissions?"
         )
 
+    req_url = f"{req_url}&audience=sigstore"
     resp = requests.get(req_url, headers={"Authorization": f"bearer {req_token}"})
     try:
         resp.raise_for_status()

--- a/test/internal/oidc/test_ambient.py
+++ b/test/internal/oidc/test_ambient.py
@@ -68,7 +68,9 @@ def test_detect_github_request_fails(monkeypatch):
         ambient.detect_github()
     assert requests.get.calls == [
         pretend.call(
-            "fakeurl&audience=sigstore", headers={"Authorization": "bearer faketoken"}
+            "fakeurl",
+            params={"audience": "sigstore"},
+            headers={"Authorization": "bearer faketoken"},
         )
     ]
 
@@ -91,7 +93,9 @@ def test_detect_github_bad_payload(monkeypatch):
         ambient.detect_github()
     assert requests.get.calls == [
         pretend.call(
-            "fakeurl&audience=sigstore", headers={"Authorization": "bearer faketoken"}
+            "fakeurl",
+            params={"audience": "sigstore"},
+            headers={"Authorization": "bearer faketoken"},
         )
     ]
     assert resp.json.calls == [pretend.call()]
@@ -112,7 +116,9 @@ def test_detect_github(monkeypatch):
     assert ambient.detect_github() == "fakejwt"
     assert requests.get.calls == [
         pretend.call(
-            "fakeurl&audience=sigstore", headers={"Authorization": "bearer faketoken"}
+            "fakeurl",
+            params={"audience": "sigstore"},
+            headers={"Authorization": "bearer faketoken"},
         )
     ]
     assert resp.json.calls == [pretend.call()]

--- a/test/internal/oidc/test_ambient.py
+++ b/test/internal/oidc/test_ambient.py
@@ -67,7 +67,9 @@ def test_detect_github_request_fails(monkeypatch):
     ):
         ambient.detect_github()
     assert requests.get.calls == [
-        pretend.call("fakeurl", headers={"Authorization": "bearer faketoken"})
+        pretend.call(
+            "fakeurl&audience=sigstore", headers={"Authorization": "bearer faketoken"}
+        )
     ]
 
 
@@ -88,7 +90,9 @@ def test_detect_github_bad_payload(monkeypatch):
     ):
         ambient.detect_github()
     assert requests.get.calls == [
-        pretend.call("fakeurl", headers={"Authorization": "bearer faketoken"})
+        pretend.call(
+            "fakeurl&audience=sigstore", headers={"Authorization": "bearer faketoken"}
+        )
     ]
     assert resp.json.calls == [pretend.call()]
 
@@ -107,6 +111,8 @@ def test_detect_github(monkeypatch):
 
     assert ambient.detect_github() == "fakejwt"
     assert requests.get.calls == [
-        pretend.call("fakeurl", headers={"Authorization": "bearer faketoken"})
+        pretend.call(
+            "fakeurl&audience=sigstore", headers={"Authorization": "bearer faketoken"}
+        )
     ]
     assert resp.json.calls == [pretend.call()]


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->
This change hooks up the ambient credential detection to the CLI and uses it to sign releases in Github Actions.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
See https://github.com/sigstore/sigstore-python/issues/31. Does not close, since other detectors are needed.