### PR TITLE
oidc/ambient: constrain nosec

### DIFF
--- a/sigstore/_internal/oidc/ambient.py
+++ b/sigstore/_internal/oidc/ambient.py
@@ -28,7 +28,7 @@ from sigstore._internal.oidc import DEFAULT_AUDIENCE, IdentityError
 logger = logging.getLogger(__name__)
 
 GCP_PRODUCT_NAME_FILE = "/sys/class/dmi/id/product_name"
-GCP_ID_TOKEN_REQUEST_URL = "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity"  # noqa # nosec
+GCP_ID_TOKEN_REQUEST_URL = "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity"  # noqa # nosec B105
 
 
 class AmbientCredentialError(IdentityError):


### PR DESCRIPTION
Adds the specific false positive, so that we don't accidentally mask others.