### PR TITLE
pyproject.toml: Pin `cryptography` to >= 3.1 to avoid incompatibilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Topic :: Security :: Cryptography",
 ]
 dependencies = [
-  "cryptography",
+  "cryptography>=3.1",
   "pem",
   "pydantic",
   "pyjwt>=2.1",


### PR DESCRIPTION
I noticed when testing in Github Actions that `sigstore-python` is incompatible with `cryptography` versions earlier than 3.1 because the API is designed to take different arguments.