### PR TITLE
Initial Sigstore bundle support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build
 *.sh
 *.pub
 *.rekor
+*.sigstore
 
 # Don't ignore these files when we intend to include them
 !sigstore/_store/*.crt

--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ usage: sigstore sign [-h] [--identity-token TOKEN] [--oidc-client-id ID]
                      [--oidc-client-secret SECRET]
                      [--oidc-disable-ambient-providers] [--oidc-issuer URL]
                      [--no-default-files] [--signature FILE]
-                     [--certificate FILE] [--rekor-bundle FILE] [--overwrite]
-                     [--staging] [--rekor-url URL] [--rekor-root-pubkey FILE]
-                     [--fulcio-url URL] [--ctfe FILE]
+                     [--certificate FILE] [--rekor-bundle FILE] [--bundle]
+                     [--overwrite] [--staging] [--rekor-url URL]
+                     [--rekor-root-pubkey FILE] [--fulcio-url URL]
+                     [--ctfe FILE]
                      FILE [FILE ...]
 
 positional arguments:
@@ -169,6 +170,9 @@ Output options:
                         Write a single offline Rekor bundle to the given file;
                         does not work with multiple input files (default:
                         None)
+  --bundle              Emit a single {input}.sigstore file for each input;
+                        this option is experimental and may change between
+                        releases until stabilized (default: False)
   --overwrite           Overwrite preexisting signature and certificate
                         outputs, if present (default: False)
 
@@ -205,7 +209,8 @@ to by a particular OIDC provider (like `https://github.com/login/oauth`).
 <!-- @begin-sigstore-verify-identity-help@ -->
 ```
 usage: sigstore verify identity [-h] [--certificate FILE] [--signature FILE]
-                                [--rekor-bundle FILE] --cert-identity IDENTITY
+                                [--rekor-bundle FILE] [--bundle]
+                                --cert-identity IDENTITY
                                 [--require-rekor-offline] --cert-oidc-issuer
                                 URL [--staging] [--rekor-url URL]
                                 [--rekor-root-pubkey FILE]
@@ -223,6 +228,9 @@ Verification inputs:
                         multiple inputs (default: None)
   --rekor-bundle FILE   The offline Rekor bundle to verify with; not used with
                         multiple inputs (default: None)
+  --bundle              Verify from {input}.sigstore for each input; this
+                        option is experimental and may change between releases
+                        until stabilized (default: False)
   FILE                  The file to verify
 
 Verification options:
@@ -271,11 +279,11 @@ claims more precisely than `sigstore verify identity` allows:
 <!-- @begin-sigstore-verify-github-help@ -->
 ```
 usage: sigstore verify github [-h] [--certificate FILE] [--signature FILE]
-                              [--rekor-bundle FILE] --cert-identity IDENTITY
-                              [--require-rekor-offline] [--trigger EVENT]
-                              [--sha SHA] [--name NAME] [--repository REPO]
-                              [--ref REF] [--staging] [--rekor-url URL]
-                              [--rekor-root-pubkey FILE]
+                              [--rekor-bundle FILE] [--bundle] --cert-identity
+                              IDENTITY [--require-rekor-offline]
+                              [--trigger EVENT] [--sha SHA] [--name NAME]
+                              [--repository REPO] [--ref REF] [--staging]
+                              [--rekor-url URL] [--rekor-root-pubkey FILE]
                               [--certificate-chain FILE]
                               FILE [FILE ...]
 
@@ -290,6 +298,9 @@ Verification inputs:
                         multiple inputs (default: None)
   --rekor-bundle FILE   The offline Rekor bundle to verify with; not used with
                         multiple inputs (default: None)
+  --bundle              Verify from {input}.sigstore for each input; this
+                        option is experimental and may change between releases
+                        until stabilized (default: False)
   FILE                  The file to verify
 
 Verification options:

--- a/README.md
+++ b/README.md
@@ -285,10 +285,11 @@ claims more precisely than `sigstore verify identity` allows:
 ```
 usage: sigstore verify github [-h] [--certificate FILE] [--signature FILE]
                               [--rekor-bundle FILE] [--bundle FILE]
-                              --cert-identity IDENTITY [--require-rekor-offline]
-                              [--trigger EVENT] [--sha SHA] [--name NAME]
-                              [--repository REPO] [--ref REF] [--staging]
-                              [--rekor-url URL] [--rekor-root-pubkey FILE]
+                              --cert-identity IDENTITY
+                              [--require-rekor-offline] [--trigger EVENT]
+                              [--sha SHA] [--name NAME] [--repository REPO]
+                              [--ref REF] [--staging] [--rekor-url URL]
+                              [--rekor-root-pubkey FILE]
                               [--certificate-chain FILE]
                               FILE [FILE ...]
 

--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ usage: sigstore sign [-h] [--identity-token TOKEN] [--oidc-client-id ID]
                      [--oidc-client-secret SECRET]
                      [--oidc-disable-ambient-providers] [--oidc-issuer URL]
                      [--no-default-files] [--signature FILE]
-                     [--certificate FILE] [--rekor-bundle FILE] [--bundle]
-                     [--overwrite] [--staging] [--rekor-url URL]
-                     [--rekor-root-pubkey FILE] [--fulcio-url URL]
-                     [--ctfe FILE]
+                     [--certificate FILE] [--rekor-bundle FILE]
+                     [--bundle FILE] [--no-bundle] [--overwrite] [--staging]
+                     [--rekor-url URL] [--rekor-root-pubkey FILE]
+                     [--fulcio-url URL] [--ctfe FILE]
                      FILE [FILE ...]
 
 positional arguments:
@@ -170,9 +170,13 @@ Output options:
                         Write a single offline Rekor bundle to the given file;
                         does not work with multiple input files (default:
                         None)
-  --bundle              Emit a single {input}.sigstore file for each input;
-                        this option is experimental and may change between
-                        releases until stabilized (default: False)
+  --bundle FILE         Write a single Sigstore bundle to the given file; does
+                        not work with multiple input files; this option is
+                        experimental and may change between releases until
+                        stabilized (default: None)
+  --no-bundle           Don't emit {input}.sigstore files for each input; this
+                        option is experimental and may change between releases
+                        until stabilized (default: False)
   --overwrite           Overwrite preexisting signature and certificate
                         outputs, if present (default: False)
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ to by a particular OIDC provider (like `https://github.com/login/oauth`).
 <!-- @begin-sigstore-verify-identity-help@ -->
 ```
 usage: sigstore verify identity [-h] [--certificate FILE] [--signature FILE]
-                                [--rekor-bundle FILE] [--bundle]
+                                [--rekor-bundle FILE] [--bundle FILE]
                                 --cert-identity IDENTITY
                                 [--require-rekor-offline] --cert-oidc-issuer
                                 URL [--staging] [--rekor-url URL]
@@ -232,9 +232,10 @@ Verification inputs:
                         multiple inputs (default: None)
   --rekor-bundle FILE   The offline Rekor bundle to verify with; not used with
                         multiple inputs (default: None)
-  --bundle              Verify from {input}.sigstore for each input; this
-                        option is experimental and may change between releases
-                        until stabilized (default: False)
+  --bundle FILE         The Sigstore bundle to verify with; not used with
+                        multiple inputs; this option is experimental and may
+                        change between releases until stabilized (default:
+                        None)
   FILE                  The file to verify
 
 Verification options:
@@ -283,8 +284,8 @@ claims more precisely than `sigstore verify identity` allows:
 <!-- @begin-sigstore-verify-github-help@ -->
 ```
 usage: sigstore verify github [-h] [--certificate FILE] [--signature FILE]
-                              [--rekor-bundle FILE] [--bundle] --cert-identity
-                              IDENTITY [--require-rekor-offline]
+                              [--rekor-bundle FILE] [--bundle FILE]
+                              --cert-identity IDENTITY [--require-rekor-offline]
                               [--trigger EVENT] [--sha SHA] [--name NAME]
                               [--repository REPO] [--ref REF] [--staging]
                               [--rekor-url URL] [--rekor-root-pubkey FILE]
@@ -302,9 +303,10 @@ Verification inputs:
                         multiple inputs (default: None)
   --rekor-bundle FILE   The offline Rekor bundle to verify with; not used with
                         multiple inputs (default: None)
-  --bundle              Verify from {input}.sigstore for each input; this
-                        option is experimental and may change between releases
-                        until stabilized (default: False)
+  --bundle FILE         The Sigstore bundle to verify with; not used with
+                        multiple inputs; this option is experimental and may
+                        change between releases until stabilized (default:
+                        None)
   FILE                  The file to verify
 
 Verification options:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "pyOpenSSL >= 23.0.0",
   "requests",
   "securesystemslib",
+  "sigstore-protobuf-specs ~= 0.1.0",
   "tuf >= 2.0.0",
 ]
 requires-python = ">=3.7"

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -652,8 +652,8 @@ def _sign(args: argparse.Namespace) -> None:
             if not args.no_bundle:
                 bundle = file.parent / f"{file.name}.sigstore"
 
-        extants = []
         if not args.overwrite:
+            extants = []
             if sig and sig.exists():
                 extants.append(str(sig))
             if cert and cert.exists():

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -587,14 +587,14 @@ def _sign(args: argparse.Namespace) -> None:
 
     if args.bundle:
         logger.warning(
-            "--bundle support is experimental; this flag may change behaviour "
-            "between releases until stabilized or may be removed."
+            "--bundle support is experimental; the behaviour of this flag may change "
+            "between releases until stabilized."
         )
 
     if args.no_bundle:
         logger.warning(
-            "--no-bundle support is experimental; this flag may change behaviour "
-            "between releases until stabilized or may be removed."
+            "--no-bundle support is experimental; the behaviour of this flag may change "
+            "between releases until stabilized."
         )
 
     # `--no-default-files` has no effect on `--{signature,certificate,rekor-bundle,bundle}`,

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -725,7 +725,7 @@ def _sign(args: argparse.Namespace) -> None:
         print(f"Transparency log entry created at index: {result.log_entry.log_index}")
 
         sig_output: TextIO
-        if "sig" in outputs:
+        if outputs["sig"] is not None:
             sig_output = outputs["sig"].open("w")
         else:
             sig_output = sys.stdout

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -725,7 +725,7 @@ def _sign(args: argparse.Namespace) -> None:
         print(f"Transparency log entry created at index: {result.log_entry.log_index}")
 
         sig_output: TextIO
-        if outputs["sig"] in outputs:
+        if "sig" in outputs:
             sig_output = outputs["sig"].open("w")
         else:
             sig_output = sys.stdout

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -219,7 +219,8 @@ class SigningResult(BaseModel):
         from this `SigningResult`.
         """
 
-        # TODO: Should we include our Fulcio intermediate in the chain?
+        # TODO: Include the current Fulcio intermediate and root in the
+        # chain as well.
         cert = x509.load_pem_x509_certificate(self.cert_pem.encode())
         cert_der = cert.public_bytes(encoding=serialization.Encoding.DER)
         chain = X509CertificateChain(certificates=[X509Certificate(raw_bytes=cert_der)])

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -238,9 +238,6 @@ class SigningResult(BaseModel):
         tlog_entry = TransparencyLogEntry(
             log_index=self.log_entry.log_index,
             log_id=LogId(key_id=bytes.fromhex(self.log_entry.log_id)),
-            # TODO: Maybe leave this field out? It appears to be optional
-            # and it's just hardcoded for us, since it's the only kind of Rekor
-            # entry we support.
             kind_version=KindVersion(kind="hashedrekord", version="0.0.1"),
             integrated_time=self.log_entry.integrated_time,
             inclusion_promise=InclusionPromise(


### PR DESCRIPTION
This adds initial support for Sigstore bundles during signing, in the form of the `--bundle` flag. When passed, `sigstore sign` will generate a single `{input}.sigstore` instead of separate `.crt`, `.sig`, and `.rekor` files.

I haven't included `sigstore verify` support in the initial changeset, in an effort to keep the diff small. But adding it shouldn't be difficult, and will provide a good dogfood/smoke test for round-tripping through the bundle format.

See #251.

Signed-off-by: William Woodruff <william@trailofbits.com>
