### PR TITLE
Eliminate deprecation warnings on 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - uses: actions/checkout@d171c3b028d844f2bf14e9fdec0c58114451e4bf
       - uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9
+        with:
+          python-version: "3.x"
       - name: deps
         run: make dev SIGSTORE_EXTRA=lint
       - name: lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,11 @@ classifiers = [
   "Topic :: Security :: Cryptography",
 ]
 dependencies = [
-  "cryptography>=38",
+  "cryptography >= 38",
+  "importlib_resources ~= 5.7; python_version < '3.11'",
   "pydantic",
-  "pyjwt>=2.1",
-  "pyOpenSSL>=22.0.0",
+  "pyjwt >= 2.1",
+  "pyOpenSSL >= 22.0.0",
   "requests",
   "securesystemslib",
 ]
@@ -66,7 +67,7 @@ lint = [
 ]
 dev = [
   "build",
-  "bump>=1.3.2",
+  "bump >= 1.3.2",
   "pdoc3",
   "sigstore[test,lint]",
 ]

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -17,7 +17,6 @@ import base64
 import logging
 import os
 import sys
-from importlib import resources
 from pathlib import Path
 from textwrap import dedent
 from typing import Optional, TextIO, Union, cast
@@ -45,6 +44,7 @@ from sigstore._sign import Signer
 from sigstore._utils import (
     SplitCertificateChainError,
     load_pem_public_key,
+    read_embedded,
     split_certificate_chain,
 )
 from sigstore._verify import (
@@ -70,7 +70,7 @@ class _Embedded:
         self._name = name
 
     def read(self) -> bytes:
-        return resources.read_binary("sigstore._store", self._name)
+        return read_embedded(self._name)
 
     def __repr__(self) -> str:
         return f"{self._name} (embedded)"

--- a/sigstore/_internal/ctfe.py
+++ b/sigstore/_internal/ctfe.py
@@ -18,7 +18,6 @@ Functionality for interacting with CT ("CTFE") signing keys.
 
 from __future__ import annotations
 
-from importlib import resources
 from typing import List
 
 import cryptography.hazmat.primitives.asymmetric.padding as padding
@@ -26,7 +25,12 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 
-from sigstore._utils import PublicKey, key_id, load_pem_public_key
+from sigstore._utils import (
+    PublicKey,
+    key_id,
+    load_pem_public_key,
+    read_embedded,
+)
 
 
 class CTKeyringError(Exception):
@@ -89,7 +93,7 @@ class CTKeyring:
         Adds a key to the current keyring, as identified by its
         resource name under `sigstore._store`.
         """
-        key_pem = resources.read_binary("sigstore._store", name)
+        key_pem = read_embedded(name)
         self.add(key_pem)
 
     def add(self, key_pem: bytes) -> None:

--- a/sigstore/_internal/rekor/client.py
+++ b/sigstore/_internal/rekor/client.py
@@ -22,7 +22,6 @@ import base64
 import logging
 from abc import ABC
 from dataclasses import dataclass
-from importlib import resources
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
@@ -34,22 +33,18 @@ from pydantic import BaseModel, Field, StrictInt, StrictStr, validator
 from securesystemslib.formats import encode_canonical
 
 from sigstore._internal.ctfe import CTKeyring
-from sigstore._utils import base64_encode_pem_cert
+from sigstore._utils import base64_encode_pem_cert, read_embedded
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_REKOR_URL = "https://rekor.sigstore.dev"
 STAGING_REKOR_URL = "https://rekor.sigstage.dev"
 
-_DEFAULT_REKOR_ROOT_PUBKEY = resources.read_binary("sigstore._store", "rekor.pub")
-_STAGING_REKOR_ROOT_PUBKEY = resources.read_binary(
-    "sigstore._store", "rekor.staging.pub"
-)
+_DEFAULT_REKOR_ROOT_PUBKEY = read_embedded("rekor.pub")
+_STAGING_REKOR_ROOT_PUBKEY = read_embedded("rekor.staging.pub")
 
-_DEFAULT_REKOR_CTFE_PUBKEY = resources.read_binary("sigstore._store", "ctfe.pub")
-_STAGING_REKOR_CTFE_PUBKEY = resources.read_binary(
-    "sigstore._store", "ctfe.staging.pub"
-)
+_DEFAULT_REKOR_CTFE_PUBKEY = read_embedded("ctfe.pub")
+_STAGING_REKOR_CTFE_PUBKEY = read_embedded("ctfe.staging.pub")
 
 
 class RekorBundle(BaseModel):

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -20,11 +20,17 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import sys
 from typing import IO, Union
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.x509 import Certificate
+
+if sys.version_info < (3, 11):
+    import importlib_resources as resources
+else:
+    from importlib import resources
 
 PublicKey = Union[rsa.RSAPublicKey, ec.EllipticCurvePublicKey]
 
@@ -137,3 +143,11 @@ def sha256_streaming(io: IO[bytes]) -> bytes:
         nbytes = io.readinto(view)  # type: ignore
 
     return sha256.digest()
+
+
+def read_embedded(name: str) -> bytes:
+    """
+    Read a resource embedded in this distribution of sigstore-python,
+    returning its contents as bytes.
+    """
+    return resources.files("sigstore._store").joinpath(name).read_bytes()

--- a/sigstore/_verify/verifier.py
+++ b/sigstore/_verify/verifier.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import datetime
 import logging
-from importlib import resources
 from typing import List, cast
 
 from cryptography.exceptions import InvalidSignature
@@ -46,6 +45,7 @@ from sigstore._internal.merkle import (
 )
 from sigstore._internal.rekor import RekorClient
 from sigstore._internal.set import InvalidSetError, verify_set
+from sigstore._utils import read_embedded
 from sigstore._verify.models import InvalidRekorEntry as InvalidRekorEntryError
 from sigstore._verify.models import RekorEntryMissing as RekorEntryMissingError
 from sigstore._verify.models import (
@@ -58,18 +58,11 @@ from sigstore._verify.policy import VerificationPolicy
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_FULCIO_ROOT_CERT = read_embedded("fulcio.crt.pem")
+_DEFAULT_FULCIO_INTERMEDIATE_CERT = read_embedded("fulcio_intermediate.crt.pem")
 
-_DEFAULT_FULCIO_ROOT_CERT = resources.read_binary("sigstore._store", "fulcio.crt.pem")
-_DEFAULT_FULCIO_INTERMEDIATE_CERT = resources.read_binary(
-    "sigstore._store", "fulcio_intermediate.crt.pem"
-)
-
-_STAGING_FULCIO_ROOT_CERT = resources.read_binary(
-    "sigstore._store", "fulcio.crt.staging.pem"
-)
-_STAGING_FULCIO_INTERMEDIATE_CERT = resources.read_binary(
-    "sigstore._store", "fulcio_intermediate.crt.staging.pem"
-)
+_STAGING_FULCIO_ROOT_CERT = read_embedded("fulcio.crt.staging.pem")
+_STAGING_FULCIO_INTERMEDIATE_CERT = read_embedded("fulcio_intermediate.crt.staging.pem")
 
 
 class RekorEntryMissing(VerificationFailure):

--- a/test/unit/test_store.py
+++ b/test/unit/test_store.py
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib import resources
+from sigstore._utils import read_embedded
 
 
 def test_store_reads_fulcio_root_cert():
-    fulcio_crt = resources.read_text("sigstore._store", "fulcio.crt.pem").strip()
-    lines = fulcio_crt.split("\n")
+    fulcio_crt = read_embedded("fulcio.crt.pem").strip()
+    lines = fulcio_crt.split(b"\n")
 
-    assert lines[0].startswith("-----BEGIN CERTIFICATE-----")
-    assert lines[-1].startswith("-----END CERTIFICATE-----")
+    assert lines[0].startswith(b"-----BEGIN CERTIFICATE-----")
+    assert lines[-1].startswith(b"-----END CERTIFICATE-----")
 
 
 def test_store_reads_ctfe_pub():
-    ctfe_pub = resources.read_text("sigstore._store", "ctfe.pub").strip()
-    lines = ctfe_pub.split("\n")
+    ctfe_pub = read_embedded("ctfe.pub").strip()
+    lines = ctfe_pub.split(b"\n")
 
-    assert lines[0].startswith("-----BEGIN PUBLIC KEY-----")
-    assert lines[-1].startswith("-----END PUBLIC KEY-----")
+    assert lines[0].startswith(b"-----BEGIN PUBLIC KEY-----")
+    assert lines[-1].startswith(b"-----END PUBLIC KEY-----")


### PR DESCRIPTION
This uses `importlib_resources` as a "polyfill" on older Python
versions, allowing us to use the new `resources.files()` APIs.

(These uses will be mostly removed with the TUF work in #25 anyways, but we might as well quash them for the time being.)

Closes #212.

Signed-off-by: William Woodruff <william@trailofbits.com>