### PR TITLE
oidc/oauth: avoid logging the OAuth auth headers

### DIFF
--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -249,7 +249,7 @@ def get_identity_token(client_id: str, client_secret: str, issuer: Issuer) -> st
         client_id,
         client_secret,
     )
-    logging.debug(f"PAYLOAD: data={data}, auth={auth}")
+    logging.debug(f"PAYLOAD: data={data}")
     resp: requests.Response = requests.post(
         issuer.token_endpoint,
         data=data,


### PR DESCRIPTION
The auth headers contain the OAuth client secret, which we shouldn't log (to minimize the chances of a user accidentally disclosing it while reporting bugs.)

Signed-off-by: William Woodruff <william@trailofbits.com>
