### PR TITLE
sct, test_sign: adjust exception messages

### DIFF
--- a/sigstore/_internal/sct.py
+++ b/sigstore/_internal/sct.py
@@ -213,5 +213,9 @@ def verify_sct(
         ct_keyring.verify(
             key_id=KeyID(sct.log_id), signature=sct.signature, data=digitally_signed
         )
-    except (KeyringLookupError, KeyringError) as exc:
+    except KeyringLookupError as exc:
+        raise InvalidSCTError(
+            "Invalid key ID in SCT: not found in current keyring"
+        ) from exc
+    except KeyringError as exc:
         raise InvalidSCTError from exc

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -75,7 +75,7 @@ def test_sct_verify_keyring_lookup_error(signer, monkeypatch):
 
     with pytest.raises(
         InvalidSCTError,
-        match="Invalid key ID in SCT: not found in current keyring.",
+        match="Invalid key ID in SCT: not found in current keyring",
     ):
         signer.sign(payload, token)
 


### PR DESCRIPTION
Should fix the [failing online tests](https://github.com/sigstore/sigstore-python/actions/runs/4406822705/jobs/7719602599#step:6:881).