### PR TITLE
Publish cert to Rekor instead of pubkey

### DIFF
--- a/sigstore/_internal/rekor/_client.py
+++ b/sigstore/_internal/rekor/_client.py
@@ -146,7 +146,7 @@ class RekorEntries(Endpoint):
         self,
         b64_artifact_signature: str,
         sha256_artifact_hash: str,
-        encoded_public_key: str,
+        b64_cert: str,
     ) -> RekorEntry:
         data = {
             "kind": "hashedrekord",
@@ -154,7 +154,7 @@ class RekorEntries(Endpoint):
             "spec": {
                 "signature": {
                     "content": b64_artifact_signature,
-                    "publicKey": {"content": encoded_public_key},
+                    "publicKey": {"content": b64_cert},
                 },
                 "data": {
                     "hash": {"algorithm": "sha256", "value": sha256_artifact_hash}

--- a/sigstore/_sign.py
+++ b/sigstore/_sign.py
@@ -110,16 +110,10 @@ def sign(file: BinaryIO, identity_token: str, ctfe_pem: bytes) -> SigningResult:
     b64_artifact_signature = base64.b64encode(artifact_signature).decode()
 
     # Prepare inputs
-    pub_b64 = base64.b64encode(
-        public_key.public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-    )
+    b64_cert = base64.b64encode(cert.public_bytes(encoding=serialization.Encoding.PEM))
 
     # Create the transparency log entry
     rekor = RekorClient()
-    b64_cert = base64.b64encode(cert.public_bytes(encoding=serialization.Encoding.PEM))
     entry = rekor.log.entries.post(
         b64_artifact_signature=b64_artifact_signature,
         sha256_artifact_hash=sha256_artifact_hash,

--- a/sigstore/_sign.py
+++ b/sigstore/_sign.py
@@ -119,10 +119,11 @@ def sign(file: BinaryIO, identity_token: str, ctfe_pem: bytes) -> SigningResult:
 
     # Create the transparency log entry
     rekor = RekorClient()
+    b64_cert = base64.b64encode(cert.public_bytes(encoding=serialization.Encoding.PEM))
     entry = rekor.log.entries.post(
         b64_artifact_signature=b64_artifact_signature,
         sha256_artifact_hash=sha256_artifact_hash,
-        encoded_public_key=pub_b64.decode(),
+        b64_cert=b64_cert.decode(),
     )
 
     logger.debug(f"Transparency log entry created with index: {entry.log_index}")


### PR DESCRIPTION
This fixes a small bug where we were publishing the public key with the Rekor entry instead of the signing certificate (which includes the public key).

(cc @eddiezane)