### PR TITLE
pyproject, sigstore: use flit as our build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "sigstore"
@@ -63,15 +63,6 @@ dev = [
   "types-pyOpenSSL",
   "types-pyjwt",
 ]
-
-[tool.setuptools]
-packages = ["sigstore"]
-
-[tool.setuptools.dynamic]
-version = { attr = "sigstore.__version__" }
-
-[tool.setuptools.package-data]
-sigstore = ["_store/*"]
 
 [tool.isort]
 multi_line_output = 3

--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -16,6 +16,6 @@
 The `sigstore` APIs.
 """
 
-from sigstore._version import __version__
+from ._version import __version__
 
 __all__ = ["__version__"]


### PR DESCRIPTION
This will hopefully fix some of the distribution strangeness we're seeing.