### PR TITLE
OAuth: more debug logs, configurable browser

### DIFF
--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -162,8 +162,7 @@ def get_identity_token(client_id: str, client_secret: str, issuer: Issuer) -> st
     https://github.com/psteniusubi/python-sample
     """
 
-    browser = webbrowser.get(os.getenv("SIGSTORE_OAUTH_BROWSER"))
-    logger.debug(f"OAuth flow: using browser: {browser}")
+    force_oob = os.getenv("SIGSTORE_OAUTH_FORCE_OOB") is not None
 
     code: str
     with RedirectServer(client_id, client_secret, issuer) as server:
@@ -174,7 +173,7 @@ def get_identity_token(client_id: str, client_secret: str, issuer: Issuer) -> st
         thread.start()
 
         # Launch web browser
-        if browser.open(server.base_uri):
+        if not force_oob and webbrowser.open(server.base_uri):
             print(f"Your browser will now be opened to:\n{server.auth_request()}\n")
         else:
             server.enable_oob()

--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -174,7 +174,8 @@ def get_identity_token(client_id: str, client_secret: str, issuer: Issuer) -> st
 
         # Launch web browser
         if not force_oob and webbrowser.open(server.base_uri):
-            print(f"Your browser will now be opened to:\n{server.auth_request()}\n")
+            print("Waiting for browser interaction...")
+            # print(f"Your browser will now be opened to:\n{server.auth_request()}\n")
         else:
             server.enable_oob()
             print(

--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -51,7 +51,7 @@ class RedirectHandler(http.server.BaseHTTPRequestHandler):
         pass
 
     def do_GET(self) -> None:
-        logger.debug(f"GET: {self.path}")
+        logger.debug(f"GET: {self.path} with {dict(self.headers)}")
         server = cast(RedirectServer, self.server)
 
         # If the auth response has already been populated, the main thread will be stopping this

--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -54,10 +54,10 @@ class RedirectHandler(http.server.BaseHTTPRequestHandler):
         logger.debug(f"GET: {self.path}")
         server = cast(RedirectServer, self.server)
 
-        # If the auth response has already been populated, the main thread will be stopping this
-        # thread and accessing the auth response shortly so we should stop servicing any requests.
-        if not server.active:
-            return None
+        # # If the auth response has already been populated, the main thread will be stopping this
+        # # thread and accessing the auth response shortly so we should stop servicing any requests.
+        # if not server.active:
+        #     return None
 
         r = urllib.parse.urlsplit(self.path)
 

--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -141,7 +141,7 @@ class RedirectServer(http.server.HTTPServer):
         return f"{self._issuer.auth_endpoint}?{urllib.parse.urlencode(params)}"
 
     def enable_oob(self) -> None:
-        logger.debug("enabling out-of-band oauth flow")
+        logger.debug("enabling out-of-band OAuth flow")
         self.is_oob = True
 
 
@@ -153,6 +153,9 @@ def get_identity_token(client_id: str, client_secret: str, issuer: Issuer) -> st
     https://github.com/psteniusubi/python-sample
     """
 
+    browser = webbrowser.get(os.getenv("SIGSTORE_OAUTH_BROWSER"))
+    logger.debug(f"OAuth flow: using browser: {browser}")
+
     code: str
     with RedirectServer(client_id, client_secret, issuer) as server:
         thread = threading.Thread(
@@ -162,7 +165,7 @@ def get_identity_token(client_id: str, client_secret: str, issuer: Issuer) -> st
         thread.start()
 
         # Launch web browser
-        if webbrowser.open(server.base_uri):
+        if browser.open(server.base_uri):
             print(f"Your browser will now be opened to:\n{server.auth_request()}\n")
         else:
             server.enable_oob()

--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -212,6 +212,7 @@ def get_identity_token(client_id: str, client_secret: str, issuer: Issuer) -> st
         client_id,
         client_secret,
     )
+    logger.debug(f"token endpoint payloads: {data=} {auth=}")
     resp: requests.Response = requests.post(
         issuer.token_endpoint,
         data=data,

--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -15,6 +15,7 @@
 import base64
 import hashlib
 import http.server
+import logging
 import os
 import threading
 import time
@@ -27,6 +28,8 @@ import requests
 
 from sigstore._internal.oidc import IdentityError
 from sigstore._internal.oidc.issuer import Issuer
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_OAUTH_ISSUER = "https://oauth2.sigstore.dev/auth"
 STAGING_OAUTH_ISSUER = "https://oauth2.sigstage.dev/auth"
@@ -48,6 +51,7 @@ class RedirectHandler(http.server.BaseHTTPRequestHandler):
         pass
 
     def do_GET(self) -> None:
+        logger.debug(f"GET: {self.path}")
         server = cast(RedirectServer, self.server)
 
         # If the auth response has already been populated, the main thread will be stopping this
@@ -137,6 +141,7 @@ class RedirectServer(http.server.HTTPServer):
         return f"{self._issuer.auth_endpoint}?{urllib.parse.urlencode(params)}"
 
     def enable_oob(self) -> None:
+        logger.debug("enabling out-of-band oauth flow")
         self.is_oob = True
 
 

--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -78,9 +78,12 @@ class RedirectHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(302)
             self.send_header("Location", url)
             self.end_headers()
+            return None
         else:
+            logger.debug(f"404: {self.path}")
             # Anything else sends a "Not Found" response.
             self.send_response(404)
+            return None
 
 
 OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob"

--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -210,6 +210,7 @@ def get_identity_token(client_id: str, client_secret: str, issuer: Issuer) -> st
         client_id,
         client_secret,
     )
+    logging.debug(f"PAYLOAD: data={data}, auth={auth}")
     resp: requests.Response = requests.post(
         issuer.token_endpoint,
         data=data,


### PR DESCRIPTION
~~WIP.~~

~~This adds more debug logs and adds the `SIGSTORE_OAUTH_BROWSER` environment variable, which can be used to override the `webbrowser`'s default browser selection (e.g. `SIGSTORE_OAUTH_BROWSER=firefox`).~~

Removed the `SIGSTORE_OAUTH_BROWSER` variable, since it's essentially a duplicate of what `webbrowser` already does via the `BROWSER` variable. Instead, this PR adds `SIGSTORE_OAUTH_FORCE_OOB`, which forcefully disables the in-band OAuth flow if set.

See #96.