### PR TITLE
deps: constrain pyOpenSSL to >=22.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "cryptography>=38",
   "pydantic",
   "pyjwt>=2.1",
-  "pyOpenSSL",
+  "pyOpenSSL>=22.0.0",
   "requests",
   "securesystemslib",
 ]


### PR DESCRIPTION
Without this, environments that already have `pyOpenSSL` installed are likely to reuse that version, causing breakages when we directly or indirectly (via `cryptography`) use more recent APIs. 

In particular, the lack of a constraint here caused some failures in `gh-action-sigstore-python`: https://github.com/trailofbits/gh-action-sigstore-python/issues/25

Signed-off-by: William Woodruff <william@trailofbits.com>
