### PR TITLE
cli: replace `--output` with `--no-default-files`

### DIFF
--- a/.github/workflows/staging-tests.yml
+++ b/.github/workflows/staging-tests.yml
@@ -31,7 +31,7 @@ jobs:
 
           # Our signing target is not important here, so we just sign
           # the README in the repository.
-          ./staging-env/bin/python -m sigstore sign --output --staging README.md
+          ./staging-env/bin/python -m sigstore sign --staging README.md
 
           # Verification also requires a different Rekor instance, so we
           # also test it.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Signing:
 ```
 usage: sigstore sign [-h] [--identity-token TOKEN] [--oidc-client-id ID]
                      [--oidc-client-secret SECRET]
-                     [--oidc-disable-ambient-providers] [--output]
+                     [--oidc-disable-ambient-providers] [--no-default-files]
                      [--output-signature FILE] [--output-certificate FILE]
                      [--overwrite] [--fulcio-url URL] [--rekor-url URL]
                      [--ctfe FILE] [--rekor-root-pubkey FILE]
@@ -90,8 +90,8 @@ OpenID Connect options:
                         (e.g. on GitHub Actions) (default: False)
 
 Output options:
-  --output              Write signature and certificate results to default
-                        files ({input}.sig and {input}.crt) (default: False)
+  --no-default-files    Don't emit the default output files ({input}.sig and
+                        {input}.crt) (default: False)
   --output-signature FILE
                         Write a single signature to the given file; conflicts
                         with --output and does not work with multiple input

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -102,12 +102,9 @@ def _parser() -> argparse.ArgumentParser:
 
     output_options = sign.add_argument_group("Output options")
     output_options.add_argument(
-        "--output",
+        "--no-default-files",
         action="store_true",
-        help=(
-            "Write signature and certificate results to default files "
-            "({input}.sig and {input}.crt)"
-        ),
+        help="Don't emit the default output files ({input}.sig and {input}.crt)",
     )
     output_options.add_argument(
         "--output-signature",
@@ -260,10 +257,12 @@ def main() -> None:
 
 
 def _sign(args: argparse.Namespace) -> None:
-    # `--output` may not be mixed with `--output-signature` or `--output-certificate`.
-    if args.output and (args.output_signature or args.output_certificate):
+    # `--no-default-files` has no effect on `--output-{signature,certificate}`,
+    # but we forbid it because it indicates user confusion.
+    if args.no_default_files and (args.output_signature or args.output_certificate):
         args._parser.error(
-            "--output may not be combined with --output-signature or --output-certificate",
+            "--no-default-files may not be combined with "
+            "--output-signature or --output-certificate",
         )
 
     # Fail if `--output-signature` or `--output-certificate` is specified
@@ -279,7 +278,7 @@ def _sign(args: argparse.Namespace) -> None:
     output_map = {}
     for file in args.files:
         sig, cert = args.output_signature, args.output_certificate
-        if args.output:
+        if not args.no_default_files:
             sig = file.parent / f"{file.name}.sig"
             cert = file.parent / f"{file.name}.crt"
 


### PR DESCRIPTION
This removes the `--output` file and makes its previous behavior the default, to prevent ambiguous argument lines like `sigstore sign --output input.ext`. 

The old default behavior can be re-enabled by passing `--no-default-files`. Open to suggestions on a better flag name 🙂 

Signed-off-by: William Woodruff <william@trailofbits.com>