### PR TITLE
_cli: Remove references to removed `--output` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,11 @@ Output options:
   --no-default-files    Don't emit the default output files ({input}.sig and
                         {input}.crt) (default: False)
   --output-signature FILE
-                        Write a single signature to the given file; conflicts
-                        with --output and does not work with multiple input
-                        files (default: None)
+                        Write a single signature to the given file; does not
+                        work with multiple input files (default: None)
   --output-certificate FILE
-                        Write a single certificate to the given file;
-                        conflicts with --output and does not work with
-                        multiple input files (default: None)
+                        Write a single certificate to the given file; does not
+                        work with multiple input files (default: None)
   --overwrite           Overwrite preexisting signature and certificate
                         outputs, if present (default: False)
 

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -111,8 +111,7 @@ def _parser() -> argparse.ArgumentParser:
         metavar="FILE",
         type=Path,
         help=(
-            "Write a single signature to the given file; conflicts with --output and "
-            "does not work with multiple input files"
+            "Write a single signature to the given file; does not work with multiple input files"
         ),
     )
     output_options.add_argument(
@@ -120,8 +119,7 @@ def _parser() -> argparse.ArgumentParser:
         metavar="FILE",
         type=Path,
         help=(
-            "Write a single certificate to the given file; conflicts with --output and "
-            "does not work with multiple input files"
+            "Write a single certificate to the given file; does not work with multiple input files"
         ),
     )
     output_options.add_argument(


### PR DESCRIPTION
Just something I noticed when working on a Github Action for `sigstore-python`.