### PR TITLE
oidc/ambient: Google: fail softly if the SMBIOS product name doesn't match

### DIFF
--- a/sigstore/_internal/oidc/ambient.py
+++ b/sigstore/_internal/oidc/ambient.py
@@ -169,9 +169,10 @@ def detect_gcp() -> Optional[str]:
             return None
 
         if name not in {"Google", "Google Compute Engine"}:
-            raise AmbientCredentialError(
+            logger.debug(
                 f"GCP: product name file exists, but product name is {name!r}; giving up"
             )
+            return None
 
         logger.debug("GCP: requesting OIDC token")
         resp = requests.get(

--- a/test/internal/oidc/test_ambient.py
+++ b/test/internal/oidc/test_ambient.py
@@ -322,16 +322,15 @@ def test_gcp_wrong_product(monkeypatch):
     logger = pretend.stub(debug=pretend.call_recorder(lambda s: None))
     monkeypatch.setattr(ambient, "logger", logger)
 
-    with pytest.raises(
-        ambient.AmbientCredentialError,
-        match="GCP: product name file exists, but product name is 'Unsupported Product'; giving up",
-    ):
-        ambient.detect_gcp()
+    assert ambient.detect_gcp() is None
 
     assert logger.debug.calls == [
         pretend.call("GCP: looking for OIDC credentials"),
         pretend.call(
             "GCP: GOOGLE_SERVICE_ACCOUNT_NAME not set; skipping impersonation"
+        ),
+        pretend.call(
+            "GCP: product name file exists, but product name is 'Unsupported Product'; giving up"
         ),
     ]
 


### PR DESCRIPTION
This prevents an overzealous error when detecting ambient Google Cloud credentials. The root cause is that many vendors use the DMI/SMBIOS table to pass around product information; unexpected data here is a sign of the wrong host rather than an erroneous state on the right host.

Fixes #97.

Signed-off-by: William Woodruff <william@trailofbits.com>

