### PR TITLE
_internal/fulcio: refactor SCT model

### DIFF
--- a/sigstore/_internal/fulcio/__init__.py
+++ b/sigstore/_internal/fulcio/__init__.py
@@ -21,12 +21,12 @@ from .client import (
     FulcioCertificateSigningRequest,
     FulcioCertificateSigningResponse,
     FulcioClient,
-    FulcioSignedCertificateTimestamp,
+    FulcioSCT,
 )
 
 __all__ = [
     "FulcioCertificateSigningRequest",
     "FulcioCertificateSigningResponse",
     "FulcioClient",
-    "FulcioSignedCertificateTimestamp",
+    "FulcioSCT",
 ]

--- a/sigstore/_internal/fulcio/__init__.py
+++ b/sigstore/_internal/fulcio/__init__.py
@@ -18,15 +18,15 @@ APIs for interacting with Fulcio.
 
 
 from .client import (
+    DetachedFulcioSCT,
     FulcioCertificateSigningRequest,
     FulcioCertificateSigningResponse,
     FulcioClient,
-    FulcioSCT,
 )
 
 __all__ = [
     "FulcioCertificateSigningRequest",
     "FulcioCertificateSigningResponse",
     "FulcioClient",
-    "FulcioSCT",
+    "DetachedFulcioSCT",
 ]

--- a/sigstore/_internal/fulcio/client.py
+++ b/sigstore/_internal/fulcio/client.py
@@ -91,7 +91,7 @@ class DetachedFulcioSCT(BaseModel):
 
     version: Version = Field(..., alias="sct_version")
     log_id: bytes = Field(..., alias="id")
-    raw_timestamp: int = Field(..., alias="timestamp")
+    timestamp: datetime.datetime
     digitally_signed: bytes = Field(..., alias="signature")
     extensions: bytes
 
@@ -115,10 +115,6 @@ class DetachedFulcioSCT(BaseModel):
     @validator("extensions", pre=True)
     def _validate_extensions(cls, v: bytes) -> bytes:
         return base64.b64decode(v)
-
-    @property
-    def timestamp(self) -> datetime.datetime:
-        return datetime.datetime.fromtimestamp(self.raw_timestamp / 1000)
 
     @property
     def entry_type(self) -> LogEntryType:

--- a/sigstore/_internal/fulcio/client.py
+++ b/sigstore/_internal/fulcio/client.py
@@ -96,20 +96,20 @@ class FulcioSCT(BaseModel):
         arbitrary_types_allowed = True
 
     @validator("digitally_signed", pre=True)
-    def _validate_digitally_signed(cls, v: str) -> bytes:
+    def _validate_digitally_signed(cls, v: bytes) -> bytes:
         digitally_signed = base64.b64decode(v)
 
-        if len(digitally_signed) < 4:
+        if len(digitally_signed) <= 4:
             raise ValueError("impossibly small digitally-signed struct")
 
         return digitally_signed
 
     @validator("log_id", pre=True)
-    def _validate_log_id(cls, v: str) -> bytes:
+    def _validate_log_id(cls, v: bytes) -> bytes:
         return base64.b64decode(v)
 
     @validator("extensions", pre=True)
-    def _validate_extensions(cls, v: str) -> bytes:
+    def _validate_extensions(cls, v: bytes) -> bytes:
         return base64.b64decode(v)
 
     @property
@@ -122,10 +122,14 @@ class FulcioSCT(BaseModel):
 
     @property
     def signature_hash_algorithm(self) -> int:
+        # TODO(ww): This should become a cryptography `Hash` subclass
+        # instance once cryptography adds this API.
         return self.digitally_signed[0]
 
     @property
     def signature_algorithm(self) -> int:
+        # TODO(ww): This should become a SignatureAlgorithm variant
+        # once cryptography adds this API.
         return self.digitally_signed[1]
 
     @property

--- a/sigstore/_internal/fulcio/client.py
+++ b/sigstore/_internal/fulcio/client.py
@@ -84,7 +84,11 @@ class FulcioSCTError(Exception):
     pass
 
 
-class FulcioSCT(BaseModel):
+class DetachedFulcioSCT(BaseModel):
+    """
+    Represents a "detached" SignedCertificateTimestamp from Fulcio.
+    """
+
     version: Version = Field(..., alias="sct_version")
     log_id: bytes = Field(..., alias="id")
     raw_timestamp: int = Field(..., alias="timestamp")
@@ -143,9 +147,9 @@ class FulcioSCT(BaseModel):
         return self.digitally_signed[4:]
 
 
-# SignedCertificateTimestamp is an ABC, so register our FulcioSCT as
+# SignedCertificateTimestamp is an ABC, so register our DetachedFulcioSCT as
 # virtual subclass.
-SignedCertificateTimestamp.register(FulcioSCT)
+SignedCertificateTimestamp.register(DetachedFulcioSCT)
 
 
 @dataclass(frozen=True)
@@ -176,7 +180,7 @@ class FulcioCertificateSigningResponse:
 
     cert: Certificate
     chain: List[Certificate]
-    sct: FulcioSCT
+    sct: DetachedFulcioSCT
 
 
 @dataclass(frozen=True)
@@ -241,7 +245,7 @@ class FulcioSigningCert(Endpoint):
             raise FulcioClientError from exc
 
         try:
-            sct = FulcioSCT.parse_obj(sct_json)
+            sct = DetachedFulcioSCT.parse_obj(sct_json)
         except Exception as exc:
             # Ideally we'd catch something less generic here.
             raise FulcioClientError from exc

--- a/sigstore/_internal/fulcio/client.py
+++ b/sigstore/_internal/fulcio/client.py
@@ -36,6 +36,7 @@ from cryptography.x509.certificate_transparency import (
     SignedCertificateTimestamp,
     Version,
 )
+from pydantic import BaseModel, Field, validator
 
 DEFAULT_FULCIO_URL = "https://fulcio.sigstore.dev"
 SIGNING_CERT_ENDPOINT = "/api/v1/signingCert"
@@ -83,70 +84,64 @@ class FulcioSCTError(Exception):
     pass
 
 
-class FulcioSignedCertificateTimestamp(SignedCertificateTimestamp):
-    def __init__(self, b64_encoded_sct: str):
-        self.struct = json.loads(base64.b64decode(b64_encoded_sct).decode())
+class FulcioSCT(BaseModel):
+    version: Version = Field(..., alias="sct_version")
+    log_id: bytes = Field(..., alias="id")
+    raw_timestamp: int = Field(..., alias="timestamp")
+    digitally_signed: bytes = Field(..., alias="signature")
+    extensions: bytes
 
-        # Pull the SCT version out of the struct and pre-validate it.
-        try:
-            self._version = Version(self.struct.get("sct_version"))
-        except ValueError as exc:
-            raise FulcioSCTError("invalid SCT version") from exc
+    class Config:
+        allow_population_by_field_name = True
+        arbitrary_types_allowed = True
 
-        # The "signature" here is really an RFC 5246 DigitallySigned struct;
-        # we need to decompose it further to get the actual interior signature.
-        # See: https://datatracker.ietf.org/doc/html/rfc5246#section-4.7
-        digitally_signed = base64.b64decode(self.struct["signature"])
+    @validator("digitally_signed", pre=True)
+    def _validate_digitally_signed(cls, v: str) -> bytes:
+        digitally_signed = base64.b64decode(v)
 
-        # The first two bytes signify the hash and signature algorithms, respectively.
-        # We currently only accept SHA256 + ECDSA.
-        hash_algo, sig_algo = digitally_signed[0:2]
-        if (
-            hash_algo != SCTHashAlgorithm.SHA256
-            or sig_algo != SCTSignatureAlgorithm.ECDSA
-        ):
-            raise FulcioSCTError(
-                f"unexpected hash algorithm {hash_algo} or signature algorithm {sig_algo}"
-            )
+        if len(digitally_signed) < 4:
+            raise ValueError("impossibly small digitally-signed struct")
 
-        # The next two bytes are the size of the signature, big-endian.
-        # We expect this to be the remainder of the `signature` blob above, but check it anyways.
-        (sig_size,) = struct.unpack("!H", digitally_signed[2:4])
-        if len(digitally_signed[4:]) != sig_size:
-            raise FulcioSCTError(
-                f"signature size mismatch: expected {sig_size} bytes, "
-                f"got {len(digitally_signed[4:])}"
-            )
+        return digitally_signed
 
-        # Finally, extract the underlying signature.
-        self.signature: bytes = digitally_signed[4:]
+    @validator("log_id", pre=True)
+    def _validate_log_id(cls, v: str) -> bytes:
+        return base64.b64decode(v)
 
-    @property
-    def version(self) -> Version:
-        return self._version
-
-    @property
-    def log_id(self) -> bytes:
-        """
-        Returns an identifier indicating which log this SCT is for.
-        """
-        # The ID from fulcio is a base64 encoded bytestring of the SHA256 hash
-        # of the public cert. Call .hex() on this when displaying.
-        return base64.b64decode(self.struct.get("id"))
+    @validator("extensions", pre=True)
+    def _validate_extensions(cls, v: str) -> bytes:
+        return base64.b64decode(v)
 
     @property
     def timestamp(self) -> datetime.datetime:
-        """
-        Returns the timestamp for this SCT.
-        """
-        return datetime.datetime.fromtimestamp(self.struct["timestamp"] / 1000.0)
+        return datetime.datetime.fromtimestamp(self.raw_timestamp / 1000)
 
     @property
     def entry_type(self) -> LogEntryType:
-        """
-        Returns whether this is an SCT for a certificate or pre-certificate.
-        """
         return LogEntryType.X509_CERTIFICATE
+
+    @property
+    def signature_hash_algorithm(self) -> int:
+        return self.digitally_signed[0]
+
+    @property
+    def signature_algorithm(self) -> int:
+        return self.digitally_signed[1]
+
+    @property
+    def signature(self) -> bytes:
+        (sig_size,) = struct.unpack("!H", self.digitally_signed[2:4])
+        if len(self.digitally_signed[4:]) != sig_size:
+            raise FulcioSCTError(
+                f"signature size mismatch: expected {sig_size} bytes, "
+                f"got {len(self.digitally_signed[4:])}"
+            )
+        return self.digitally_signed[4:]
+
+
+# SignedCertificateTimestamp is an ABC, so register our FulcioSCT as
+# virtual subclass.
+SignedCertificateTimestamp.register(FulcioSCT)
 
 
 @dataclass(frozen=True)
@@ -177,7 +172,7 @@ class FulcioCertificateSigningResponse:
 
     cert: Certificate
     chain: List[Certificate]
-    sct: FulcioSignedCertificateTimestamp
+    sct: FulcioSCT
 
 
 @dataclass(frozen=True)
@@ -229,8 +224,20 @@ class FulcioSigningCert(Endpoint):
             except (AttributeError, KeyError):
                 raise FulcioClientError from http_error
 
+        # The SCT header is a base64-encoded payload, which in turn
+        # is a JSON representation of the SignedCertificateTimestamp
+        # in RFC 6962 (subsec. 3.2).
+        sct_b64 = resp.headers.get("SCT")
+        if sct_b64 is None:
+            raise FulcioClientError("Fulcio response did not include a SCT header")
+
         try:
-            sct = FulcioSignedCertificateTimestamp(resp.headers["SCT"])
+            sct_json = json.loads(base64.b64decode(sct_b64).decode())
+        except ValueError as exc:
+            raise FulcioClientError from exc
+
+        try:
+            sct = FulcioSCT.parse_obj(sct_json)
         except Exception as exc:
             # Ideally we'd catch something less generic here.
             raise FulcioClientError from exc

--- a/sigstore/_internal/sct.py
+++ b/sigstore/_internal/sct.py
@@ -57,7 +57,7 @@ def _pack_digitally_signed(sct: DetachedFulcioSCT, cert: Certificate) -> bytes:
         pattern,
         sct.version.value,
         0,  # Signature Type
-        sct.raw_timestamp,
+        int(sct.timestamp.timestamp() * 1000),
         0,  # Entry Type
         len1,
         len2,

--- a/sigstore/_internal/sct.py
+++ b/sigstore/_internal/sct.py
@@ -23,12 +23,10 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.x509 import Certificate
 
-from sigstore._internal.fulcio import FulcioSignedCertificateTimestamp
+from sigstore._internal.fulcio import FulcioSCT
 
 
-def _pack_digitally_signed(
-    sct: FulcioSignedCertificateTimestamp, cert: Certificate
-) -> bytes:
+def _pack_digitally_signed(sct: FulcioSCT, cert: Certificate) -> bytes:
     """
     The format of the digitally signed data is described in IETF's RFC 6962.
 
@@ -57,15 +55,15 @@ def _pack_digitally_signed(
     pattern = "!BBQhBBB%ssh" % len(cert_der)
     data = struct.pack(
         pattern,
-        sct.struct["sct_version"],
+        sct.version.value,
         0,  # Signature Type
-        sct.struct["timestamp"],
+        sct.raw_timestamp,
         0,  # Entry Type
         len1,
         len2,
         len3,
         cert_der,
-        len(sct.struct["extensions"]),
+        len(sct.extensions),
     )
 
     return data
@@ -76,7 +74,7 @@ class InvalidSctError(Exception):
 
 
 def verify_sct(
-    sct: FulcioSignedCertificateTimestamp,
+    sct: FulcioSCT,
     cert: Certificate,
     ctfe_key: ec.EllipticCurvePublicKey,
 ) -> None:

--- a/sigstore/_internal/sct.py
+++ b/sigstore/_internal/sct.py
@@ -23,10 +23,10 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.x509 import Certificate
 
-from sigstore._internal.fulcio import FulcioSCT
+from sigstore._internal.fulcio import DetachedFulcioSCT
 
 
-def _pack_digitally_signed(sct: FulcioSCT, cert: Certificate) -> bytes:
+def _pack_digitally_signed(sct: DetachedFulcioSCT, cert: Certificate) -> bytes:
     """
     The format of the digitally signed data is described in IETF's RFC 6962.
 
@@ -74,7 +74,7 @@ class InvalidSctError(Exception):
 
 
 def verify_sct(
-    sct: FulcioSCT,
+    sct: DetachedFulcioSCT,
     cert: Certificate,
     ctfe_key: ec.EllipticCurvePublicKey,
 ) -> None:

--- a/test/internal/fulcio/__init__.py
+++ b/test/internal/fulcio/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/internal/fulcio/test_client.py
+++ b/test/internal/fulcio/test_client.py
@@ -26,13 +26,13 @@ from pydantic import ValidationError
 from sigstore._internal.fulcio import client
 
 
-class TestFulcioSCT:
+class TestDetachedFulcioSCT:
     def test_fulcio_sct_virtual_subclass(self):
-        assert issubclass(client.FulcioSCT, SignedCertificateTimestamp)
+        assert issubclass(client.DetachedFulcioSCT, SignedCertificateTimestamp)
 
     def test_fields(self):
         blob = enc(b"this is a base64-encoded blob")
-        sct = client.FulcioSCT(
+        sct = client.DetachedFulcioSCT(
             version=0,
             log_id=blob,
             timestamp=1000,
@@ -63,7 +63,7 @@ class TestFulcioSCT:
         with pytest.raises(
             ValidationError, match="value is not a valid enumeration member"
         ):
-            client.FulcioSCT(
+            client.DetachedFulcioSCT(
                 version=version,
                 log_id=enc(b"fakeid"),
                 timestamp=1,
@@ -84,7 +84,7 @@ class TestFulcioSCT:
     )
     def test_digitally_signed_invalid(self, digitally_signed, reason):
         with pytest.raises(ValidationError, match=reason):
-            client.FulcioSCT(
+            client.DetachedFulcioSCT(
                 version=0,
                 log_id=enc(b"fakeid"),
                 timestamp=1,
@@ -94,7 +94,7 @@ class TestFulcioSCT:
 
     def test_log_id_invalid(self):
         with pytest.raises(ValidationError, match="Invalid base64-encoded string"):
-            client.FulcioSCT(
+            client.DetachedFulcioSCT(
                 version=0,
                 log_id=b"invalid base64",
                 timestamp=1,
@@ -104,7 +104,7 @@ class TestFulcioSCT:
 
     def test_extensions_invalid(self):
         with pytest.raises(ValidationError, match="Invalid base64-encoded string"):
-            client.FulcioSCT(
+            client.DetachedFulcioSCT(
                 version=0,
                 log_id=enc(b"fakeid"),
                 timestamp=1,
@@ -113,7 +113,7 @@ class TestFulcioSCT:
             )
 
     def test_digitally_signed_invalid_size(self):
-        sct = client.FulcioSCT(
+        sct = client.DetachedFulcioSCT(
             version=0,
             log_id=enc(b"fakeid"),
             timestamp=1,

--- a/test/internal/fulcio/test_client.py
+++ b/test/internal/fulcio/test_client.py
@@ -1,0 +1,125 @@
+# Copyright 2022 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from base64 import b64encode as enc
+from datetime import datetime
+
+import pytest
+from cryptography.x509.certificate_transparency import (
+    LogEntryType,
+    SignedCertificateTimestamp,
+    Version,
+)
+from pydantic import ValidationError
+
+from sigstore._internal.fulcio import client
+
+
+class TestFulcioSCT:
+    def test_fulcio_sct_virtual_subclass(self):
+        assert issubclass(client.FulcioSCT, SignedCertificateTimestamp)
+
+    def test_fields(self):
+        blob = enc(b"this is a base64-encoded blob")
+        sct = client.FulcioSCT(
+            version=0,
+            log_id=blob,
+            timestamp=1000,
+            digitally_signed=enc(b"\x00\x00\x00\x04abcd"),
+            extensions=blob,
+        )
+
+        assert sct is not None
+
+        # Each of these fields is transformed, as expected.
+        assert sct.version == Version.v1
+        assert enc(sct.log_id) == blob
+        assert sct.digitally_signed == b"\x00\x00\x00\x04abcd"
+        assert enc(sct.extensions) == blob
+
+        # No transformation on the raw timestamp, which is in MS.
+        assert sct.raw_timestamp == 1000
+
+        # Computed fields are also correct.
+        assert sct.timestamp == datetime.fromtimestamp(1)
+        assert sct.entry_type == LogEntryType.X509_CERTIFICATE
+        assert sct.signature_hash_algorithm == sct.digitally_signed[0]
+        assert sct.signature_algorithm == sct.digitally_signed[1]
+        assert sct.signature == sct.digitally_signed[4:] == b"abcd"
+
+    @pytest.mark.parametrize("version", [-1, 1, 2, 3])
+    def test_invalid_version(self, version):
+        with pytest.raises(
+            ValidationError, match="value is not a valid enumeration member"
+        ):
+            client.FulcioSCT(
+                version=version,
+                log_id=enc(b"fakeid"),
+                timestamp=1,
+                digitally_signed=enc(b"fakesigned"),
+                extensions=b"",
+            )
+
+    @pytest.mark.parametrize(
+        ("digitally_signed", "reason"),
+        [
+            (enc(b""), "impossibly small digitally-signed struct"),
+            (enc(b"0"), "impossibly small digitally-signed struct"),
+            (enc(b"00"), "impossibly small digitally-signed struct"),
+            (enc(b"000"), "impossibly small digitally-signed struct"),
+            (enc(b"0000"), "impossibly small digitally-signed struct"),
+            (b"invalid base64", "Invalid base64-encoded string"),
+        ],
+    )
+    def test_digitally_signed_invalid(self, digitally_signed, reason):
+        with pytest.raises(ValidationError, match=reason):
+            client.FulcioSCT(
+                version=0,
+                log_id=enc(b"fakeid"),
+                timestamp=1,
+                digitally_signed=digitally_signed,
+                extensions=b"",
+            )
+
+    def test_log_id_invalid(self):
+        with pytest.raises(ValidationError, match="Invalid base64-encoded string"):
+            client.FulcioSCT(
+                version=0,
+                log_id=b"invalid base64",
+                timestamp=1,
+                digitally_signed=enc(b"fakesigned"),
+                extensions=b"",
+            )
+
+    def test_extensions_invalid(self):
+        with pytest.raises(ValidationError, match="Invalid base64-encoded string"):
+            client.FulcioSCT(
+                version=0,
+                log_id=enc(b"fakeid"),
+                timestamp=1,
+                digitally_signed=enc(b"fakesigned"),
+                extensions=b"invalid base64",
+            )
+
+    def test_digitally_signed_invalid_size(self):
+        sct = client.FulcioSCT(
+            version=0,
+            log_id=enc(b"fakeid"),
+            timestamp=1,
+            digitally_signed=enc(b"\x00\x00\x00\x05abcd"),
+            extensions=b"",
+        )
+
+        with pytest.raises(client.FulcioSCTError, match="expected 5 bytes, got 4"):
+            sct.signature


### PR DESCRIPTION
This replaces `FulcioSignedCertificateTimestamp` with `FulcioSCT`,
which inherits from `pydantic.BaseModel` and uses pydantic's
verification APIs instead of doing all verification ad-hoc in
the constructor.

The relationship to `cryptography.x509.SignedCertificateTimestamp`
is maintained via virtual subclassing.

This should make testing detached SCTs much easier. Marking as a draft until I add some corresponding tests.

Signed-off-by: William Woodruff <william@trailofbits.com>

