### PR TITLE
test: add an `ambient_oidc` marker

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,13 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from pathlib import Path
 from typing import Tuple
 
 import pytest
 
+from sigstore._internal.oidc.ambient import (
+    AmbientCredentialError,
+    GitHubOidcPermissionCredentialError,
+    detect_credential,
+)
+
 _ASSETS = (Path(__file__).parent / "assets").resolve()
 assert _ASSETS.is_dir()
+
+
+def _is_ambient_env():
+    try:
+        token = detect_credential()
+        if token is None:
+            return False
+    except GitHubOidcPermissionCredentialError:
+        # On GitHub Actions, forks do not have access to OIDC identities.
+        # We differentiate this case from other GitHub credential errors,
+        # since it's a case where we want to skip (i.e. return False).
+        if os.getenv("GITHUB_EVENT_NAME") == "pull_request":
+            return False
+        return True
+    except AmbientCredentialError:
+        # If ambient credential detection raises, then we *are* in an ambient
+        # environment but one that's been configured incorrectly. We
+        # pass this through, so that the CI fails appropriately rather than
+        # silently skipping the faulty tests.
+        return True
+
+    return True
 
 
 def pytest_addoption(parser):
@@ -34,6 +63,8 @@ def pytest_runtest_setup(item):
         pytest.skip(
             "skipping test that requires network connectivity due to `--skip-online` flag"
         )
+    elif "ambient_oidc" in item.keywords and not _is_ambient_env():
+        pytest.skip("skipping test that requires an ambient OIDC credential")
 
 
 def pytest_configure(config):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -71,6 +71,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "online: mark test as requiring network connectivity"
     )
+    config.addinivalue_line(
+        "markers", "ambient_oidc: mark test as requiring an ambient OIDC identity"
+    )
 
 
 @pytest.fixture

--- a/test/test_sign.py
+++ b/test/test_sign.py
@@ -31,11 +31,11 @@ def test_signer_staging():
 
 
 @pytest.mark.online
+@pytest.mark.ambient_oidc
 @pytest.mark.parametrize("signer", [Signer.production(), Signer.staging()])
 def test_sign_rekor_entry_consistent(signer):
     token = detect_credential()
-    if token is None:
-        pytest.skip("no ambient credentials; skipping")
+    assert token is not None
 
     payload = secrets.token_bytes(32)
     expected_entry = signer.sign(payload, token).log_entry


### PR DESCRIPTION
See #258.

Fixes #257.