### PR TITLE
workflows/staging-tests: add missing identity check

### DIFF
--- a/.github/workflows/staging-tests.yml
+++ b/.github/workflows/staging-tests.yml
@@ -43,6 +43,7 @@ jobs:
           # also test it.
           ./staging-env/bin/python -m sigstore verify --staging \
             --cert-oidc-issuer https://token.actions.githubusercontent.com \
+            --cert-identity ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/.github/.workflows/staging-tests.yml@${GITHUB_REF} \
             README.md
 
       - name: generate an issue if staging tests fail
@@ -61,7 +62,7 @@ jobs:
 
           The full CI failure can be found here:
 
-          $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+          ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/$GITHUB_RUN_ID
           EOF
 
       - name: open an issue if the staging tests fail


### PR DESCRIPTION
#299 made `--cert-identity` mandatory, so this should fix the staging tests by using it.

Signed-off-by: William Woodruff <william@trailofbits.com>
