### PR TITLE
Implement a Python-native sign/verify API

### DIFF
--- a/sigstore/_api.py
+++ b/sigstore/_api.py
@@ -1,0 +1,88 @@
+from textwrap import dedent
+from typing import cast
+
+from sigstore._internal.oidc.ambient import (
+    detect_credential,
+    GitHubOidcPermissionCredentialError
+)
+from sigstore._internal.oidc.issuer import Issuer
+from sigstore._internal.oidc.oauth import (
+    DEFAULT_OAUTH_ISSUER,
+    get_identity_token,
+)
+from sigstore._sign import Signer, SigningResult
+from sigstore._verify import (
+    VerificationFailure,
+    Verifier,
+)
+
+# Sign an artifact using sigstore-python. Returns SigningResult
+def sign(artifact, signer=Signer.production(), identity_token=None, disable_oidc_ambient_providers=False, oidc_issuer=DEFAULT_OAUTH_ISSUER, oidc_client_id="sigstore", oidc_client_secret="") -> SigningResult:
+    # Attempt to detect Github ambient credentials if an identity token is not provided.
+    if not identity_token and not disable_oidc_ambient_providers:
+        try:
+            identity_token = detect_credential()
+        except GitHubOidcPermissionCredentialError as exception:
+            # Provide some common reasons for why we hit permission errors in
+            # GitHub Actions.
+            print(
+                dedent(
+                    f"""
+                    Insufficient permissions for GitHub Actions workflow.
+
+                    The most common reason for this is incorrect
+                    configuration of the top-level `permissions` setting of the
+                    workflow YAML file. It should be configured like so:
+
+                        permissions:
+                          id-token: write
+
+                    Relevant documentation here:
+
+                        https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
+
+                    Another possible reason is that the workflow run has been
+                    triggered by a PR from a forked repository. PRs from forked
+                    repositories typically cannot be granted write access.
+
+                    Relevant documentation here:
+
+                        https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+
+                    Additional context:
+
+                    {exception}
+                    """
+                )
+            )
+            raise exception
+    if not identity_token:
+        issuer = Issuer(oidc_issuer)
+        identity_token = get_identity_token(
+            oidc_client_id,
+            oidc_client_secret, # oidc client secret
+            issuer,
+        )
+
+    return signer.sign(
+        input_=artifact,
+        identity_token=identity_token
+    )
+
+
+# Verify an artifact, signature, and certificate using sigstore-python. Returns bool
+def verify(artifact, crt, sig, verifier=Verifier.production()) -> bool:
+    result = verifier.verify(
+        input_=artifact,
+        certificate=crt,
+        signature=sig
+    )
+
+    if result:
+        print("Sigstore verification: OK")
+        return True
+    else:
+        result = cast(VerificationFailure, result)
+        print("Sigstore verification: FAIL")
+        print(f"Failure reason: {result.reason}")
+        return False


### PR DESCRIPTION
#### Summary

Linked issue: #273 

This PR exposes a similar sign/verify interface to what's currently available from the `sigstore-python` CLI in native Python. This will allow other Python projects to sign and verify directly, without needing to wrap the CLI.

cc @lukehinds @mayaCostantini

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->