### PR TITLE
verify: Stop using `pydantic` aliases in constructor to avoid `mypy` plugin bug

### DIFF
--- a/sigstore/verify/models.py
+++ b/sigstore/verify/models.py
@@ -241,9 +241,9 @@ class VerificationMaterials:
         tlog_entry = tlog_entries[0]
 
         inclusion_proof = LogInclusionProof(
-            logIndex=tlog_entry.inclusion_proof.log_index,
-            rootHash=tlog_entry.inclusion_proof.root_hash.hex(),
-            treeSize=tlog_entry.inclusion_proof.tree_size,
+            log_index=tlog_entry.inclusion_proof.log_index,
+            root_hash=tlog_entry.inclusion_proof.root_hash.hex(),
+            tree_size=tlog_entry.inclusion_proof.tree_size,
             hashes=[h.hex() for h in tlog_entry.inclusion_proof.hashes],
         )
         entry = LogEntry(


### PR DESCRIPTION
I'll just give a dot point summary of what happened here:

- `mypy` released 1.1.1 which broke our lint.
- We committed 8a42a26943e144e053d21553dea4483dbc58f48a to fix this. We shouldn't have needed to do this because using the field name instead of the alias is not a bug, but we did this just to get things passing again.
- `pydantic` released 1.10.6 to fix their `mypy` plugin.
- Now the plugin is complaining that we're using the aliases and not the field name despite using `allow_population_by_field_name`.
- I'm making this PR to move back to using the field name.

There's still an underlying bug in `pydantic`'s `mypy` plugin as it should be fine to use the alias. This is described here: https://github.com/pydantic/pydantic/issues/5070