### PR TITLE
Ignore targets missing the `custom` field

### DIFF
--- a/sigstore/_internal/tuf.py
+++ b/sigstore/_internal/tuf.py
@@ -146,8 +146,12 @@ class TrustUpdater:
 
         targets = self._updater._trusted_set.targets.signed.targets
         for target_info in targets.values():
-            custom = target_info.unrecognized_fields["custom"]["sigstore"]
-            if custom["status"] in statuses and custom["usage"] == usage:
+            custom = target_info.unrecognized_fields.get("custom", {}).get("sigstore")
+            if (
+                custom
+                and custom.get("status") in statuses
+                and custom.get("usage") == usage
+            ):
                 path = self._updater.find_cached_target(target_info)
                 if path is None:
                     path = self._updater.download_target(target_info)


### PR DESCRIPTION
The latest signing merge in https://github.com/sigstore/root-signing/commit/d35895290d0c54b6f01cb4c02da721a57b9d9c8c includes a target (`trusted_root.json`) that is missing the `custom` field.

This was previously failing with:

```
____________________________ test_signer_production ____________________________

    @pytest.mark.online
    def test_signer_production():
>       signer = Signer.production()


test/unit/test_sign.py:31: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
sigstore/sign.py:104: in production
    rekor = RekorClient.production(updater)
        cls        = <class 'sigstore.sign.Signer'>
        updater    = <sigstore._internal.tuf.TrustUpdater object at 0x7fd25d604a90>
sigstore/_internal/rekor/client.py:280: in production
    rekor_keys = updater.get_rekor_keys()
        cls        = <class 'sigstore._internal.rekor.client.RekorClient'>
        updater    = <sigstore._internal.tuf.TrustUpdater object at 0x7fd25d604a90>
sigstore/_internal/tuf.py:174: in get_rekor_keys
    keys = self._get("Rekor", ["Active"])
        self       = <sigstore._internal.tuf.TrustUpdater object at 0x7fd25d604a90>
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sigstore._internal.tuf.TrustUpdater object at 0x7fd25d604a90>
usage = 'Rekor', statuses = ['Active']

    def _get(self, usage: str, statuses: list[str]) -> list[bytes]:
        """Return all targets with given usage and any of the statuses"""
        if not self._updater:
            self._updater = self._setup()
    
        data = []
    
        targets = self._updater._trusted_set.targets.signed.targets
        for target_info in targets.values():
>           custom = target_info.unrecognized_fields["custom"]["sigstore"]
E           KeyError: 'custom'

custom     = {'status': 'Active', 'uri': 'https://rekor.sigstore.dev', 'usage': 'Rekor'}
data       = [b'-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tab'
 b'dTV5BcGiBIx0a9fAFwr\nkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M'
 b'9+RYtw==\n-----END PUBLIC KEY-----\n']
f          = <_io.BufferedReader name='/home/runner/.cache/sigstore-python/tuf/https%3A%2F%2Fsigstore-tuf-root.storage.googleapis.com%2F/rekor.pub'>
path       = '/home/runner/.cache/sigstore-python/tuf/https%3A%2F%2Fsigstore-tuf-root.storage.googleapis.com%2F/rekor.pub'
self       = <sigstore._internal.tuf.TrustUpdater object at 0x7fd25d604a90>
statuses   = ['Active']
target_info = <tuf.api.metadata.TargetFile object at 0x7fd25d63b650>
targets    = {'artifact.pub': <tuf.api.metadata.TargetFile object at 0x7fd25d605dd0>,
 'ctfe.pub': <tuf.api.metadata.TargetFile object at 0x7fd25d605f90>,
 'ctfe_2022.pub': <tuf.api.metadata.TargetFile object at 0x7fd25d63b510>,
 'fulcio.crt.pem': <tuf.api.metadata.TargetFile object at 0x7fd25d63aa50>,
 'fulcio_intermediate_v1.crt.pem': <tuf.api.metadata.TargetFile object at 0x7fd25d63a790>,
 'fulcio_v1.crt.pem': <tuf.api.metadata.TargetFile object at 0x7fd25d63aa90>,
 'rekor.pub': <tuf.api.metadata.TargetFile object at 0x7fd25d63b4d0>,
 'trusted_root.json': <tuf.api.metadata.TargetFile object at 0x7fd25d63b650>}
usage      = 'Rekor'

sigstore/_internal/tuf.py:[149](https://github.com/sigstore/sigstore-python/actions/runs/4336463020/jobs/7571768751#step:6:150): KeyError
```