### PR TITLE
Skip curl to download requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ python -m pip install sigstore
 Optionally, to install `sigstore` and all its dependencies with [hash-checking mode](https://pip.pypa.io/en/stable/topics/secure-installs/#hash-checking-mode) enabled, run the following:
 
 ```console
-python -m pip install -r <(curl -s https://raw.githubusercontent.com/sigstore/sigstore-python/main/install/requirements.txt)
+python -m pip install -r https://raw.githubusercontent.com/sigstore/sigstore-python/main/install/requirements.txt
 ```
 
 This installs the requirements file located [here](https://github.com/sigstore/sigstore-python/blob/main/install/requirements.txt), which is kept up-to-date.


### PR DESCRIPTION
#### Summary
pip can download the file automatically, so the curl call is not needed. Unless you trust curl more than requests, which I guess is not entirely unreasonable :)

Close #191.