### PR TITLE
Tweak linting target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,12 @@ make lint
 * [`interrogate`](https://interrogate.readthedocs.io/en/latest/): Documentation coverage
 
 
+To automatically apply any lint-suggested changes, you can run:
+
+```bash
+make reformat
+```
+
 ### Testing
 
 You can run the tests locally with:

--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,17 @@ run:
 .PHONY: lint
 lint:
 	. env/bin/activate && \
-		black $(ALL_PY_SRCS) && \
-		isort $(ALL_PY_SRCS) && \
+		black --check $(ALL_PY_SRCS) && \
+		isort --check $(ALL_PY_SRCS) && \
 		flake8 $(ALL_PY_SRCS) && \
 		mypy $(PY_MODULE) && \
 		bandit -c pyproject.toml -r $(PY_MODULE)
 
-	  git diff --exit-code
+.PHONY: reformat
+reformat:
+	. env/bin/activate && \
+		black $(ALL_PY_SRCS) && \
+		isort $(ALL_PY_SRCS)
 
 .PHONY: test
 test:


### PR DESCRIPTION
This follows the same pattern as Warehouse, and splits `make lint` into two separate targets:

* `make lint`: Run all linters, exiting with nonzero if any fail
* `make reformat`: Run the subset of linters that can automatically rewrite the source

Closes #169.