### PR TITLE
Run tests in CI with full verbosity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: deps
         run: make dev SIGSTORE_EXTRA=test
       - name: test
-        run: make test
+        run: make test TEST_ARGS="-vv"
       - name: test (offline)
         run: |
           # We use `unshare` to "un-share" the default networking namespace,
@@ -38,7 +38,7 @@ jobs:
           # This in turn effectively exercises the correctness of our
           # "online-only" test markers, since any test that's online
           # but not marked as such will fail.
-          unshare --map-root-user --net make test TEST_ARGS="--skip-online"
+          unshare --map-root-user --net make test TEST_ARGS="--skip-online -vv"
 
   licenses:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[A recent test run](https://github.com/sigstore/sigstore-python/actions/runs/3641503672/jobs/6147515676) seems to have caused a 500-level error with Rekor, but the full certificate that was uploaded in the test was truncated.

This PR ensures CI tests are run with full verbosity so long strings like certificates appear intact in the logs.