### PR TITLE
workflows/ci: check for license headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,19 @@ jobs:
       - name: test
         run: make test
 
+  licenses:
+    runs-on: ubuntu-latest
+    steps:
+      # adapted from Warehouse's bin/licenses
+      - run: |
+          for fn in $(find . -type f -name "*.py" -o); do
+              # Check for license in first 5 lines (allows for shebang,
+              # encoding and handles comment character in various languages)
+              if [[ ! "$(head -5 $fn | grep "^ *\(#\|\*\|\/\/\) .* License\(d*\)")" ]]; then
+                  echo $fn is missing a license
+                  exit 1
+              fi
+          done
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Ensures that every Python file starts with a license header.