### PR TITLE
workflows/release: set python-version explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@d171c3b028d844f2bf14e9fdec0c58114451e4bf
 
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984
+        with:
+          python-version: "3.x"
 
       - name: deps
         run: python -m pip install -U build


### PR DESCRIPTION
Fixes a `setup-python` actions warning.

Signed-off-by: William Woodruff <william@trailofbits.com>
