### PR TITLE
pyproject: remove 'pem' dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 ]
 dependencies = [
   "cryptography>=3.1",
-  "pem",
   "pydantic",
   "pyjwt>=2.1",
   "pyOpenSSL",


### PR DESCRIPTION
Unused.

Signed-off-by: William Woodruff <william@trailofbits.com>
