### PR TITLE
Add a get-identity-token subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,16 @@ Top-level:
 
 <!-- @begin-sigstore-help@ -->
 ```
-usage: sigstore [-h] [-V] {sign,verify} ...
+usage: sigstore [-h] [-V] {sign,verify,get-identity-token} ...
 
 a tool for signing and verifying Python package distributions
 
 positional arguments:
-  {sign,verify}
+  {sign,verify,get-identity-token}
 
 options:
-  -h, --help     show this help message and exit
-  -V, --version  show program's version number and exit
+  -h, --help            show this help message and exit
+  -V, --version         show program's version number and exit
 ```
 <!-- @end-sigstore-help@ -->
 
@@ -87,11 +87,11 @@ Signing:
 ```
 usage: sigstore sign [-h] [--identity-token TOKEN] [--oidc-client-id ID]
                      [--oidc-client-secret SECRET]
-                     [--oidc-disable-ambient-providers] [--no-default-files]
-                     [--signature FILE] [--certificate FILE] [--overwrite]
-                     [--fulcio-url URL] [--rekor-url URL] [--ctfe FILE]
-                     [--rekor-root-pubkey FILE] [--oidc-issuer URL]
-                     [--staging]
+                     [--oidc-disable-ambient-providers] [--oidc-issuer URL]
+                     [--no-default-files] [--signature FILE]
+                     [--certificate FILE] [--overwrite] [--fulcio-url URL]
+                     [--rekor-url URL] [--ctfe FILE]
+                     [--rekor-root-pubkey FILE] [--staging]
                      FILE [FILE ...]
 
 positional arguments:
@@ -111,6 +111,8 @@ OpenID Connect options:
   --oidc-disable-ambient-providers
                         Disable ambient OpenID Connect credential detection
                         (e.g. on GitHub Actions) (default: False)
+  --oidc-issuer URL     The OpenID Connect issuer to use (conflicts with
+                        --staging) (default: https://oauth2.sigstore.dev/auth)
 
 Output options:
   --no-default-files    Don't emit the default output files ({input}.sig and
@@ -135,8 +137,6 @@ Sigstore instance options:
                         A PEM-encoded root public key for Rekor itself
                         (conflicts with --staging) (default: rekor.pub
                         (embedded))
-  --oidc-issuer URL     The OpenID Connect issuer to use (conflicts with
-                        --staging) (default: https://oauth2.sigstore.dev/auth)
   --staging             Use sigstore's staging instances, instead of the
                         default production instances (default: False)
 ```

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -61,6 +61,34 @@ class _Embedded:
         return f"{self._name} (embedded)"
 
 
+def _add_shared_oidc_options(group):
+    group.add_argument(
+        "--oidc-client-id",
+        metavar="ID",
+        type=str,
+        default="sigstore",
+        help="The custom OpenID Connect client ID to use during OAuth2",
+    )
+    group.add_argument(
+        "--oidc-client-secret",
+        metavar="SECRET",
+        type=str,
+        help="The custom OpenID Connect client secret to use during OAuth2",
+    )
+    group.add_argument(
+        "--oidc-disable-ambient-providers",
+        action="store_true",
+        help="Disable ambient OpenID Connect credential detection (e.g. on GitHub Actions)",
+    )
+    group.add_argument(
+        "--oidc-issuer",
+        metavar="URL",
+        type=str,
+        default=DEFAULT_OAUTH_ISSUER,
+        help="The OpenID Connect issuer to use (conflicts with --staging)",
+    )
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="sigstore",
@@ -84,24 +112,7 @@ def _parser() -> argparse.ArgumentParser:
         type=str,
         help="the OIDC identity token to use",
     )
-    oidc_options.add_argument(
-        "--oidc-client-id",
-        metavar="ID",
-        type=str,
-        default="sigstore",
-        help="The custom OpenID Connect client ID to use during OAuth2",
-    )
-    oidc_options.add_argument(
-        "--oidc-client-secret",
-        metavar="SECRET",
-        type=str,
-        help="The custom OpenID Connect client secret to use during OAuth2",
-    )
-    oidc_options.add_argument(
-        "--oidc-disable-ambient-providers",
-        action="store_true",
-        help="Disable ambient OpenID Connect credential detection (e.g. on GitHub Actions)",
-    )
+    _add_shared_oidc_options(oidc_options)
 
     output_options = sign.add_argument_group("Output options")
     output_options.add_argument(
@@ -162,13 +173,6 @@ def _parser() -> argparse.ArgumentParser:
         type=argparse.FileType("rb"),
         help="A PEM-encoded root public key for Rekor itself (conflicts with --staging)",
         default=_Embedded("rekor.pub"),
-    )
-    instance_options.add_argument(
-        "--oidc-issuer",
-        metavar="URL",
-        type=str,
-        default=DEFAULT_OAUTH_ISSUER,
-        help="The OpenID Connect issuer to use (conflicts with --staging)",
     )
     instance_options.add_argument(
         "--staging",

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -19,7 +19,7 @@ import sys
 from importlib import resources
 from pathlib import Path
 from textwrap import dedent
-from typing import TextIO, cast
+from typing import Optional, TextIO, Union, cast
 
 from sigstore import __version__
 from sigstore._internal.fulcio.client import DEFAULT_FULCIO_URL, FulcioClient
@@ -61,7 +61,9 @@ class _Embedded:
         return f"{self._name} (embedded)"
 
 
-def _add_shared_oidc_options(group):
+def _add_shared_oidc_options(
+    group: Union[argparse._ArgumentGroup, argparse.ArgumentParser]
+) -> None:
     group.add_argument(
         "--oidc-client-id",
         metavar="ID",
@@ -468,7 +470,7 @@ def _verify(args: argparse.Namespace) -> None:
             sys.exit(1)
 
 
-def _get_identity_token(args):
+def _get_identity_token(args: argparse.Namespace) -> Optional[str]:
     if not args.oidc_disable_ambient_providers:
         try:
             return detect_credential()

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -247,10 +247,7 @@ def _parser() -> argparse.ArgumentParser:
     )
 
     # `sigstore get-identity-token`
-    get_identity_token = subcommands.add_parser(
-        "get-identity-token",
-        help="Generate and print an identity token to be used with --identity-token",
-    )
+    get_identity_token = subcommands.add_parser("get-identity-token")
     _add_shared_oidc_options(get_identity_token)
 
     return parser

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -244,6 +244,13 @@ def _parser() -> argparse.ArgumentParser:
         help="The file to verify",
     )
 
+    # `sigstore get-identity-token`
+    get_identity_token = subcommands.add_parser(
+        "get-identity-token",
+        help="Generate and print an identity token to be used with --identity-token",
+    )
+    _add_shared_oidc_options(get_identity_token)
+
     return parser
 
 
@@ -261,6 +268,8 @@ def main() -> None:
         _sign(args)
     elif args.subcommand == "verify":
         _verify(args)
+    elif args.subcommand == "get-identity-token":
+        print(_get_identity_token(args))
     else:
         parser.error(f"Unknown subcommand: {args.subcommand}")
 


### PR DESCRIPTION
This PR adds a subcommand `get-identity-token` that allows the user to get an identity token which can be used with the `sign` command's `--identity-token` flag.