### PR TITLE
Support configurable OIDC issuers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ Usage: sigstore sign [OPTIONS] FILE [FILE ...]
 Options:
   --identity-token TEXT
   --ctfe FILENAME
-  --help                 Show this message and exit.
+  --oidc-client-id TEXT
+  --oidc-client-secret TEXT
+  --oidc-issuer TEXT
+  --help                     Show this message and exit.
 ```
 <!-- @end-sigstore-sign-help@ -->
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Usage: sigstore sign [OPTIONS] FILE [FILE ...]
 
 Options:
   --identity-token TOKEN          the OIDC identity token to use
-  --ctfe FILENAME
+  --ctfe FILENAME                 A PEM-encoded public key for the CT log
   --oidc-client-id ID             The custom OpenID Connect client ID to use
   --oidc-client-secret SECRET     The custom OpenID Connect client secret to
                                   use

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ Signing:
 Usage: sigstore sign [OPTIONS] FILE [FILE ...]
 
 Options:
-  --identity-token TEXT
+  --identity-token TOKEN
   --ctfe FILENAME
-  --oidc-client-id TEXT
-  --oidc-client-secret TEXT
-  --oidc-issuer TEXT
-  --help                     Show this message and exit.
+  --oidc-client-id ID
+  --oidc-client-secret SECRET
+  --oidc-issuer URL
+  --help                       Show this message and exit.
 ```
 <!-- @end-sigstore-sign-help@ -->
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ Usage: sigstore sign [OPTIONS] FILE [FILE ...]
 Options:
   --identity-token TOKEN          the OIDC identity token to use
   --ctfe FILENAME
-  --oidc-client-id ID
-  --oidc-client-secret SECRET
-  --oidc-issuer URL
+  --oidc-client-id ID             The custom OpenID Connect client ID to use
+  --oidc-client-secret SECRET     The custom OpenID Connect client secret to
+                                  use
+  --oidc-issuer URL               The custom OpenID Connect issuer to use
   --oidc-disable-ambient-providers
                                   Disable ambient OIDC detection (e.g. on
                                   GitHub Actions)

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -44,6 +44,7 @@ def main():
     "--ctfe",
     type=click.File("rb"),
     default=resources.open_binary("sigstore._store", "ctfe.pub"),
+    help="A PEM-encoded public key for the CT log"
 )
 @click.option(
     "oidc_client_id",

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -51,6 +51,7 @@ def main():
     metavar="ID",
     type=click.STRING,
     default="sigstore",
+    help="The custom OpenID Connect client ID to use",
 )
 @click.option(
     "oidc_client_secret",
@@ -58,6 +59,7 @@ def main():
     metavar="SECRET",
     type=click.STRING,
     default=str(),
+    help="The custom OpenID Connect client secret to use",
 )
 @click.option(
     "oidc_issuer",
@@ -65,6 +67,7 @@ def main():
     metavar="URL",
     type=click.STRING,
     default="https://oauth2.sigstore.dev/auth",
+    help="The custom OpenID Connect issuer to use",
 )
 @click.option(
     "oidc_disable_ambient_providers",

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -28,7 +28,7 @@ def main():
 
 
 @main.command("sign")
-@click.option("identity_token", "--identity-token", type=click.STRING)
+@click.option("identity_token", "--identity-token", metavar="TOKEN", type=click.STRING)
 @click.option(
     "ctfe_pem",
     "--ctfe",
@@ -36,14 +36,23 @@ def main():
     default=resources.open_binary("sigstore._store", "ctfe.pub"),
 )
 @click.option(
-    "oidc_client_id", "--oidc-client-id", type=click.STRING, default="sigstore"
+    "oidc_client_id",
+    "--oidc-client-id",
+    metavar="ID",
+    type=click.STRING,
+    default="sigstore",
 )
 @click.option(
-    "oidc_client_secret", "--oidc-client-secret", type=click.STRING, default=str()
+    "oidc_client_secret",
+    "--oidc-client-secret",
+    metavar="SECRET",
+    type=click.STRING,
+    default=str(),
 )
 @click.option(
     "oidc_issuer",
     "--oidc-issuer",
+    metavar="URL",
     type=click.STRING,
     default="https://oauth2.sigstore.dev/auth",
 )

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -44,7 +44,7 @@ def main():
     "--ctfe",
     type=click.File("rb"),
     default=resources.open_binary("sigstore._store", "ctfe.pub"),
-    help="A PEM-encoded public key for the CT log"
+    help="A PEM-encoded public key for the CT log",
 )
 @click.option(
     "oidc_client_id",

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -81,7 +81,13 @@ def main():
     required=True,
 )
 def _sign(
-    files, identity_token, ctfe_pem, oidc_client_id, oidc_client_secret, oidc_issuer, oidc_disable_ambient_providers
+    files,
+    identity_token,
+    ctfe_pem,
+    oidc_client_id,
+    oidc_client_secret,
+    oidc_issuer,
+    oidc_disable_ambient_providers,
 ):
     # The order of precedence is as follows:
     #
@@ -97,7 +103,6 @@ def _sign(
             oidc_client_secret,
             issuer,
         )
-        identity_token = get_identity_token()
     if not identity_token:
         click.echo("No identity token supplied or detected!", err=True)
         raise click.Abort

--- a/sigstore/_internal/oidc/__init__.py
+++ b/sigstore/_internal/oidc/__init__.py
@@ -14,13 +14,13 @@
 
 import jwt
 
-# From https://github.com/sigstore/fulcio/blob/b2186c0/pkg/config/config.go#L182-L201
-OIDC_ISSUERS = {
+# See: https://github.com/sigstore/fulcio/blob/b2186c0/pkg/config/config.go#L182-L201
+_KNOWN_OIDC_ISSUERS = {
     "https://accounts.google.com": "email",
     "https://oauth2.sigstore.dev/auth": "email",
     "https://token.actions.githubusercontent.com": "sub",
 }
-AUDIENCE = "sigstore"
+_AUDIENCE = "sigstore"
 
 
 class IdentityError(Exception):
@@ -31,26 +31,32 @@ class Identity:
     def __init__(self, identity_token: str) -> None:
         identity_jwt = jwt.decode(identity_token, options={"verify_signature": False})
 
-        if "iss" not in identity_jwt:
-            raise IdentityError("Identity token  missing the required 'iss' claim")
-
         iss = identity_jwt.get("iss")
-
-        if iss not in OIDC_ISSUERS:
-            raise IdentityError(f"Not a valid OIDC issuer: {iss!r}")
+        if iss is None:
+            raise IdentityError("Identity token missing the required `iss` claim")
 
         if "aud" not in identity_jwt:
-            raise IdentityError("Identity token missing the required 'aud' claim")
+            raise IdentityError("Identity token missing the required `aud` claim")
 
         aud = identity_jwt.get("aud")
 
-        if aud != AUDIENCE:
-            raise IdentityError(f"Audience should be {AUDIENCE!r}, not {aud!r}")
+        if aud != _AUDIENCE:
+            raise IdentityError(f"Audience should be {_AUDIENCE!r}, not {aud!r}")
 
-        proof_claim = OIDC_ISSUERS[iss]
-        if proof_claim not in identity_jwt:
-            raise IdentityError(
-                f"Identity token missing the required {proof_claim!r} claim"
-            )
+        # When verifying the private key possession proof, Fulcio uses
+        # different claims depending on the token's issuer.
+        # We currently special-case a handful of these, and fall back
+        # on signing the "sub" claim otherwise.
+        proof_claim = _KNOWN_OIDC_ISSUERS.get(iss)
+        if proof_claim is not None:
+            if proof_claim not in identity_jwt:
+                raise IdentityError(
+                    f"Identity token missing the required `{proof_claim!r}` claim"
+                )
 
-        self.proof: str = str(identity_jwt.get(proof_claim))
+            self.proof = str(identity_jwt.get(proof_claim))
+        else:
+            try:
+                self.proof = str(identity_jwt["sub"])
+            except KeyError:
+                raise IdentityError("Identity token missing `sub` claim")

--- a/sigstore/_internal/oidc/issuer.py
+++ b/sigstore/_internal/oidc/issuer.py
@@ -37,18 +37,18 @@ class Issuer:
         except requests.HTTPError as http_error:
             raise IssuerError from http_error
 
-        self.struct = resp.json()
+        struct = resp.json()
 
         try:
-            self.auth_endpoint: str = self.struct["authorization_endpoint"]
+            self.auth_endpoint: str = struct["authorization_endpoint"]
         except KeyError as key_error:
             raise IssuerError(
-                f"OIDC configuration does not contain authorization endpoint: {self.struct}"
+                f"OIDC configuration does not contain authorization endpoint: {struct}"
             ) from key_error
 
         try:
-            self.token_endpoint: str = self.struct["token_endpoint"]
+            self.token_endpoint: str = struct["token_endpoint"]
         except KeyError as key_error:
             raise IssuerError(
-                f"OIDC configuration does not contain token endpoint: {self.struct}"
+                f"OIDC configuration does not contain token endpoint: {struct}"
             ) from key_error

--- a/sigstore/_internal/oidc/issuer.py
+++ b/sigstore/_internal/oidc/issuer.py
@@ -1,0 +1,54 @@
+# Copyright 2022 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Helper that queries the OpenID configuration for a given issuer and extracts its endpoints
+"""
+
+import urllib.parse
+
+import requests
+
+
+class IssuerError(Exception):
+    pass
+
+
+class Issuer:
+    def __init__(self, base_url: str) -> None:
+        oidc_config_url = urllib.parse.urljoin(
+            f"{base_url}/", ".well-known/openid-configuration"
+        )
+
+        resp: requests.Response = requests.get(oidc_config_url)
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError as http_error:
+            raise IssuerError from http_error
+
+        self.struct = resp.json()
+
+        try:
+            self.auth_endpoint: str = self.struct["authorization_endpoint"]
+        except KeyError as key_error:
+            raise IssuerError(
+                f"OIDC configuration does not contain authorization endpoint: {self.struct}"
+            ) from key_error
+
+        try:
+            self.token_endpoint: str = self.struct["token_endpoint"]
+        except KeyError as key_error:
+            raise IssuerError(
+                f"OIDC configuration does not contain token endpoint: {self.struct}"
+            ) from key_error

--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -21,11 +21,12 @@ import time
 import urllib.parse
 import uuid
 import webbrowser
-from typing import Dict, cast
+from typing import Dict, List, Optional, cast
 
 import requests
 
 from sigstore._internal.oidc import IdentityError
+from sigstore._internal.oidc.issuer import Issuer
 
 AUTH_SUCCESS_HTML = """
 <html>
@@ -68,13 +69,16 @@ OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"
 
 
 class RedirectServer(http.server.HTTPServer):
-    def __init__(self):
+    def __init__(self, client_id: str, client_secret: str, issuer: Issuer) -> None:
         super().__init__(("127.0.0.1", 0), RedirectHandler)
-        self.state = None
-        self.nonce = None
-        self.auth_response = None
-        self._port: int = self.socket.getsockname()[1]
+        self.state: Optional[str] = None
+        self.nonce: Optional[str] = None
+        self.auth_response: Optional[Dict[str, List[str]]] = None
         self.is_oob = False
+        self._port: int = self.socket.getsockname()[1]
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._issuer = issuer
 
     @property
     def active(self) -> bool:
@@ -108,7 +112,8 @@ class RedirectServer(http.server.HTTPServer):
         self.nonce = str(uuid.uuid4())
         return {
             "response_type": "code",
-            "client_id": "sigstore",
+            "client_id": self._client_id,
+            "client_secret": self._client_secret,
             "scope": "openid email",
             "redirect_uri": self.redirect_uri,
             "code_challenge": code_challenge.decode("utf-8"),
@@ -119,13 +124,13 @@ class RedirectServer(http.server.HTTPServer):
 
     def auth_request(self) -> str:
         params = self.auth_request_params()
-        return "https://oauth2.sigstore.dev/auth/auth?" + urllib.parse.urlencode(params)
+        return f"{self._issuer.auth_endpoint}?{urllib.parse.urlencode(params)}"
 
     def enable_oob(self) -> None:
         self.is_oob = True
 
 
-def get_identity_token() -> str:
+def get_identity_token(client_id: str, client_secret: str, issuer: Issuer) -> str:
     """
     Retrieve an OpenID Connect token from the Sigstore provider
 
@@ -134,7 +139,7 @@ def get_identity_token() -> str:
     """
 
     code: str
-    with RedirectServer() as server:
+    with RedirectServer(client_id, client_secret, issuer) as server:
         # Launch web browser
         if webbrowser.open(server.base_uri):
             print(f"Your browser will now be opened to:\n{server.auth_request()}\n")
@@ -175,11 +180,11 @@ def get_identity_token() -> str:
         "code_verifier": server.code_verifier.decode("utf-8"),
     }
     auth = (
-        "sigstore",
-        "",  # Client secret
+        client_id,
+        client_secret,
     )
     resp: requests.Response = requests.post(
-        "https://oauth2.sigstore.dev/auth/token",
+        issuer.token_endpoint,
         data=data,
         auth=auth,
     )

--- a/sigstore/_sign.py
+++ b/sigstore/_sign.py
@@ -87,6 +87,13 @@ def sign(file: BinaryIO, identity_token: str, ctfe_pem: bytes) -> SigningResult:
     # )
     # certificate_request = builder.sign(private_key, hashes.SHA256())
 
+    # NOTE: The proof here is not a proof of identity, but solely
+    # a proof that we possess the private key. Fulcio verifies this
+    # signature using the public key we give it and the "subject",
+    # which is a function of one or more claims in the identity token.
+    # An identity token whose issuer is unknown to Fulcio will fail this
+    # test, since Fulcio won't know how to construct the subject.
+    # See: https://github.com/sigstore/fulcio/blob/f6016fd/pkg/challenges/challenges.go#L437-L478
     signed_proof = private_key.sign(
         oidc_identity.proof.encode(), ec.ECDSA(hashes.SHA256())
     )


### PR DESCRIPTION
Signed-off-by: Alex Cameron <asc@tetsuo.sh>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

This PR adds support for configurable OIDC issuers. An `oidc-issuer` flag has been added for this purpose. `sigstore` will query the issuer's `.well-known/openid-configuration` to find its endpoints and then use them to retrieve an OIDC token. The following flags have also been exposed since they need to be customised on a per issuer basis:
- `oidc-client-id`
- `oidc-client-secret`