### PR TITLE
Support Google Cloud impersonation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Options:
 ```
 <!-- @end-sigstore-sign-help@ -->
 
-Verifying
+Verifying:
 
 <!-- @begin-sigstore-verify-help@ -->
 ```
@@ -82,6 +82,18 @@ Options:
   --help                Show this message and exit.
 ```
 <!-- @end-sigstore-verify-help@ -->
+
+### Ambient credential detection
+
+For environments that support OIDC natively, `sigstore` supports automatic ambient credential detection:
+
+- GitHub:
+  - Actions: requires setting the `id-token` permission, see https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect. An example is [here](https://github.com/sigstore/sigstore-python/blob/main/.github/workflows/release.yml).
+- Google Cloud:
+  - Compute Engine: automatic
+  - Cloud Build: requires setting `GOOGLE_SERVICE_ACCOUNT_NAME` to an appropriately configured service account name, see https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-direct. An example is [here](https://github.com/sigstore/sigstore-python/blob/main/cloudbuild.yaml)
+- GitLab: planned, see https://github.com/sigstore/sigstore-python/issues/31
+- CircleCI: planned, see https://github.com/sigstore/sigstore-python/issues/31
 
 ## Licensing
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,12 @@
+steps:
+  # Install dependencies
+  - name: python
+    entrypoint: python
+    args: ["-m", "pip", "install", ".", "--user"]
+
+  # Sign with ambient GCP credentials
+  - name: python
+    entrypoint: python
+    args: ["-m", "sigstore", "sign", "README.md"]
+    env:
+      - "GOOGLE_SERVICE_ACCOUNT_NAME=sigstore-python-test@projectsigstore.iam.gserviceaccount.com"

--- a/sigstore/_internal/oidc/ambient.py
+++ b/sigstore/_internal/oidc/ambient.py
@@ -28,7 +28,9 @@ from sigstore._internal.oidc import DEFAULT_AUDIENCE, IdentityError
 logger = logging.getLogger(__name__)
 
 GCP_PRODUCT_NAME_FILE = "/sys/class/dmi/id/product_name"
-GCP_ID_TOKEN_REQUEST_URL = "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity"  # noqa # nosec B105
+GCP_TOKEN_REQUEST_URL = "http://metadata/computeMetadata/v1/instance/service-accounts/default/token"  # noqa # nosec B105
+GCP_IDENTITY_REQUEST_URL = "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity"  # noqa # nosec B105
+GCP_GENERATEIDTOKEN_REQUEST_URL = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}:generateIdToken"  # noqa
 
 
 class AmbientCredentialError(IdentityError):
@@ -107,31 +109,83 @@ def detect_github() -> Optional[str]:
 
 def detect_gcp() -> Optional[str]:
     logger.debug("GCP: looking for OIDC credentials")
-    try:
-        with open(GCP_PRODUCT_NAME_FILE) as f:
-            name = f.read().strip()
-    except OSError:
-        logger.debug("GCP: environment doesn't have GCP product name file; giving up")
-        return None
 
-    if name not in {"Google", "Google Compute Engine"}:
-        raise AmbientCredentialError(
-            f"GCP: product name file exists, but product name is {name!r}; giving up"
+    service_account_name = os.getenv("GOOGLE_SERVICE_ACCOUNT_NAME")
+    if service_account_name:
+        logger.debug("GCP: GOOGLE_SERVICE_ACCOUNT_NAME set; attempting impersonation")
+
+        logger.debug("GCP: requesting access token")
+        resp = requests.get(
+            GCP_TOKEN_REQUEST_URL,
+            params={"scopes": "https://www.googleapis.com/auth/cloud-platform"},
+            headers={"Metadata-Flavor": "Google"},
+        )
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError as http_error:
+            raise AmbientCredentialError(
+                f"GCP: access token request failed (code={resp.status_code})"
+            ) from http_error
+
+        access_token = resp.json().get("access_token")
+
+        if not access_token:
+            raise AmbientCredentialError("GCP: access token missing from response")
+
+        resp = requests.post(
+            GCP_GENERATEIDTOKEN_REQUEST_URL.format(service_account_name),
+            json={"audience": "sigstore", "includeEmail": True},
+            headers={
+                "Authorization": f"Bearer {access_token}",
+            },
         )
 
-    logger.debug("GCP: requesting OIDC token")
-    resp = requests.get(
-        GCP_ID_TOKEN_REQUEST_URL,
-        params={"audience": DEFAULT_AUDIENCE, "format": "full"},
-        headers={"Metadata-Flavor": "Google"},
-    )
+        logger.debug("GCP: requesting OIDC token")
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError as http_error:
+            raise AmbientCredentialError(
+                f"GCP: OIDC token request failed (code={resp.status_code})"
+            ) from http_error
 
-    try:
-        resp.raise_for_status()
-    except requests.HTTPError as http_error:
-        raise AmbientCredentialError(
-            f"GCP: OIDC token request failed (code={resp.status_code})"
-        ) from http_error
+        oidc_token: str = resp.json().get("token")
 
-    logger.debug("GCP: successfully requested OIDC token")
-    return resp.text
+        if not oidc_token:
+            raise AmbientCredentialError("GCP: OIDC token missing from response")
+
+        logger.debug("GCP: successfully requested OIDC token")
+        return oidc_token
+
+    else:
+        logger.debug("GCP: GOOGLE_SERVICE_ACCOUNT_NAME not set; skipping impersonation")
+
+        try:
+            with open(GCP_PRODUCT_NAME_FILE) as f:
+                name = f.read().strip()
+        except OSError:
+            logger.debug(
+                "GCP: environment doesn't have GCP product name file; giving up"
+            )
+            return None
+
+        if name not in {"Google", "Google Compute Engine"}:
+            raise AmbientCredentialError(
+                f"GCP: product name file exists, but product name is {name!r}; giving up"
+            )
+
+        logger.debug("GCP: requesting OIDC token")
+        resp = requests.get(
+            GCP_IDENTITY_REQUEST_URL,
+            params={"audience": DEFAULT_AUDIENCE, "format": "full"},
+            headers={"Metadata-Flavor": "Google"},
+        )
+
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError as http_error:
+            raise AmbientCredentialError(
+                f"GCP: OIDC token request failed (code={resp.status_code})"
+            ) from http_error
+
+        logger.debug("GCP: successfully requested OIDC token")
+        return resp.text


### PR DESCRIPTION
As a follow-on to #88, and towards #31, support service account impersonation, which makes it possible to use Google Cloud Build.

Also adds documentation for ambient credential detection.