### PR TITLE
sigstore: use stricter pydantic fields, where applicable

### DIFF
--- a/sigstore/_internal/oidc/ambient.py
+++ b/sigstore/_internal/oidc/ambient.py
@@ -21,7 +21,7 @@ import os
 from typing import Callable, List, Optional
 
 import requests
-from pydantic import BaseModel
+from pydantic import BaseModel, StrictStr
 
 from sigstore._internal.oidc import DEFAULT_AUDIENCE, IdentityError
 
@@ -74,7 +74,7 @@ class _GitHubTokenPayload(BaseModel):
     This exists solely to provide nice error handling.
     """
 
-    value: str
+    value: StrictStr
 
 
 def detect_github() -> Optional[str]:

--- a/sigstore/_internal/rekor/client.py
+++ b/sigstore/_internal/rekor/client.py
@@ -28,7 +28,7 @@ from urllib.parse import urljoin
 import requests
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, StrictInt, StrictStr, validator
 
 DEFAULT_REKOR_URL = "https://rekor.sigstore.dev"
 STAGING_REKOR_URL = "https://rekor.sigstage.dev"
@@ -75,10 +75,10 @@ class RekorEntry:
 
 
 class RekorInclusionProof(BaseModel):
-    log_index: int = Field(..., alias="logIndex")
-    root_hash: str = Field(..., alias="rootHash")
-    tree_size: int = Field(..., alias="treeSize")
-    hashes: List[str] = Field(..., alias="hashes")
+    log_index: StrictInt = Field(..., alias="logIndex")
+    root_hash: StrictStr = Field(..., alias="rootHash")
+    tree_size: StrictInt = Field(..., alias="treeSize")
+    hashes: List[StrictStr] = Field(..., alias="hashes")
 
     class Config:
         allow_population_by_field_name = True


### PR DESCRIPTION
Just a small QoL improvement: this prevents us from over-accepting inputs to these models, since Pydantic is happy to coerce fields into their correct types without `StrictFoo`.

Signed-off-by: William Woodruff <william@trailofbits.com>
