### PR TITLE
sigstore, test: add actual SANs to policy failure reason

### DIFF
--- a/test/unit/verify/test_policy.py
+++ b/test/unit/verify/test_policy.py
@@ -139,5 +139,8 @@ class TestIdentity:
         result = policy_.verify(materials.certificate)
         assert not result
         assert result == VerificationFailure(
-            reason="Certificate's SANs do not match bad@ident.example.com"
+            reason=(
+                "Certificate's SANs do not match bad@ident.example.com; "
+                "actual SANs: {'william@yossarian.net'}"
+            )
         )


### PR DESCRIPTION
This should make debugging `--cert-identity` failures a little easier.

xref https://github.com/sigstore/sigstore-python/pull/307#issuecomment-1322438494

Signed-off-by: William Woodruff <william@trailofbits.com>
