### PR TITLE
pyproject: bump pyOpenSSL >= 23.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Constrained our dependency on `pyOpenSSL` to `>= 23.0.0` to prevent
+  a runtime error caused by incompatible earlier versions
+  ([#448](https://github.com/sigstore/sigstore-python/pull/448))
+
 ## [1.0.0]
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "importlib_resources ~= 5.7; python_version < '3.11'",
   "pydantic",
   "pyjwt >= 2.1",
-  "pyOpenSSL >= 22.0.0",
+  "pyOpenSSL >= 23.0.0",
   "requests",
   "securesystemslib",
   "tuf >= 2.0.0",


### PR DESCRIPTION
Fixes #447.

