### PR TITLE
_cli: refactor logging behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Added
+
+* `sigstore` now supports the `-v`/`--verbose` flag as an alternative to
+  `SIGSTORE_LOGLEVEL` for debug logging
+  ([#372](https://github.com/sigstore/sigstore-python/pull/372))
+
+### Changed
+
+* The default behavior of `SIGSTORE_LOGLEVEL` has changed; the logger
+  configured is now the `sigstore.*` hierarchy logger, rather than the "root"
+  logger ([#372](https://github.com/sigstore/sigstore-python/pull/372))
+
 ## [0.9.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Top-level:
 
 <!-- @begin-sigstore-help@ -->
 ```
-usage: sigstore [-h] [-V] {sign,verify,get-identity-token} ...
+usage: sigstore [-h] [-V] [-v] {sign,verify,get-identity-token} ...
 
 a tool for signing and verifying Python package distributions
 
@@ -81,6 +81,8 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -V, --version         show program's version number and exit
+  -v, --verbose         run with additional debug logging; supply multiple
+                        times to increase verbosity (default: 0)
 ```
 <!-- @end-sigstore-help@ -->
 

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -54,12 +54,11 @@ from sigstore._verify import (
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
-level = os.environ.get("SIGSTORE_LOGLEVEL", "INFO").upper()
 
 # NOTE: We configure the top package logger, rather than the root logger,
 # to avoid overly verbose logging in third-party code by default.
 package_logger = logging.getLogger("sigstore")
-package_logger.setLevel(level)
+package_logger.setLevel(os.environ.get("SIGSTORE_LOGLEVEL", "INFO").upper())
 
 
 def _boolify_env(envvar: str) -> bool:

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -52,13 +52,14 @@ from sigstore._verify import (
     policy,
 )
 
+logging.basicConfig()
 logger = logging.getLogger(__name__)
 level = os.environ.get("SIGSTORE_LOGLEVEL", "INFO").upper()
-logging.basicConfig(level=level)
 
-# workaround to make tuf less verbose https://github.com/theupdateframework/python-tuf/pull/2243
-if level == "INFO":
-    logging.getLogger("tuf").setLevel("WARNING")
+# NOTE: We configure the top package logger, rather than the root logger,
+# to avoid overly verbose logging in third-party code by default.
+package_logger = logging.getLogger("sigstore")
+package_logger.setLevel(level)
 
 
 def _boolify_env(envvar: str) -> bool:
@@ -145,6 +146,13 @@ def _parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "-V", "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="run with additional debug logging; supply multiple times to increase verbosity",
     )
     subcommands = parser.add_subparsers(required=True, dest="subcommand")
 
@@ -323,6 +331,12 @@ def _parser() -> argparse.ArgumentParser:
 def main() -> None:
     parser = _parser()
     args = parser.parse_args()
+
+    # Configure logging upfront, so that we don't miss anything.
+    if args.verbose >= 1:
+        package_logger.setLevel("DEBUG")
+    if args.verbose >= 2:
+        logging.getLogger().setLevel("DEBUG")
 
     logger.debug(f"parsed arguments {args}")
 


### PR DESCRIPTION
This refactors `sigstore`'s logging behavior to the following:

1. `SIGSTORE_LOGLEVEL` now only affects the `sigstore.*` logger hierarchy
2. `-v` is added as an additive option;
    1. `-v` corresponds to `SIGSTORE_LOGLEVEL=debug`
    2. `-vv` corresponds to `<root logger>.setLevel("DEBUG")`

cc @jku 

Closes #371.

Signed-off-by: William Woodruff <william@trailofbits.com>
