### PR TITLE
oidc: configure timeouts for `requests`

### DIFF
--- a/sigstore/_errors.py
+++ b/sigstore/_errors.py
@@ -52,10 +52,24 @@ class NetworkError(Error):
 
     def diagnostics(self) -> str:
         """Returns diagnostics for the error."""
-        return """A network issue occurred.
+
+        cause_ctx = (
+            f"""
+        Additional context:
+
+        {self.__cause__}
+        """
+            if self.__cause__
+            else ""
+        )
+
+        return (
+            """A network issue occurred.
 
         Check your internet connection and try again.
         """
+            + cause_ctx
+        )
 
 
 class TUFError(Error):

--- a/sigstore/oidc.py
+++ b/sigstore/oidc.py
@@ -69,7 +69,7 @@ class Issuer:
             f"{base_url}/", ".well-known/openid-configuration"
         )
 
-        resp: requests.Response = requests.get(oidc_config_url)
+        resp: requests.Response = requests.get(oidc_config_url, timeout=30)
         try:
             resp.raise_for_status()
         except requests.HTTPError as http_error:
@@ -156,6 +156,7 @@ class Issuer:
             self.oidc_config.token_endpoint,
             data=data,
             auth=auth,
+            timeout=30,
         )
 
         try:

--- a/sigstore/oidc.py
+++ b/sigstore/oidc.py
@@ -28,6 +28,8 @@ import requests
 from id import IdentityError
 from pydantic import BaseModel, StrictStr
 
+from sigstore._errors import NetworkError
+
 DEFAULT_OAUTH_ISSUER_URL = "https://oauth2.sigstore.dev/auth"
 STAGING_OAUTH_ISSUER_URL = "https://oauth2.sigstage.dev/auth"
 
@@ -69,7 +71,11 @@ class Issuer:
             f"{base_url}/", ".well-known/openid-configuration"
         )
 
-        resp: requests.Response = requests.get(oidc_config_url, timeout=30)
+        try:
+            resp: requests.Response = requests.get(oidc_config_url, timeout=30)
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            raise NetworkError from exc
+
         try:
             resp.raise_for_status()
         except requests.HTTPError as http_error:
@@ -152,12 +158,15 @@ class Issuer:
             client_secret,
         )
         logging.debug(f"PAYLOAD: data={data}")
-        resp: requests.Response = requests.post(
-            self.oidc_config.token_endpoint,
-            data=data,
-            auth=auth,
-            timeout=30,
-        )
+        try:
+            resp: requests.Response = requests.post(
+                self.oidc_config.token_endpoint,
+                data=data,
+                auth=auth,
+                timeout=30,
+            )
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            raise NetworkError from exc
 
         try:
             resp.raise_for_status()


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Bandit recently released v1.7.5, which includes [a new lint for `requests` usage without a timeout](https://bandit.readthedocs.io/en/1.7.5/plugins/b113_request_without_timeout.html). This changeset fixes our usage of `requests` in `oidc`.