### PR TITLE
API tweak to allow further external verification

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -44,11 +44,12 @@ def pytest_configure(config):
 
 @pytest.fixture
 def signed_asset():
-    def _signed_asset(name: str) -> Tuple[bytes, bytes, bytes]:
+    def _signed_asset(name: str) -> Tuple[bytes, bytes, bytes, str]:
         file = _ASSETS / name
         cert = _ASSETS / f"{name}.crt"
         sig = _ASSETS / f"{name}.sig"
+        email = _ASSETS / f"{name}.email"
 
-        return (file.read_bytes(), cert.read_bytes(), sig.read_bytes())
+        return (file.read_bytes(), cert.read_bytes(), sig.read_bytes(), email.read_text().strip())
 
     return _signed_asset

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -19,6 +19,7 @@ from sigstore._verify import (
     VerificationFailure,
     VerificationSuccess,
     Verifier,
+    load_pem_x509_certificate,
 )
 
 
@@ -37,7 +38,11 @@ def test_verifier_one_verification(signed_asset):
     a_assets = signed_asset("a.txt")
 
     verifier = Verifier.staging()
-    assert verifier.verify(a_assets[0], a_assets[1], a_assets[2])
+    assert verifier.verify_base(a_assets[0], a_assets[1], a_assets[2])
+    assert verifier.verify_email(a_assets[0], a_assets[1], a_assets[2], a_assets[3])
+
+    # Failure tests
+    assert not verifier.verify_email(a_assets[0], a_assets[1], a_assets[2], "email@example.org")
 
 
 @pytest.mark.online
@@ -47,10 +52,17 @@ def test_verifier_multiple_verifications(signed_asset):
 
     verifier = Verifier.staging()
     for assets in [a_assets, b_assets]:
-        assert verifier.verify(assets[0], assets[1], assets[2])
+        assert verifier.verify_base(assets[0], assets[1], assets[2])
+        assert verifier.verify_email(assets[0], assets[1], assets[2], assets[3])
+
+        # Failure tests
+        assert not verifier.verify_email(assets[0], assets[1], assets[2], "email@example.org")
 
 
-def test_verify_result_boolish():
+def test_verify_result_boolish(signed_asset):
+    # signed asset argument just to have a cert for VerificationSuccess
+    cert = load_pem_x509_certificate(signed_asset("a.txt")[1])
+
     assert not VerificationFailure(reason="foo")
     assert not CertificateVerificationFailure(reason="foo", exception=ValueError("bar"))
-    assert VerificationSuccess()
+    assert VerificationSuccess(certificate=cert)


### PR DESCRIPTION
This is a discussion starter for #157

#### Summary

It is currently not possible to use sigstore-python to verify the signatures made with a GitHub Actions certificate -- or rather it's not possible to verify any meaningful claims made by GitHub (like which project is responsible or what workflow was used). This is true for both the CLI tool and the API.

This change keeps CLI as is, but tweaks the API so that callers of verify() can do their own verification of the certificate contents after sigstore-python is happy with it.

#### Release Notes

* Renamed current verify() to verify_email() -- this rename could be easily avoided if that's desirable
* Refactored the generic verification code to verify_base() for re-use in both verify_email() and other code
* Included (cryptography.X509) Certificate in the VerificationSuccess object: this enables calling code to continue verifying the contents without re-parsing the certificate

#### Documentation

The change allows an external developer to write (as an example) this code to verify  GitHub specific claims outside the sigstore-python codebase:

```python
from typing import Optional
from cryptography.x509 import ExtensionNotFound, ObjectIdentifier, SubjectAlternativeName, UniformResourceIdentifier
from sigstore._verify import Verifier, VerificationResult, VerificationFailure

GITHUB_ACTIONS_ISSUER = "https://token.actions.githubusercontent.com"
OIDC_GITHUB_WORKFLOW_SHA_OID = ObjectIdentifier("1.3.6.1.4.1.57264.1.3")
OIDC_GITHUB_WORKFLOW_REPOSITORY_OID = ObjectIdentifier("1.3.6.1.4.1.57264.1.5")

def verify_github(filename: str, expected_repo: str, expected_workflow: str, expected_tag: str, expected_sha: Optional[str]) -> VerificationResult:
    with open(filename, "rb") as f:
        input_ = f.read()
    with open(f"{filename}.crt", "rb") as f:
        cert = f.read()
    with open(f"{filename}.sig", "rb") as f:
        sig = f.read()
    
    verifier = Verifier.production()

    # Verify that signature is correct and issuer is GitHub
    result = verifier.verify_base(input_, cert, sig, GITHUB_ACTIONS_ISSUER)
    if not result:
        return result

    extensions = result.certificate.extensions
    san_ext = extensions.get_extension_for_class(SubjectAlternativeName)
    sans = san_ext.value.get_values_for_type(UniformResourceIdentifier)
    try:
        repository = extensions.get_extension_for_oid(OIDC_GITHUB_WORKFLOW_REPOSITORY_OID).value
        sha = extensions.get_extension_for_oid(OIDC_GITHUB_WORKFLOW_SHA_OID).value
    except ExtensionNotFound:
        return VerificationFailure(reason="Certificate does not contain a required GitHub extension")

    # Verify the signer identity
    expected_san = f"https://github.com/{expected_repo}/{expected_workflow}@refs/tags/{expected_tag}"
    if expected_san not in sans:
        return VerificationFailure(reason=f"Expected subject name '{expected_san}', got '{sans}'")
    
    # Verify the repository
    if repository.value != expected_repo.encode():
        return VerificationFailure(
            reason=f"Certificate's workflow repository does not match (got {repository.value})"
        )

    # Verify SHA
    if expected_sha:
        if sha.value != expected_sha.encode():
            return VerificationFailure(
                reason=f"Certificate's workflow SHA does not match (got {sha.value})"
            )

    # All good!
    return result

verify_github(
    "sigstore-0.6.3-py3-none-any.whl"
    "sigstore/sigstore-python",
    ".github/workflows/release.yml",
    "v0.6.3",
    "bff2e635da74627b62b31efd746f533bf97801ed"
)

```