### PR TITLE
FIX(jl): Makefile `TESTS` environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ALL_PY_SRCS := $(shell find $(PY_MODULE) -name '*.py') \
 BUMP_ARGS :=
 
 # Optionally overridden by the user in the `test` target.
-TESTS :=
+TESTS ?=
 
 # Optionally overridden by the user/CI, to limit the installation to a specific
 # subset of development dependencies.


### PR DESCRIPTION
with the Makefile declaration

```
TESTS := 
```

```sh
$ make test TESTS="foo"
# only runs test matching the pattern "foo"
```

works as intended, but the definition overrides and pre-declaration of the `TESTS` variable,

```sh
$ TESTS="foo" make test
# runs all tests, ignoring the pattern "foo"
```

fix by only declaring if undefined using `?=`,

```
TESTS ?=
```