### PR TITLE
pyproject.toml: Don't check for line-length with `ruff` since we're reformatting with `black`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,6 @@ lint: $(VENV)/pyvenv.cfg
 .PHONY: reformat
 reformat: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
-		black $(ALL_PY_SRCS) && \
 		ruff --fix $(ALL_PY_SRCS) && \
 		black $(ALL_PY_SRCS) && \
 		isort $(ALL_PY_SRCS)

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ lint: $(VENV)/pyvenv.cfg
 .PHONY: reformat
 reformat: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
+		black $(ALL_PY_SRCS) && \
 		ruff --fix $(ALL_PY_SRCS) && \
 		black $(ALL_PY_SRCS) && \
 		isort $(ALL_PY_SRCS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,8 @@ plugins = ["pydantic.mypy"]
 exclude_dirs = ["./test"]
 
 [tool.ruff]
-line-length = 100
+# Never enforce `E501` (line length violations).
+ignore = ["E501"]
 # TODO: Enable "UP" here once Pydantic allows us to:
 # See: https://github.com/pydantic/pydantic/issues/4146
 select = ["E", "F", "W"]


### PR DESCRIPTION
See: https://github.com/pypa/pip-audit/pull/505