### PR TITLE
treewide: remove flake8, add ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@d171c3b028d844f2bf14e9fdec0c58114451e4bf
       - uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9
         with:
-          python-version: "3.x"
+          python-version: "3.7"
       - name: deps
         run: make dev SIGSTORE_EXTRA=lint
       - name: lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ make lint
 
 * [`black`](https://github.com/psf/black): Code formatting
 * [`isort`](https://github.com/PyCQA/isort): Import sorting, ordering
-* [`flake8`](https://flake8.pycqa.org/en/latest/): PEP-8 linting, style enforcement
+* [`ruff`](https://github.com/charliermarsh/ruff): PEP-8 linting, style enforcement
 * [`mypy`](https://mypy.readthedocs.io/en/stable/): Static type checking
 * [`bandit`](https://github.com/PyCQA/bandit): Security issue scanning
 * [`interrogate`](https://interrogate.readthedocs.io/en/latest/): Documentation coverage

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ lint: env/pyvenv.cfg
 	. env/bin/activate && \
 		black --check $(ALL_PY_SRCS) && \
 		isort --check $(ALL_PY_SRCS) && \
-		flake8 $(ALL_PY_SRCS) && \
+		ruff $(ALL_PY_SRCS) && \
 		mypy $(PY_MODULE) && \
 		bandit -c pyproject.toml -r $(PY_MODULE)
 

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ lint: env/pyvenv.cfg
 .PHONY: reformat
 reformat: env/pyvenv.cfg
 	. env/bin/activate && \
+		ruff --fix $(ALL_PY_SRCS) && \
 		black $(ALL_PY_SRCS) && \
 		isort $(ALL_PY_SRCS)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,4 @@ exclude_dirs = ["./test"]
 
 [tool.ruff]
 line-length = 100
+select = ["E", "F", "W", "UP"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,11 @@ test = [
 ]
 lint = [
   "bandit",
-  "flake8",
   "black",
   "isort",
   "interrogate",
   "mypy",
+  "ruff",
   "types-requests",
   # Needed for protocol typing in 3.7; remove when our minimum Python is 3.8.
   "typing-extensions; python_version < '3.8'",
@@ -111,3 +111,6 @@ plugins = ["pydantic.mypy"]
 
 [tool.bandit]
 exclude_dirs = ["./test"]
+
+[tool.ruff]
+line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,4 +114,7 @@ exclude_dirs = ["./test"]
 
 [tool.ruff]
 line-length = 100
-select = ["E", "F", "W", "UP"]
+# TODO: Enable "UP" here once Pydantic allows us to:
+# See: https://github.com/pydantic/pydantic/issues/4146
+select = ["E", "F", "W"]
+target-version = "py37"

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -158,4 +158,4 @@ def read_embedded(name: str) -> bytes:
     Read a resource embedded in this distribution of sigstore-python,
     returning its contents as bytes.
     """
-    return resources.files("sigstore._store").joinpath(name).read_bytes()
+    return resources.files("sigstore._store").joinpath(name).read_bytes()  # type: ignore


### PR DESCRIPTION
ruff is feature-complete (for our purposes) with flake8 and is an order of magnitude faster.

H/T @alex

Signed-off-by: William Woodruff <william@trailofbits.com>
