### PR TITLE
Update CONTRIBUTING.md to expose the requirements to open a PR. Closes #224

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+<!--
+Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.
+
+Please remember to:
+- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
+issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
+  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
+- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
+
+Thank you :)
+-->
+
+#### Summary
+<!--
+ Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
+-->
+
+#### Release Note
+<!--
+Add a release note for each of the following conditions:
+
+* Config changes (additions, deletions, updates)
+* API additions—new endpoint, new response fields, or newly accepted request parameters
+* Database changes (any)
+* Websocket additions or changes
+* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
+* New features and improvements, including behavioural changes, UI changes and CLI changes
+* Bug fixes and fixes of previous known issues
+* Deprecation warnings, breaking changes, or compatibility notes
+
+If no release notes are required write NONE. Use past-tense.
+
+-->
+
+#### Documentation
+<!--
+
+Does this change require an update to documentation? How will users implement your new feature?
+
+Please reference a PR within https://docs.sigstore.dev
+
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,5 +140,6 @@ bug reports when their debug logs include helpful context!
 in changes to `sigstore`'s CLI, please record them under the "Unreleased" section,
 with an entry in an appropriate subsection ("Added", "Changed", "Removed", or "Fixed").
 
-* Ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin). 
+* Ensure your commits are signed off, as sigstore uses the
+[DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin). 
 You can do it using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,3 +139,6 @@ bug reports when their debug logs include helpful context!
 * *Update the [CHANGELOG](./CHANGELOG.md)*. If your changes are public or result
 in changes to `sigstore`'s CLI, please record them under the "Unreleased" section,
 with an entry in an appropriate subsection ("Added", "Changed", "Removed", or "Fixed").
+
+* Ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin). 
+You can do it using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits.


### PR DESCRIPTION
Signed-off-by: Diogo Teles Sant'Anna <diogoteles08@gmail.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This PR was created because the Template for creating a PR have a text that says it's necessary to have all commits signed-off to make the PR, but it was not said on the CONTRIBUTING.md.

IMPORTANT: on the PR template it's still present the item "lastly, ensure there are no merge commits!". If this step is not necessary anymore, it would be better to have it removed. I could not find where to change this text, so I supposed it was configured directly on github. Let me know if I can help with this as well.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->