### PR TITLE
ci: add debug loglevel to ci and debug log of verified log index

### DIFF
--- a/.github/workflows/staging-tests.yml
+++ b/.github/workflows/staging-tests.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a
 
       - name: staging tests
+        env:
+          SIGSTORE_LOGLEVEL: DEBUG
         run: |
           # This is similar to the "smoketest" that we run during the
           # release workflow, except that we run against Sigstore's

--- a/sigstore/_verify.py
+++ b/sigstore/_verify.py
@@ -249,6 +249,7 @@ class Verifier:
         uuids = self._rekor.index.retrieve.post(sha256_artifact_hash, pub_b64.decode())
 
         valid_sig_exists = False
+        log_index = None
         for uuid in uuids:
             entry: RekorEntry = self._rekor.log.entries.get(uuid)
 
@@ -285,12 +286,13 @@ class Verifier:
 
             # TODO: Does it make sense to collect all valid Rekor entries?
             valid_sig_exists = True
+            log_index = entry.log_index
             break
 
         if not valid_sig_exists:
             return VerificationFailure(reason="No valid Rekor entries were found")
 
-        logger.debug("Successfully verified Rekor entry...")
+        logger.debug(f"Successfully verified Rekor entry at index {log_index}..")
         return VerificationSuccess()
 
 


### PR DESCRIPTION
…fied entry

Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Part of https://github.com/sigstore/sigstore-python/issues/184

* Adds log level `DEBUG` to CI staging tests to allow for detection of problems in case something goes wrong with staging.
* Adds an debug log output in `verify` for the `log_index` of the verified entry, to match with parity on `sign`.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->