### PR TITLE
CLI: Add `--output` and `--force`

### DIFF
--- a/.github/workflows/staging-tests.yml
+++ b/.github/workflows/staging-tests.yml
@@ -31,10 +31,7 @@ jobs:
 
           # Our signing target is not important here, so we just sign
           # the README in the repository.
-          ./staging-env/bin/python -m sigstore sign --staging \
-            README.md \
-            --output-signature \
-            --output-certificate
+          ./staging-env/bin/python -m sigstore sign --output --staging README.md
 
           # Verification also requires a different Rekor instance, so we
           # also test it.

--- a/README.md
+++ b/README.md
@@ -45,15 +45,16 @@ Top-level:
 
 <!-- @begin-sigstore-help@ -->
 ```
-Usage: sigstore [OPTIONS] COMMAND [ARGS]...
+usage: sigstore [-h] [-V] {sign,verify} ...
 
-Options:
-  --version  Show the version and exit.
-  --help     Show this message and exit.
+a tool for signing and verifying Python package distributions
 
-Commands:
-  sign
-  verify
+positional arguments:
+  {sign,verify}
+
+options:
+  -h, --help     show this help message and exit
+  -V, --version  show program's version number and exit
 ```
 <!-- @end-sigstore-help@ -->
 
@@ -61,39 +62,59 @@ Signing:
 
 <!-- @begin-sigstore-sign-help@ -->
 ```
-Usage: sigstore sign [OPTIONS] FILE [FILE ...]
+usage: sigstore sign [-h] [--identity-token TOKEN] [--oidc-client-id ID]
+                     [--oidc-client-secret SECRET]
+                     [--oidc-disable-ambient-providers] [--output]
+                     [--output-signature FILE] [--output-certificate FILE]
+                     [--force] [--fulcio-url URL] [--rekor-url URL]
+                     [--ctfe FILE] [--rekor-root-pubkey FILE]
+                     [--oidc-issuer URL] [--staging]
+                     FILE [FILE ...] [FILE [FILE ...] ...]
 
-Options:
-  --identity-token TOKEN          the OIDC identity token to use
-  --oidc-client-id ID             The custom OpenID Connect client ID to use
-  --oidc-client-secret SECRET     The custom OpenID Connect client secret to
-                                  use
-  --oidc-issuer URL               The custom OpenID Connect issuer to use
-                                  (conflicts with --staging)
-  --staging                       Use the sigstore project's staging
-                                  instances, instead of the default production
-                                  instances
+positional arguments:
+  FILE [FILE ...]       The files to sign
+
+options:
+  -h, --help            show this help message and exit
+
+OpenID Connect options:
+  --identity-token TOKEN
+                        the OIDC identity token to use
+  --oidc-client-id ID   The custom OpenID Connect client ID to use during
+                        OAuth2
+  --oidc-client-secret SECRET
+                        The custom OpenID Connect client secret to use during
+                        OAuth2
   --oidc-disable-ambient-providers
-                                  Disable ambient OIDC detection (e.g. on
-                                  GitHub Actions)
-  --output-signature FILE         With a value, write a single signature to
-                                  the given file; without a value, write each
-                                  signing result to {input}.sig
-  --output-certificate FILE       With a value, write a single signing
-                                  certificate to the given file; without a
-                                  value, write each signing certificate to
-                                  {input}.cert
-  --fulcio-url URL                The Fulcio instance to use (conflicts with
-                                  --staging)  [default:
-                                  https://fulcio.sigstore.dev]
-  --rekor-url URL                 The Rekor instance to use (conflicts with
-                                  --staging)  [default:
-                                  https://rekor.sigstore.dev]
-  --ctfe FILE                     A PEM-encoded public key for the CT log
-                                  (conflicts with --staging)
-  --rekor-root-pubkey FILE        A PEM-encoded root public key for Rekor
-                                  itself (conflicts with --staging)
-  --help                          Show this message and exit.
+                        Disable ambient OpenID Connect credential detection
+                        (e.g. on GitHub Actions)
+
+Output options:
+  --output              Write signature and certificate results to default
+                        files ({input}.sig and {input}.crt)
+  --output-signature FILE
+                        Write a single signature to the given file; conflicts
+                        with --output and does not work with multiple input
+                        files
+  --output-certificate FILE
+                        Write a single certificate to the given file;
+                        conflicts with --output and does not work with
+                        multiple input files
+  --force               Overwrite preexisting signature and certificate
+                        outputs, if present
+
+Sigstore instance options:
+  --fulcio-url URL      The Fulcio instance to use (conflicts with --staging)
+  --rekor-url URL       The Rekor instance to use (conflicts with --staging)
+  --ctfe FILE           A PEM-encoded public key for the CT log (conflicts
+                        with --staging)
+  --rekor-root-pubkey FILE
+                        A PEM-encoded root public key for Rekor itself
+                        (conflicts with --staging)
+  --oidc-issuer URL     The OpenID Connect issuer to use (conflicts with
+                        --staging)
+  --staging             Use sigstore's staging instances, instead of the
+                        default production instances
 ```
 <!-- @end-sigstore-sign-help@ -->
 
@@ -101,22 +122,33 @@ Verifying:
 
 <!-- @begin-sigstore-verify-help@ -->
 ```
-Usage: sigstore verify [OPTIONS] FILE [FILE ...]
+usage: sigstore verify [-h] --certificate FILE --signature FILE
+                       [--cert-email EMAIL] [--cert-oidc-issuer URL]
+                       [--rekor-url URL] [--staging]
+                       FILE
 
-Options:
-  --cert FILENAME          The PEM-encoded certificate to verify against
-                           [required]
-  --signature FILENAME     The signature to verify against  [required]
-  --cert-email TEXT        The email address (or other identity string) to
-                           check for in the certificate's Subject Alternative
-                           Name
-  --cert-oidc-issuer TEXT  The OIDC issuer URL to check for in the
-                           certificate's OIDC issuer extension
-  --staging                Use the sigstore project's staging instances,
-                           instead of the default production instances
-  --rekor-url URL          The Rekor instance to use (conflicts with
-                           --staging)  [default: https://rekor.sigstore.dev]
-  --help                   Show this message and exit.
+positional arguments:
+  FILE                  The file to verify
+
+options:
+  -h, --help            show this help message and exit
+
+Verification inputs:
+  --certificate FILE, --cert FILE
+                        The PEM-encoded certificate to verify against
+  --signature FILE      The signature to verify against
+
+Extended verification options:
+  --cert-email EMAIL    The email address to check for in the certificate's
+                        Subject Alternative Name
+  --cert-oidc-issuer URL
+                        The OIDC issuer URL to check for in the certificate's
+                        OIDC issuer extension
+
+Sigstore instance options:
+  --rekor-url URL       The Rekor instance to use (conflicts with --staging)
+  --staging             Use sigstore's staging instances, instead of the
+                        default production instances
 ```
 <!-- @end-sigstore-verify-help@ -->
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ usage: sigstore sign [-h] [--identity-token TOKEN] [--oidc-client-id ID]
                      [--oidc-client-secret SECRET]
                      [--oidc-disable-ambient-providers] [--output]
                      [--output-signature FILE] [--output-certificate FILE]
-                     [--force] [--fulcio-url URL] [--rekor-url URL]
+                     [--overwrite] [--fulcio-url URL] [--rekor-url URL]
                      [--ctfe FILE] [--rekor-root-pubkey FILE]
                      [--oidc-issuer URL] [--staging]
                      FILE [FILE ...]
@@ -100,7 +100,7 @@ Output options:
                         Write a single certificate to the given file;
                         conflicts with --output and does not work with
                         multiple input files (default: None)
-  --force               Overwrite preexisting signature and certificate
+  --overwrite           Overwrite preexisting signature and certificate
                         outputs, if present (default: False)
 
 Sigstore instance options:

--- a/README.md
+++ b/README.md
@@ -69,52 +69,55 @@ usage: sigstore sign [-h] [--identity-token TOKEN] [--oidc-client-id ID]
                      [--force] [--fulcio-url URL] [--rekor-url URL]
                      [--ctfe FILE] [--rekor-root-pubkey FILE]
                      [--oidc-issuer URL] [--staging]
-                     FILE [FILE ...] [FILE [FILE ...] ...]
+                     FILE [FILE ...]
 
 positional arguments:
-  FILE [FILE ...]       The files to sign
+  FILE                  The file to sign
 
 options:
   -h, --help            show this help message and exit
 
 OpenID Connect options:
   --identity-token TOKEN
-                        the OIDC identity token to use
+                        the OIDC identity token to use (default: None)
   --oidc-client-id ID   The custom OpenID Connect client ID to use during
-                        OAuth2
+                        OAuth2 (default: sigstore)
   --oidc-client-secret SECRET
                         The custom OpenID Connect client secret to use during
-                        OAuth2
+                        OAuth2 (default: None)
   --oidc-disable-ambient-providers
                         Disable ambient OpenID Connect credential detection
-                        (e.g. on GitHub Actions)
+                        (e.g. on GitHub Actions) (default: False)
 
 Output options:
   --output              Write signature and certificate results to default
-                        files ({input}.sig and {input}.crt)
+                        files ({input}.sig and {input}.crt) (default: False)
   --output-signature FILE
                         Write a single signature to the given file; conflicts
                         with --output and does not work with multiple input
-                        files
+                        files (default: None)
   --output-certificate FILE
                         Write a single certificate to the given file;
                         conflicts with --output and does not work with
-                        multiple input files
+                        multiple input files (default: None)
   --force               Overwrite preexisting signature and certificate
-                        outputs, if present
+                        outputs, if present (default: False)
 
 Sigstore instance options:
   --fulcio-url URL      The Fulcio instance to use (conflicts with --staging)
+                        (default: https://fulcio.sigstore.dev)
   --rekor-url URL       The Rekor instance to use (conflicts with --staging)
+                        (default: https://rekor.sigstore.dev)
   --ctfe FILE           A PEM-encoded public key for the CT log (conflicts
-                        with --staging)
+                        with --staging) (default: ctfe.pub (embedded))
   --rekor-root-pubkey FILE
                         A PEM-encoded root public key for Rekor itself
-                        (conflicts with --staging)
+                        (conflicts with --staging) (default: rekor.pub
+                        (embedded))
   --oidc-issuer URL     The OpenID Connect issuer to use (conflicts with
-                        --staging)
+                        --staging) (default: https://oauth2.sigstore.dev/auth)
   --staging             Use sigstore's staging instances, instead of the
-                        default production instances
+                        default production instances (default: False)
 ```
 <!-- @end-sigstore-sign-help@ -->
 
@@ -136,19 +139,21 @@ options:
 Verification inputs:
   --certificate FILE, --cert FILE
                         The PEM-encoded certificate to verify against
-  --signature FILE      The signature to verify against
+                        (default: None)
+  --signature FILE      The signature to verify against (default: None)
 
 Extended verification options:
   --cert-email EMAIL    The email address to check for in the certificate's
-                        Subject Alternative Name
+                        Subject Alternative Name (default: None)
   --cert-oidc-issuer URL
                         The OIDC issuer URL to check for in the certificate's
-                        OIDC issuer extension
+                        OIDC issuer extension (default: None)
 
 Sigstore instance options:
   --rekor-url URL       The Rekor instance to use (conflicts with --staging)
+                        (default: https://rekor.sigstore.dev)
   --staging             Use sigstore's staging instances, instead of the
-                        default production instances
+                        default production instances (default: False)
 ```
 <!-- @end-sigstore-verify-help@ -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
   "Topic :: Security :: Cryptography",
 ]
 dependencies = [
-  "click>=8",
   "cryptography",
   "pem",
   "pydantic",

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -323,7 +323,7 @@ def _sign(args: argparse.Namespace) -> None:
         issuer = Issuer(args.oidc_issuer)
 
         if args.oidc_client_secret is None:
-            args.oidc_client_secret = ""
+            args.oidc_client_secret = ""  # nosec: B105
 
         args.identity_token = get_identity_token(
             args.oidc_client_id,

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -358,8 +358,9 @@ def _verify(args: argparse.Namespace) -> None:
     logger.debug(f"Using signature from: {args.signature.name}")
     signature = args.signature.read()
 
+    logger.debug(f"Verifying contents from: {args.file.name}")
     result = verifier.verify(
-        file=args.file,
+        input_=args.file.read(),
         certificate=certificate,
         signature=signature,
         expected_cert_email=args.cert_email,
@@ -371,6 +372,7 @@ def _verify(args: argparse.Namespace) -> None:
     else:
         result = cast(VerificationFailure, result)
         print(f"FAIL: {args.file.name}")
+        print(f"Failure reason: {result.reason}", file=sys.stderr)
 
         if isinstance(result, CertificateVerificationFailure):
             # If certificate verification failed, it's either because of
@@ -378,7 +380,6 @@ def _verify(args: argparse.Namespace) -> None:
             # These might already be resolved in a newer version, so
             # we suggest that users try to upgrade and retry before
             # anything else.
-            print(result.reason, file=sys.stderr)
             print(
                 dedent(
                     f"""
@@ -395,7 +396,5 @@ def _verify(args: argparse.Namespace) -> None:
                 ),
                 file=sys.stderr,
             )
-        else:
-            print(result.reason, file=sys.stderr)
 
         sys.exit(1)

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import logging
 import os
 import sys
-from io import BytesIO
+from pathlib import Path
 from textwrap import dedent
-from typing import BinaryIO, List, Optional, TextIO, cast
-
-import click
+from typing import TextIO, cast
 
 from sigstore import __version__
 from sigstore._internal.fulcio.client import DEFAULT_FULCIO_URL, FulcioClient
@@ -30,12 +29,7 @@ from sigstore._internal.oidc.oauth import (
     STAGING_OAUTH_ISSUER,
     get_identity_token,
 )
-from sigstore._internal.rekor.client import (
-    DEFAULT_REKOR_CTFE_PUBKEY,
-    DEFAULT_REKOR_ROOT_PUBKEY,
-    DEFAULT_REKOR_URL,
-    RekorClient,
-)
+from sigstore._internal.rekor.client import DEFAULT_REKOR_URL, RekorClient
 from sigstore._sign import Signer
 from sigstore._verify import (
     CertificateVerificationFailure,
@@ -47,163 +41,255 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=os.environ.get("SIGSTORE_LOGLEVEL", "INFO").upper())
 
 
-@click.group()
-@click.version_option(version=__version__)
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sigstore",
+        description="a tool for signing and verifying Python package distributions",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "-V", "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+    subcommands = parser.add_subparsers(required=True, dest="subcommand")
+
+    # `sigstore sign`
+    sign = subcommands.add_parser("sign")
+
+    oidc_options = sign.add_argument_group("OpenID Connect options")
+    oidc_options.add_argument(
+        "--identity-token",
+        metavar="TOKEN",
+        type=str,
+        help="the OIDC identity token to use",
+    )
+    oidc_options.add_argument(
+        "--oidc-client-id",
+        metavar="ID",
+        type=str,
+        default="sigstore",
+        help="The custom OpenID Connect client ID to use during OAuth2",
+    )
+    oidc_options.add_argument(
+        "--oidc-client-secret",
+        metavar="SECRET",
+        type=str,
+        default="",
+        help="The custom OpenID Connect client secret to use during OAuth2",
+    )
+    oidc_options.add_argument(
+        "--oidc-disable-ambient-providers",
+        action="store_true",
+        help="Disable ambient OpenID Connect credential detection (e.g. on GitHub Actions)",
+    )
+
+    output_options = sign.add_argument_group("Output options")
+    output_options.add_argument(
+        "--output",
+        action="store_true",
+        help=(
+            "Write signature and certificate results to default files "
+            "({input}.sig and {input}.crt)"
+        ),
+    )
+    output_options.add_argument(
+        "--output-signature",
+        metavar="FILE",
+        type=Path,
+        help=(
+            "Write a single signature to the given file; conflicts with --output and "
+            "does not work with multiple input files"
+        ),
+    )
+    output_options.add_argument(
+        "--output-certificate",
+        metavar="FILE",
+        type=Path,
+        help=(
+            "Write a single certificate to the given file; conflicts with --output and "
+            "does not work with multiple input files"
+        ),
+    )
+    output_options.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite preexisting signature and certificate outputs, if present",
+    )
+
+    instance_options = sign.add_argument_group("Sigstore instance options")
+    instance_options.add_argument(
+        "--fulcio-url",
+        metavar="URL",
+        type=str,
+        default=DEFAULT_FULCIO_URL,
+        help="The Fulcio instance to use (conflicts with --staging)",
+    )
+    instance_options.add_argument(
+        "--rekor-url",
+        metavar="URL",
+        type=str,
+        default=DEFAULT_REKOR_URL,
+        help="The Rekor instance to use (conflicts with --staging)",
+    )
+    instance_options.add_argument(
+        "--ctfe",
+        dest="ctfe_pem",
+        metavar="FILE",
+        type=argparse.FileType("rb"),
+        help="A PEM-encoded public key for the CT log (conflicts with --staging)",
+        # TODO: Dynamic default here
+    )
+    instance_options.add_argument(
+        "--rekor-root-pubkey",
+        metavar="FILE",
+        type=argparse.FileType("rb"),
+        help="A PEM-encoded root public key for Rekor itself (conflicts with --staging)",
+        # TODO: Dynamic default here
+    )
+    instance_options.add_argument(
+        "--oidc-issuer",
+        metavar="URL",
+        type=str,
+        default=DEFAULT_OAUTH_ISSUER,
+        help="The OpenID Connect issuer to use (conflicts with --staging)",
+    )
+    instance_options.add_argument(
+        "--staging",
+        action="store_true",
+        help="Use sigstore's staging instances, instead of the default production instances",
+    )
+
+    sign.add_argument(
+        "files",
+        metavar="FILE [FILE ...]",
+        type=Path,
+        nargs="+",
+        help="The files to sign",
+    )
+
+    # `sigstore verify`
+    verify = subcommands.add_parser("verify")
+
+    input_options = verify.add_argument_group("Verification inputs")
+    input_options.add_argument(
+        "--certificate",
+        "--cert",
+        metavar="FILE",
+        type=argparse.FileType("rb"),
+        required=True,
+        help="The PEM-encoded certificate to verify against",
+    )
+    input_options.add_argument(
+        "--signature",
+        metavar="FILE",
+        type=argparse.FileType("rb"),
+        required=True,
+        help="The signature to verify against",
+    )
+
+    verification_options = verify.add_argument_group("Extended verification options")
+    verification_options.add_argument(
+        "--cert-email",
+        metavar="EMAIL",
+        type=str,
+        help="The email address to check for in the certificate's Subject Alternative Name",
+    )
+    verification_options.add_argument(
+        "--cert-oidc-issuer",
+        metavar="URL",
+        type=str,
+        help="The OIDC issuer URL to check for in the certificate's OIDC issuer extension",
+    )
+
+    instance_options = verify.add_argument_group("Sigstore instance options")
+    instance_options.add_argument(
+        "--rekor-url",
+        metavar="URL",
+        type=str,
+        default=DEFAULT_REKOR_URL,
+        help="The Rekor instance to use (conflicts with --staging)",
+    )
+    instance_options.add_argument(
+        "--staging",
+        action="store_true",
+        help="Use sigstore's staging instances, instead of the default production instances",
+    )
+
+    verify.add_argument(
+        "file", metavar="FILE", type=argparse.FileType("rb"), help="The file to verify"
+    )
+
+    return parser
+
+
 def main() -> None:
-    pass
+    parser = _parser()
+    args = parser.parse_args()
+
+    logger.debug(f"parsed arguments {args}")
+
+    # Stuff the parser back into our namespace, so that we can use it for
+    # error handling later.
+    args._parser = parser
+
+    if args.subcommand == "sign":
+        _sign(args)
+    elif args.subcommand == "verify":
+        _verify(args)
+    else:
+        parser.error(f"Unknown subcommand: {args.subcommand}")
 
 
-@main.command("sign")
-@click.option(
-    "identity_token",
-    "--identity-token",
-    metavar="TOKEN",
-    type=click.STRING,
-    help="the OIDC identity token to use",
-)
-@click.option(
-    "oidc_client_id",
-    "--oidc-client-id",
-    metavar="ID",
-    type=click.STRING,
-    default="sigstore",
-    help="The custom OpenID Connect client ID to use",
-)
-@click.option(
-    "oidc_client_secret",
-    "--oidc-client-secret",
-    metavar="SECRET",
-    type=click.STRING,
-    default=str(),
-    help="The custom OpenID Connect client secret to use",
-)
-@click.option(
-    "oidc_issuer",
-    "--oidc-issuer",
-    metavar="URL",
-    type=click.STRING,
-    default=DEFAULT_OAUTH_ISSUER,
-    help="The custom OpenID Connect issuer to use (conflicts with --staging)",
-)
-@click.option(
-    "staging",
-    "--staging",
-    is_flag=True,
-    default=False,
-    help=(
-        "Use the sigstore project's staging instances, "
-        "instead of the default production instances"
-    ),
-)
-@click.option(
-    "oidc_disable_ambient_providers",
-    "--oidc-disable-ambient-providers",
-    is_flag=True,
-    default=False,
-    help="Disable ambient OIDC detection (e.g. on GitHub Actions)",
-)
-@click.option(
-    "output_signature",
-    "--output-signature",
-    is_flag=False,
-    flag_value=str(),
-    metavar="FILE",
-    type=click.STRING,
-    help=(
-        "With a value, write a single signature to the given file; "
-        "without a value, write each signing result to {input}.sig"
-    ),
-)
-@click.option(
-    "output_certificate",
-    "--output-certificate",
-    is_flag=False,
-    flag_value=str(),
-    metavar="FILE",
-    type=click.STRING,
-    help=(
-        "With a value, write a single signing certificate to the given file; "
-        "without a value, write each signing certificate to {input}.cert"
-    ),
-)
-@click.option(
-    "--fulcio-url",
-    metavar="URL",
-    type=click.STRING,
-    default=DEFAULT_FULCIO_URL,
-    show_default=True,
-    help="The Fulcio instance to use (conflicts with --staging)",
-)
-@click.option(
-    "rekor_url",
-    "--rekor-url",
-    metavar="URL",
-    type=click.STRING,
-    default=DEFAULT_REKOR_URL,
-    show_default=True,
-    help="The Rekor instance to use (conflicts with --staging)",
-)
-@click.option(
-    "ctfe_pem",
-    "--ctfe",
-    metavar="FILE",
-    type=click.File("rb"),
-    default=BytesIO(DEFAULT_REKOR_CTFE_PUBKEY),
-    help="A PEM-encoded public key for the CT log (conflicts with --staging)",
-)
-@click.option(
-    "rekor_root_pubkey",
-    "--rekor-root-pubkey",
-    metavar="FILE",
-    type=click.File("rb"),
-    default=BytesIO(DEFAULT_REKOR_ROOT_PUBKEY),
-    help="A PEM-encoded root public key for Rekor itself (conflicts with --staging)",
-)
-@click.argument(
-    "files",
-    metavar="FILE [FILE ...]",
-    type=click.File("rb"),
-    nargs=-1,
-    required=True,
-)
-def _sign(
-    files: List[BinaryIO],
-    identity_token: Optional[str],
-    oidc_client_id: str,
-    oidc_client_secret: str,
-    oidc_issuer: str,
-    oidc_disable_ambient_providers: bool,
-    output_signature: Optional[str],
-    output_certificate: Optional[str],
-    fulcio_url: str,
-    rekor_url: str,
-    ctfe_pem: BinaryIO,
-    rekor_root_pubkey: BinaryIO,
-    staging: bool,
-) -> None:
-    # Fail if `--output-signature` or `--output-certificate` is specified with
-    # a value *and* we have more than one input. If passed without values,
-    # then treat them as an instruction to generate default {input}.sig and
-    # {input}.cert outputs for each {input}.
-    multiple_inputs = len(files) > 1
-    if (output_signature or output_certificate) and multiple_inputs:
-        click.echo(
-            "Error: --output-signature and --output-certificate can't be used with "
-            "explicit outputs for multiple inputs",
-            err=True,
+def _sign(args: argparse.Namespace) -> None:
+    # `--output` may not be mixed with `--output-signature` or `--output-certificate`.
+    if args.output and (args.output_signature or args.output_certificate):
+        args._parser.error(
+            "--output may not be combined with --output-signature or --output-certificate",
         )
-        raise click.Abort
 
-    if staging:
+    # Fail if `--output-signature` or `--output-certificate` is specified
+    # *and* we have more than one input.
+    if (args.output_signature or args.output_certificate) and len(args.files) > 1:
+        args._parser.error(
+            "Error: --output-signature and --output-certificate can't be used with "
+            "explicit outputs for multiple inputs; consider using --output",
+        )
+
+    # Build up the map of inputs -> outputs ahead of any signing operations,
+    # so that we can fail early if overwriting without `--force`.
+    output_map = {}
+    for file in args.files:
+        sig, cert = args.output_signature, args.output_certificate
+        if args.output:
+            sig = file.parent / f"{file.name}.sig"
+            cert = file.parent / f"{file.name}.crt"
+
+        if not args.force:
+            extant = None
+            if sig and sig.exists():
+                extant = sig
+            elif cert and cert.exists():
+                extant = cert
+
+            if extant:
+                args._parser.error(
+                    f"Refusing to overwrite pre-existing outputs without --force: {extant}"
+                )
+
+        output_map[file] = {"cert": cert, "sig": sig}
+
+    # Select the signer to use.
+    if args.staging:
         logger.debug("sign: staging instances requested")
         signer = Signer.staging()
-        oidc_issuer = STAGING_OAUTH_ISSUER
-    elif fulcio_url == DEFAULT_FULCIO_URL and rekor_url == DEFAULT_REKOR_URL:
+        args.oidc_issuer = STAGING_OAUTH_ISSUER
+    elif args.fulcio_url == DEFAULT_FULCIO_URL and args.rekor_url == DEFAULT_REKOR_URL:
         signer = Signer.production()
     else:
         signer = Signer(
-            fulcio=FulcioClient(fulcio_url),
-            rekor=RekorClient(rekor_url, rekor_root_pubkey.read(), ctfe_pem.read()),
+            fulcio=FulcioClient(args.fulcio_url),
+            rekor=RekorClient(
+                args.rekor_url, args.rekor_root_pubkey.read(), args.ctfe_pem.read()
+            ),
         )
 
     # The order of precedence is as follows:
@@ -211,179 +297,105 @@ def _sign(
     # 1) Explicitly supplied identity token
     # 2) Ambient credential detected in the environment, unless disabled
     # 3) Interactive OAuth flow
-    if not identity_token and not oidc_disable_ambient_providers:
-        identity_token = detect_credential()
-    if not identity_token:
-        issuer = Issuer(oidc_issuer)
-        identity_token = get_identity_token(
-            oidc_client_id,
-            oidc_client_secret,
+    if not args.identity_token and not args.oidc_disable_ambient_providers:
+        args.identity_token = detect_credential()
+    if not args.identity_token:
+        issuer = Issuer(args.oidc_issuer)
+        args.identity_token = get_identity_token(
+            args.oidc_client_id,
+            args.oidc_client_secret,
             issuer,
         )
-    if not identity_token:
-        click.echo("No identity token supplied or detected!", err=True)
-        raise click.Abort
+    if not args.identity_token:
+        args._parser.error("No identity token supplied or detected!")
 
-    for file in files:
+    for file, outputs in output_map.items():
+        logger.debug(f"signing for {file.name}")
         result = signer.sign(
-            file=file,
-            identity_token=identity_token,
+            input_=file.read_bytes(),
+            identity_token=args.identity_token,
         )
 
-        click.echo("Using ephemeral certificate:")
-        click.echo(result.cert_pem)
+        print("Using ephemeral certificate:")
+        print(result.cert_pem)
 
-        click.echo(
-            f"Transparency log entry created at index: {result.log_entry.log_index}"
-        )
+        print(f"Transparency log entry created at index: {result.log_entry.log_index}")
 
         sig_output: TextIO
-        if output_signature is None:
-            sig_output = sys.stdout
+        if outputs["sig"]:
+            sig_output = outputs["sig"].open("w")
         else:
-            if output_signature == "":
-                output_signature = f"{file.name}.sig"
-            sig_output = open(output_signature, "w")
+            sig_output = sys.stdout
 
         print(result.b64_signature, file=sig_output)
-        if output_signature:
-            click.echo(f"Signature written to file {output_signature}")
+        if outputs["sig"]:
+            print(f"Signature written to file {outputs['sig']}")
 
-        if output_certificate is not None:
-            if output_certificate == "":
-                output_certificate = f"{file.name}.crt"
-            cert_output = open(output_certificate, "w")
+        if outputs["cert"] is not None:
+            cert_output = open(outputs["cert"], "w")
             print(result.cert_pem, file=cert_output)
-            click.echo(f"Certificate written to file {output_certificate}")
+            print(f"Certificate written to file {outputs['cert']}")
 
 
-@main.command("verify")
-@click.option(
-    "certificate_path",
-    "--cert",
-    type=click.File("rb"),
-    required=True,
-    help="The PEM-encoded certificate to verify against",
-)
-@click.option(
-    "signature_path",
-    "--signature",
-    type=click.File("rb"),
-    required=True,
-    help="The signature to verify against",
-)
-@click.option(
-    "cert_email",
-    "--cert-email",
-    type=str,
-    help=(
-        "The email address (or other identity string) to check for in the "
-        "certificate's Subject Alternative Name"
-    ),
-)
-@click.option(
-    "cert_oidc_issuer",
-    "--cert-oidc-issuer",
-    type=str,
-    help=(
-        "The OIDC issuer URL to check for in the certificate's OIDC issuer extension"
-    ),
-)
-@click.option(
-    "staging",
-    "--staging",
-    is_flag=True,
-    default=False,
-    help=(
-        "Use the sigstore project's staging instances, "
-        "instead of the default production instances"
-    ),
-)
-@click.option(
-    "rekor_url",
-    "--rekor-url",
-    metavar="URL",
-    type=click.STRING,
-    default=DEFAULT_REKOR_URL,
-    show_default=True,
-    help="The Rekor instance to use (conflicts with --staging)",
-)
-@click.argument(
-    "files", metavar="FILE [FILE ...]", type=click.File("rb"), nargs=-1, required=True
-)
-def _verify(
-    files: List[BinaryIO],
-    certificate_path: BinaryIO,
-    signature_path: BinaryIO,
-    cert_email: Optional[str],
-    cert_oidc_issuer: Optional[str],
-    rekor_url: str,
-    staging: bool,
-) -> None:
-    if staging:
+def _verify(args: argparse.Namespace) -> None:
+    if args.staging:
         logger.debug("verify: staging instances requested")
         verifier = Verifier.staging()
-    elif rekor_url == DEFAULT_REKOR_URL:
+    elif args.rekor_url == DEFAULT_REKOR_URL:
         verifier = Verifier.production()
     else:
         # TODO: We need CLI flags that allow the user to figure the Fulcio cert chain
         # for verification.
-        click.echo(
+        args._parser.error(
             "Custom Rekor and Fulcio configuration for verification isn't fully supported yet!",
-            err=True,
         )
-        raise click.Abort
 
     # Load the signing certificate
-    logger.debug(f"Using certificate from: {certificate_path.name}")
-    certificate = certificate_path.read()
+    logger.debug(f"Using certificate from: {args.certificate.name}")
+    certificate = args.certificate.read()
 
     # Load the signature
-    logger.debug(f"Using signature from: {signature_path.name}")
-    signature = signature_path.read()
+    logger.debug(f"Using signature from: {args.signature.name}")
+    signature = args.signature.read()
 
-    verified = True
-    for file in files:
-        result = verifier.verify(
-            file=file,
-            certificate=certificate,
-            signature=signature,
-            expected_cert_email=cert_email,
-            expected_cert_oidc_issuer=cert_oidc_issuer,
-        )
+    result = verifier.verify(
+        file=args.file,
+        certificate=certificate,
+        signature=signature,
+        expected_cert_email=args.cert_email,
+        expected_cert_oidc_issuer=args.cert_oidc_issuer,
+    )
 
-        if result:
-            click.echo(f"OK: {file.name}")
+    if result:
+        print(f"OK: {args.file.name}")
+    else:
+        result = cast(VerificationFailure, result)
+        print(f"FAIL: {args.file.name}")
+
+        if isinstance(result, CertificateVerificationFailure):
+            # If certificate verification failed, it's either because of
+            # a chain issue or some outdated state in sigstore itself.
+            # These might already be resolved in a newer version, so
+            # we suggest that users try to upgrade and retry before
+            # anything else.
+            print(result.reason, file=sys.stderr)
+            print(
+                dedent(
+                    f"""
+                    This may be a result of an outdated `sigstore` installation.
+
+                    Consider upgrading with:
+
+                        python -m pip install --upgrade sigstore
+
+                    Additional context:
+
+                    {result.exception}
+                    """
+                ),
+                file=sys.stderr,
+            )
         else:
-            result = cast(VerificationFailure, result)
-            click.echo(f"FAIL: {file.name}")
+            print(result.reason, file=sys.stderr)
 
-            if isinstance(result, CertificateVerificationFailure):
-                # If certificate verification failed, it's either because of
-                # a chain issue or some outdated state in sigstore itself.
-                # These might already be resolved in a newer version, so
-                # we suggest that users try to upgrade and retry before
-                # anything else.
-                click.echo(result.reason, err=True)
-                click.echo(
-                    dedent(
-                        f"""
-                        This may be a result of an outdated `sigstore` installation.
-
-                        Consider upgrading with:
-
-                            python -m pip install --upgrade sigstore
-
-                        Additional context:
-
-                        {result.exception}
-                        """
-                    ),
-                    err=True,
-                )
-            else:
-                click.echo(result.reason, err=True)
-            verified = False
-
-    if not verified:
-        raise click.Abort
+        sys.exit(1)

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -53,7 +53,9 @@ def _parser() -> argparse.ArgumentParser:
     subcommands = parser.add_subparsers(required=True, dest="subcommand")
 
     # `sigstore sign`
-    sign = subcommands.add_parser("sign")
+    sign = subcommands.add_parser(
+        "sign", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
 
     oidc_options = sign.add_argument_group("OpenID Connect options")
     oidc_options.add_argument(
@@ -167,7 +169,9 @@ def _parser() -> argparse.ArgumentParser:
     )
 
     # `sigstore verify`
-    verify = subcommands.add_parser("verify")
+    verify = subcommands.add_parser(
+        "verify", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
 
     input_options = verify.add_argument_group("Verification inputs")
     input_options.add_argument(

--- a/sigstore/_internal/rekor/client.py
+++ b/sigstore/_internal/rekor/client.py
@@ -32,13 +32,15 @@ from pydantic import BaseModel, Field, validator
 DEFAULT_REKOR_URL = "https://rekor.sigstore.dev"
 STAGING_REKOR_URL = "https://rekor.sigstage.dev"
 
-DEFAULT_REKOR_ROOT_PUBKEY = resources.read_binary("sigstore._store", "rekor.pub")
-STAGING_REKOR_ROOT_PUBKEY = resources.read_binary(
+_DEFAULT_REKOR_ROOT_PUBKEY = resources.read_binary("sigstore._store", "rekor.pub")
+_STAGING_REKOR_ROOT_PUBKEY = resources.read_binary(
     "sigstore._store", "rekor.staging.pub"
 )
 
-DEFAULT_REKOR_CTFE_PUBKEY = resources.read_binary("sigstore._store", "ctfe.pub")
-STAGING_REKOR_CTFE_PUBKEY = resources.read_binary("sigstore._store", "ctfe.staging.pub")
+_DEFAULT_REKOR_CTFE_PUBKEY = resources.read_binary("sigstore._store", "ctfe.pub")
+_STAGING_REKOR_CTFE_PUBKEY = resources.read_binary(
+    "sigstore._store", "ctfe.staging.pub"
+)
 
 
 @dataclass(frozen=True)
@@ -203,13 +205,13 @@ class RekorClient:
     @classmethod
     def production(cls) -> RekorClient:
         return cls(
-            DEFAULT_REKOR_URL, DEFAULT_REKOR_ROOT_PUBKEY, DEFAULT_REKOR_CTFE_PUBKEY
+            DEFAULT_REKOR_URL, _DEFAULT_REKOR_ROOT_PUBKEY, _DEFAULT_REKOR_CTFE_PUBKEY
         )
 
     @classmethod
     def staging(cls) -> RekorClient:
         return cls(
-            STAGING_REKOR_URL, STAGING_REKOR_ROOT_PUBKEY, STAGING_REKOR_CTFE_PUBKEY
+            STAGING_REKOR_URL, _STAGING_REKOR_ROOT_PUBKEY, _STAGING_REKOR_CTFE_PUBKEY
         )
 
     @property


### PR DESCRIPTION
This addresses the greedy output flags problem by giving them mandatory values, and adding a new option (`--output`) that toggles whether default output filenames are used instead.

It also addresses #123 by adding a new `--force` option that, if not passed, will refuse to continue with `sigstore sign` until pre-existing signing artifacts are moved or deleted from the overwriting path(s).

More generally, this PR refactors the entire `sigstore` CLI to use Python's default `argparse` instead of `click`. The primarily reason for this is to avoid `click`'s ambiguities around greedy value captures (https://github.com/pallets/click/issues/2307), but it'll also help us move towards a configuration model as part of #124.

Fixes #122.
Fixes #123.