### PR TITLE
Refactor: add logging, better isolate output

### DIFF
--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -60,12 +60,12 @@ def _sign(files, identity_token, ctfe_pem):
             ctfe_pem=ctfe_pem,
         )
 
-        click.echo(f"Signature: {result.b64_signature}")
         click.echo("Using ephemeral certificate:")
         click.echo(result.cert_pem)
         click.echo(
             f"Transparency log entry created at index: {result.log_entry.log_index}"
         )
+        click.echo(f"Signature: {result.b64_signature}")
 
 
 @main.command("verify")

--- a/test/test_sign.py
+++ b/test/test_sign.py
@@ -22,6 +22,5 @@ from sigstore._sign import sign
 def test_sign():
     file_ = pretend.stub()
     identity_token = pretend.stub()
-    output = pretend.call_recorder(lambda s: None)
 
-    assert sign(file_, identity_token, output) == "Nothing here yet"
+    assert sign(file_, identity_token) == "Nothing here yet"

--- a/test/test_sign.py
+++ b/test/test_sign.py
@@ -22,5 +22,6 @@ from sigstore._sign import sign
 def test_sign():
     file_ = pretend.stub()
     identity_token = pretend.stub()
+    ctfe_pem = pretend.stub()
 
-    assert sign(file_, identity_token) == "Nothing here yet"
+    assert sign(file_, identity_token, ctfe_pem) == "Nothing here yet"


### PR DESCRIPTION
This is just general refactoring: it adds use of `logging` in the CLI and signing modules, and makes `sign` return a `SigningResult` for eventual rendering instead of plumbing `click.echo` through a non-CLI API.