### PR TITLE
_internal: Rekor and Fulcio clients clean up their HTTP sessions on release

### DIFF
--- a/sigstore/_internal/fulcio/client.py
+++ b/sigstore/_internal/fulcio/client.py
@@ -302,6 +302,9 @@ class FulcioClient:
         self.url = url
         self.session = requests.Session()
 
+    def __del__(self):
+        self.session.close()
+
     @classmethod
     def production(cls) -> FulcioClient:
         return cls(DEFAULT_FULCIO_URL)

--- a/sigstore/_internal/fulcio/client.py
+++ b/sigstore/_internal/fulcio/client.py
@@ -302,7 +302,7 @@ class FulcioClient:
         self.url = url
         self.session = requests.Session()
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.session.close()
 
     @classmethod

--- a/sigstore/_internal/rekor/client.py
+++ b/sigstore/_internal/rekor/client.py
@@ -219,7 +219,7 @@ class RekorClient:
             raise RekorClientError(f"Invalid CTFE public key type: {ctfe_pubkey}")
         self._ctfe_pubkey = ctfe_pubkey
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.session.close()
 
     @classmethod

--- a/sigstore/_internal/rekor/client.py
+++ b/sigstore/_internal/rekor/client.py
@@ -219,6 +219,9 @@ class RekorClient:
             raise RekorClientError(f"Invalid CTFE public key type: {ctfe_pubkey}")
         self._ctfe_pubkey = ctfe_pubkey
 
+    def __del__(self):
+        self.session.close()
+
     @classmethod
     def production(cls) -> RekorClient:
         return cls(


### PR DESCRIPTION
Fixes #211.

Signed-off-by: William Woodruff <william@trailofbits.com>
