### PR TITLE
Only run conformance if safe-to-test label is applied

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -13,6 +13,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   conformance:
+    if: ${{ github.event.label.name == 'safe-to-test' }}
     permissions:
       # Needed to access the workflow's OIDC identity.
       id-token: write


### PR DESCRIPTION
Signed-off-by: Appu <appu@google.com>

same with java https://github.com/sigstore/sigstore-java/pull/309