### PR TITLE
workflow: Workaround for SLSA generator failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
     with:
       attestation-name: provenance-sigstore-${{ github.event.release.tag_name }}.intoto.jsonl
       base64-subjects: "${{ needs.build.outputs.hashes }}"
+      compile-generator: true # Workaround for https://github.com/slsa-framework/slsa-github-generator/issues/1163
       upload-assets: true
 
   release-pypi:


### PR DESCRIPTION
This is currently blocking the v0.0.7 release.

My understanding is that a breaking change happened to the TUF root meaning that older Sigstore libraries used to interact with TUF no longer work.

This job was previously pulling the provenance generator binary and then verifying it with Sigstore (this is the part that was breaking with the new TUF root). With `compile-generator`, the job will build the generator from source and avoid the Sigstore verification.

We should be able to get rid of this with a new release of `slsa-github-generator` is pushed.

Extended discussion at: https://github.com/slsa-framework/slsa-github-generator/issues/1163