### PR TITLE
pyproject: semver match for tuf dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "requests",
   "securesystemslib",
   "sigstore-protobuf-specs ~= 0.1.0",
-  "tuf >= 2.0.0",
+  "tuf ~= 2.0.0",
 ]
 requires-python = ">=3.7"
 


### PR DESCRIPTION
Changes our `tuf` constraint from `>= 2.0.0` to `~= 2.0.0`, since `tuf` is semantically versioned and we don't expect to be compatible with arbitrary major version changes.

cc @jku 

Signed-off-by: William Woodruff <william@trailofbits.com>
