### PR TITLE
_cli: add `sigstore verify identity`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+
+      # NOTE: We intentionally lint against our minimum supported Python.
       - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912
         with:
           python-version: "3.7"
+
       - name: deps
         run: make dev SIGSTORE_EXTRA=lint
+
       - name: lint
         run: make lint
 
@@ -69,10 +73,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+
+      # NOTE: We intentional check `--help` rendering against our minimum Python,
+      # since it changes slightly between Python versions.
       - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912
         with:
-          python-version: "3.x"
+          python-version: "3.7"
+
       - name: deps
         run: make dev
+
       - name: check-readme
         run: make check-readme

--- a/Makefile
+++ b/Makefile
@@ -117,10 +117,10 @@ check-readme:
 	    $(MAKE) -s run ARGS="sign --help" \
 	  )
 
-	# sigstore verify --help
+	# sigstore verify identity --help
 	@diff \
 	  <( \
-	    awk '/@begin-sigstore-verify-help@/{f=1;next} /@end-sigstore-verify-help@/{f=0} f' \
+	    awk '/@begin-sigstore-verify-identity-help@/{f=1;next} /@end-sigstore-verify-identity-help@/{f=0} f' \
 	      < README.md | sed '1d;$$d' \
 	  ) \
 	  <( \

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ check-readme:
 	      < README.md | sed '1d;$$d' \
 	  ) \
 	  <( \
-	    $(MAKE) -s run ARGS="verify --help" \
+	    $(MAKE) -s run ARGS="verify identity --help" \
 	  )
 
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ Sigstore instance options:
 
 ### Verifying
 
+#### Identities
+
+This is the most common verification done with `sigstore`, and therefore
+the one you probably want: you can use it to verify that a signature was
+produced by a particular identity (like `hamilcar@example.com`), as attested
+to by a particular OIDC provider (like `https://github.com/login/oauth`).
+
 <!-- @begin-sigstore-verify-identity-help@ -->
 ```
 usage: sigstore verify identity [-h] [--certificate FILE] [--signature FILE]
@@ -206,6 +213,10 @@ Sigstore instance options:
                         (conflicts with --staging) (default: None)
 ```
 <!-- @end-sigstore-verify-identity-help@ -->
+
+For backwards compatibility, `sigstore verify [args ...]` is equivalent to
+`sigstore verify identity [args ...]`, but the latter form is **strongly**
+preferred.
 
 ## Example uses
 
@@ -272,50 +283,30 @@ same directory as the file being verified:
 
 ```console
 # looks for foo.txt.sig and foo.txt.crt
-$ python -m sigstore verify foo.txt
+$ python -m sigstore verify identity foo.txt \
+    --cert-identity 'hamilcar@example.com' \
+    --cert-oidc-issuer 'https://github.com/login/oauth'
 ```
 
 Multiple files can be verified at once:
 
 ```console
 # looks for {foo,bar}.txt.{sig,crt}
-$ python -m sigstore verify foo.txt bar.txt
+$ python -m sigstore verify identity foo.txt bar.txt \
+    --cert-identity 'hamilcar@example.com' \
+    --cert-oidc-issuer 'https://github.com/login/oauth'
 ```
 
 If your signature and certificate are at different paths, you can specify them
 explicitly (but only for one file at a time):
 
 ```console
-$ python -m sigstore verify \
+$ python -m sigstore verify identity foo.txt \
     --certificate some/other/path/foo.crt \
     --signature some/other/path/foo.sig \
-    foo.txt
+    --cert-identity 'hamilcar@example.com' \
+    --cert-oidc-issuer 'https://github.com/login/oauth'
 ```
-
-### Extended verification against OpenID Connect claims
-
-By default, `sigstore verify` only checks the validity of the certificate,
-the correctness of the signature, and the consistency of both with the
-certificate transparency log.
-
-To assert further details about the signature (such as *who* or *what* signed for the artifact),
-you can test against the OpenID Connect claims embedded within it.
-
-For example, to accept the signature and certificate only if they correspond to a particular
-email identity:
-
-```console
-$ python -m sigstore verify --cert-email developer@example.com foo.txt
-```
-
-Or to accept only if the OpenID Connect issuer is the expected one:
-
-```console
-$ python -m sigstore verify --cert-oidc-issuer https://github.com/login/oauth foo.txt
-```
-
-These options can be combined, and further extended validation options (e.g., for
-signing results from GitHub Actions) are under development.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ usage: sigstore verify identity [-h] [--certificate FILE] [--signature FILE]
 positional arguments:
   FILE                  The file to verify
 
-optionals:
+options:
   -h, --help            show this help message and exit
 
 Verification inputs:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ a tool for signing and verifying Python package distributions
 positional arguments:
   {sign,verify,get-identity-token}
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
   -V, --version         show program's version number and exit
   -v, --verbose         run with additional debug logging; supply multiple
@@ -103,7 +103,7 @@ usage: sigstore sign [-h] [--identity-token TOKEN] [--oidc-client-id ID]
 positional arguments:
   FILE                  The file to sign
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
 
 OpenID Connect options:
@@ -167,7 +167,7 @@ usage: sigstore verify identity [-h] [--certificate FILE] [--signature FILE]
 positional arguments:
   FILE                  The file to verify
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
 
 Verification inputs:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ options:
 ```
 <!-- @end-sigstore-help@ -->
 
-Signing:
+
+### Signing
 
 <!-- @begin-sigstore-sign-help@ -->
 ```
@@ -150,22 +151,23 @@ Sigstore instance options:
 ```
 <!-- @end-sigstore-sign-help@ -->
 
-Verifying:
+### Verifying
 
-<!-- @begin-sigstore-verify-help@ -->
+<!-- @begin-sigstore-verify-identity-help@ -->
 ```
-usage: sigstore verify [-h] [--certificate FILE] [--signature FILE]
-                       [--rekor-bundle FILE] [--certificate-chain FILE]
-                       [--cert-email EMAIL] --cert-identity IDENTITY
-                       --cert-oidc-issuer URL [--require-rekor-offline]
-                       [--staging] [--rekor-url URL]
-                       [--rekor-root-pubkey FILE]
-                       FILE [FILE ...]
+usage: sigstore verify identity [-h] [--certificate FILE] [--signature FILE]
+                                [--rekor-bundle FILE]
+                                [--certificate-chain FILE]
+                                [--cert-email EMAIL] --cert-identity IDENTITY
+                                --cert-oidc-issuer URL
+                                [--require-rekor-offline] [--staging]
+                                [--rekor-url URL] [--rekor-root-pubkey FILE]
+                                FILE [FILE ...]
 
 positional arguments:
   FILE                  The file to verify
 
-options:
+optionals:
   -h, --help            show this help message and exit
 
 Verification inputs:
@@ -203,7 +205,7 @@ Sigstore instance options:
                         A PEM-encoded root public key for Rekor itself
                         (conflicts with --staging) (default: None)
 ```
-<!-- @end-sigstore-verify-help@ -->
+<!-- @end-sigstore-verify-identity-help@ -->
 
 ## Example uses
 

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -267,12 +267,15 @@ def _parser() -> argparse.ArgumentParser:
 
     # `sigstore verify`
     verify = subcommands.add_parser(
-        "verify", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        "verify",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     verify_subcommand = verify.add_subparsers(dest="verify_subcommand")
 
     # `sigstore verify identity`
-    verify_identity = verify_subcommand.add_parser("identity")
+    verify_identity = verify_subcommand.add_parser(
+        "identity", help="verify against a known identity and identity provider"
+    )
     input_options = verify_identity.add_argument_group("Verification inputs")
     input_options.add_argument(
         "--certificate",

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -100,12 +100,17 @@ def _set_default_verify_subparser(parser: argparse.ArgumentParser, name: str) ->
                 if sp_name in sys.argv[1:]:
                     subparser_found = True
         if not subparser_found:
-            # If `sigstore verify identity` wasn't passed explicitly, we need
-            # to insert the `identity` subcommand into the correct position
-            # within `sys.argv`. To do that, we get the index of the `verify`
-            # subcommand, and insert it directly after it.
-            verify_idx = sys.argv.index("verify")
-            sys.argv.insert(verify_idx + 1, name)
+            try:
+                # If `sigstore verify identity` wasn't passed explicitly, we need
+                # to insert the `identity` subcommand into the correct position
+                # within `sys.argv`. To do that, we get the index of the `verify`
+                # subcommand, and insert it directly after it.
+                verify_idx = sys.argv.index("verify")
+                sys.argv.insert(verify_idx + 1, name)
+            except ValueError:
+                # This happens when we invoke `sigstore sign`, since there's no
+                # `verify` subcommand to insert under. We do nothing in this case.
+                pass
 
 
 def _add_shared_instance_options(group: argparse._ArgumentGroup) -> None:

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -84,7 +84,7 @@ def _boolify_env(envvar: str) -> bool:
 
 def _set_default_subparser(parser: argparse.ArgumentParser, name: str) -> None:
     """
-    A monkeypatch for configuring a default subparser.
+    An argparse patch for configuring a default subparser.
 
     Adapted from <https://stackoverflow.com/a/26379693>
     """
@@ -100,10 +100,11 @@ def _set_default_subparser(parser: argparse.ArgumentParser, name: str) -> None:
                 if sp_name in sys.argv[1:]:
                     subparser_found = True
         if not subparser_found:
-            # insert default in last position before global positional
-            # arguments, this implies no global options are specified after
-            # first positional argument
-            sys.argv.insert(len(sys.argv), name)
+            # NOTE: We expect the default subparser to take exactly one
+            # positional argument (e.g. `sigstore verify identity foo.txt`), so
+            # we insert the subparser's name right before that positional should
+            # appear.
+            sys.argv.insert(len(sys.argv) - 1, name)
 
 
 def _add_shared_instance_options(group: argparse._ArgumentGroup) -> None:

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -82,9 +82,9 @@ def _boolify_env(envvar: str) -> bool:
         raise ValueError(f"can't coerce '{val}' to a boolean")
 
 
-def _set_default_subparser(parser: argparse.ArgumentParser, name: str) -> None:
+def _set_default_verify_subparser(parser: argparse.ArgumentParser, name: str) -> None:
     """
-    An argparse patch for configuring a default subparser.
+    An argparse patch for configuring a default subparser for `sigstore verify`.
 
     Adapted from <https://stackoverflow.com/a/26379693>
     """
@@ -100,11 +100,12 @@ def _set_default_subparser(parser: argparse.ArgumentParser, name: str) -> None:
                 if sp_name in sys.argv[1:]:
                     subparser_found = True
         if not subparser_found:
-            # NOTE: We expect the default subparser to take exactly one
-            # positional argument (e.g. `sigstore verify identity foo.txt`), so
-            # we insert the subparser's name right before that positional should
-            # appear.
-            sys.argv.insert(len(sys.argv) - 1, name)
+            # If `sigstore verify identity` wasn't passed explicitly, we need
+            # to insert the `identity` subcommand into the correct position
+            # within `sys.argv`. To do that, we get the index of the `verify`
+            # subcommand, and insert it directly after it.
+            verify_idx = sys.argv.index("verify")
+            sys.argv.insert(verify_idx + 1, name)
 
 
 def _add_shared_instance_options(group: argparse._ArgumentGroup) -> None:
@@ -357,7 +358,7 @@ def _parser() -> argparse.ArgumentParser:
 
     # `sigstore verify` defaults to `sigstore verify identity`, for backwards
     # compatibility.
-    _set_default_subparser(verify, "identity")
+    _set_default_verify_subparser(verify, "identity")
 
     # `sigstore get-identity-token`
     get_identity_token = subcommands.add_parser("get-identity-token")

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -274,7 +274,9 @@ def _parser() -> argparse.ArgumentParser:
 
     # `sigstore verify identity`
     verify_identity = verify_subcommand.add_parser(
-        "identity", help="verify against a known identity and identity provider"
+        "identity",
+        help="verify against a known identity and identity provider",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     input_options = verify_identity.add_argument_group("Verification inputs")
     input_options.add_argument(

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -107,6 +107,11 @@ def _set_default_verify_subparser(parser: argparse.ArgumentParser, name: str) ->
                 # subcommand, and insert it directly after it.
                 verify_idx = sys.argv.index("verify")
                 sys.argv.insert(verify_idx + 1, name)
+                logger.warning(
+                    "`sigstore verify` without a subcommand will be treated as "
+                    "`sigstore verify identity`, but this behavior will be deprecated "
+                    "in a future release"
+                )
             except ValueError:
                 # This happens when we invoke `sigstore sign`, since there's no
                 # `verify` subcommand to insert under. We do nothing in this case.


### PR DESCRIPTION
This adds `sigstore verify identity`, which is aliased (through some `argparse` hackery) back to `sigstore verify`.

This allows us to remain compatible with the existing CLI, while also giving us the flexibility we need to extend verification (e.g. `sigstore verify github`).

See #322.

Signed-off-by: William Woodruff <william@trailofbits.com>
