### PR TITLE
setup: use importlib instead of exec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import importlib
 
 from setuptools import find_packages, setup
 
-version = importlib.import_module("._version", package="sigstore")
+version = importlib.import_module("sigstore._version")
 
 with open("./README.md") as f:
     long_description = f.read()

--- a/setup.py
+++ b/setup.py
@@ -13,19 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 
 from setuptools import find_packages, setup
 
-version = {}
-with open("./sigstore/_version.py") as f:
-    exec(f.read(), version)  # nosec B102
+version = importlib.import_module("._version", package="sigstore")
 
 with open("./README.md") as f:
     long_description = f.read()
 
 setup(
     name="sigstore",
-    version=version["__version__"],
+    version=version.__version__,
     license="Apache-2.0",
     author="Sigstore Authors",
     author_email="sigstore-dev@googlegroups.com",

--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -2,8 +2,6 @@
 The `sigstore` APIs.
 """
 
-from sigstore._sign import sign
-from sigstore._verify import verify
 from sigstore._version import __version__
 
-__all__ = ["__version__", "sign", "verify"]
+__all__ = ["__version__"]

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -16,9 +16,10 @@ from importlib import resources
 
 import click
 
-from sigstore import sign, verify
 from sigstore._internal.oidc.ambient import detect_credential
 from sigstore._internal.oidc.oauth import get_identity_token
+from sigstore._sign import sign
+from sigstore._verify import verify
 
 
 @click.group()

--- a/test/test_sign.py
+++ b/test/test_sign.py
@@ -15,7 +15,7 @@
 import pretend
 import pytest
 
-import sigstore
+from sigstore._sign import sign
 
 
 @pytest.mark.xfail
@@ -24,4 +24,4 @@ def test_sign():
     identity_token = pretend.stub()
     output = pretend.call_recorder(lambda s: None)
 
-    assert sigstore.sign(file_, identity_token, output) == "Nothing here yet"
+    assert sign(file_, identity_token, output) == "Nothing here yet"

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -15,7 +15,7 @@
 import pretend
 import pytest
 
-import sigstore
+from sigstore._verify import verify
 
 
 @pytest.mark.xfail
@@ -23,7 +23,4 @@ def test_verify():
     filename = pretend.stub()
     certificate_path = pretend.stub()
     signature_path = pretend.stub()
-    assert (
-        sigstore.verify(filename, certificate_path, signature_path)
-        == "Nothing here yet"
-    )
+    assert verify(filename, certificate_path, signature_path) == "Nothing here yet"


### PR DESCRIPTION
This also required some changes to the top-level `__init__.py`, to avoid importing runtime dependencies by default. We haven't stabilized a public API yet, so this shouldn't be a problem.