### PR TITLE
Pin requirements on releases with a workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,6 @@ version: 2
 
 updates:
   - package-ecosystem: pip
-    directory: "/install"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 99
-    allow:
-    - dependency-type: direct
-    - dependency-type: indirect
-    rebase-strategy: "disabled"
-
-  - package-ecosystem: pip
     directory: /
     schedule:
       interval: daily

--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -21,8 +21,6 @@ permissions:
 jobs:
   update-pinned-requirements:
     runs-on: ubuntu-latest
-    env:
-      TMPDIR: ${{ runner.temp }}
 
     permissions:
       pull-requests: write # Pull Request creation.
@@ -47,14 +45,14 @@ jobs:
           # Do some JSON traversal: get the URL of the asset that has a `.whl` file extension.
           wheel_url=$(curl $release_url | jq -r '.assets[] | select(.name | test(".whl$")) | .browser_download_url')
 
-          curl -L "$TMPDIR/sigstore.whl" -L $wheel_url
+          curl -L "$RUNNER_TEMP/sigstore.whl" -L $wheel_url
 
       - name: Update requirements
         run: |
           cd install
 
           # Pin on the downloaded wheel, as PyPI might not have updated yet.
-          echo "$TMPDIR/sigstore.whl" >requirements.in
+          echo "$RUNNER_TEMP/sigstore.whl" >requirements.in
           pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
 
           # Strip the "v" prefix from the version tag name.

--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -44,36 +44,36 @@ jobs:
 
       - name: Compute version from tag
         run: |
-          echo "SIGSTORE_RELEASE_VERSION=$(echo "${{ env.SIGSTORE_RELEASE_TAG }}" | sed 's/^v//')" >>$GITHUB_ENV
+          echo "SIGSTORE_RELEASE_VERSION=$(echo "${SIGSTORE_RELEASE_TAG}" | sed 's/^v//')" >> "${GITHUB_ENV}"
 
       - name: Download wheel from GitHub release
         run: |
-          wheel_name="sigstore-${{ env.SIGSTORE_RELEASE_VERSION }}-py3-none-any.whl"
-          wheel_url="https://github.com/sigstore/sigstore-python/releases/download/${{ env.SIGSTORE_RELEASE_TAG }}/$wheel_name"
-          wheel_path="$RUNNER_TEMP/$wheel_name"
+          wheel_name="sigstore-${SIGSTORE_RELEASE_VERSION}-py3-none-any.whl"
+          wheel_url="https://github.com/sigstore/sigstore-python/releases/download/${env.SIGSTORE_RELEASE_TAG}/${wheel_name}"
+          wheel_path="${RUNNER_TEMP}/${wheel_name}"
 
-          curl -o "$wheel_path" -L $wheel_url
-          echo "SIGSTORE_WHEEL_PATH=$wheel_path" >>$GITHUB_ENV
+          curl -L "${wheel_url}" -o "${wheel_path}" 
+          echo "SIGSTORE_WHEEL_PATH=${wheel_path}" >> "${GITHUB_ENV}"
       - name: Update requirements
         run: |
           cd install
 
           # Pin on the downloaded wheel, as PyPI might not have updated yet.
-          echo "${{ env.SIGSTORE_WHEEL_PATH }}" >requirements.in
+          echo "${SIGSTORE_WHEEL_PATH}" > requirements.in
           pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
 
           # Replace requirements.in. People should be able to run the `pip-compile` invocation provided in `requirements.txt`.
-          echo "sigstore==${{ env.SIGSTORE_RELEASE_VERSION }}" >requirements.in
+          echo "sigstore==${SIGSTORE_RELEASE_VERSION}" > requirements.in
 
       - name: Open pull request
         id: pr
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
         with:
           title: |
-            Update pinned requirements for ${{ env.SIGSTORE_RELEASE_TAG }}
+            Update pinned requirements for ${SIGSTORE_RELEASE_TAG}
           body: |
-            Pins dependencies for <https://github.com/sigstore/sigstore-python/releases/tag/${{ env.SIGSTORE_RELEASE_TAG }}>.
+            Pins dependencies for <https://github.com/sigstore/sigstore-python/releases/tag/${SIGSTORE_RELEASE_TAG}>.
           commit-message: "[BOT] install: update pinned requirements"
-          branch: "pin-requirements/sigstore/${{ env.SIGSTORE_RELEASE_TAG }}"
+          branch: "pin-requirements/sigstore/${SIGSTORE_RELEASE_TAG}"
           signoff: true
           delete-branch: true

--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -70,10 +70,10 @@ jobs:
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
         with:
           title: |
-            Update pinned requirements for ${{ inputs.tag }}
+            Update pinned requirements for ${{ env.SIGSTORE_RELEASE_TAG }}
           body: |
-            Pins dependencies for <https://github.com/sigstore/sigstore-python/releases/tag/${{ inputs.tag }}>.
+            Pins dependencies for <https://github.com/sigstore/sigstore-python/releases/tag/${{ env.SIGSTORE_RELEASE_TAG }}>.
           commit-message: "[BOT] install: update pinned requirements"
-          branch: "pin-requirements/sigstore/${{ inputs.tag }}"
+          branch: "pin-requirements/sigstore/${{ env.SIGSTORE_RELEASE_TAG }}"
           signoff: true
           delete-branch: true

--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -1,0 +1,48 @@
+name: Pin Requirements
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  update-pinned-requirements:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: main
+
+      - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
+        with:
+          python-version: "3.x"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - run: pip install pip-tools
+
+      - name: Determine latest sigstore-python PyPI release
+        run: |
+          version=$(curl -H "Accept: application/vnd.pypi.simple.v1+json" https://pypi.org/simple/sigstore/ | jq -r '.versions[-1]')
+          echo "sigstore_python_version=$version" >>$GITHUB_ENV
+      - name: Update requirements
+        run: |
+          cd install
+          echo "sigstore==${{ env.sigstore_python_version }}" >requirements.in
+          pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
+      - name: Open pull request
+        id: pr
+        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
+        with:
+          title: Update pinned requirements for v${{ env.sigstore_python_version }}
+          body: Pins dependencies for [v${{ env.sigstore_python_version }}](https://github.com/sigstore/sigstore-python/releases/tag/v${{ env.sigstore_python_version }}).
+          commit-message: "install: update pinned requirements"
+          branch: "pin-requirements/sigstore/${{ env.sigstore_python_version }}"
+          signoff: true
+          delete-branch: true
+      - if: ${{ steps.pr.outputs.pull-request-number }}
+        run: |
+          echo "Created PR \#${{ steps.pr.outputs.pull-request-number }}"

--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -18,7 +18,8 @@ jobs:
 
       - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
         with:
-          python-version: "3.x"
+          # NOTE: Update whenever sigstore-python's minimum Python is bumped.
+          python-version: "3.7"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
@@ -33,13 +34,16 @@ jobs:
           cd install
           echo "sigstore==${{ env.sigstore_python_version }}" >requirements.in
           pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
+
       - name: Open pull request
         id: pr
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
         with:
-          title: Update pinned requirements for v${{ env.sigstore_python_version }}
-          body: Pins dependencies for [v${{ env.sigstore_python_version }}](https://github.com/sigstore/sigstore-python/releases/tag/v${{ env.sigstore_python_version }}).
-          commit-message: "install: update pinned requirements"
+          title: |
+            Update pinned requirements for v${{ env.sigstore_python_version }}
+          body: |
+            Pins dependencies for <url>.
+          commit-message: "[BOT] install: update pinned requirements"
           branch: "pin-requirements/sigstore/${{ env.sigstore_python_version }}"
           signoff: true
           delete-branch: true

--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -22,6 +22,9 @@ jobs:
   update-pinned-requirements:
     runs-on: ubuntu-latest
 
+    env:
+      SIGSTORE_RELEASE_TAG: ${{ inputs.tag }}
+
     permissions:
       pull-requests: write # Pull Request creation.
       contents: write # Branch creation for PR.
@@ -39,28 +42,28 @@ jobs:
 
       - run: pip install pip-tools
 
+      - name: Compute version from tag
+        run: |
+          echo "SIGSTORE_RELEASE_VERSION=$(echo "${{ env.SIGSTORE_RELEASE_TAG }}" | sed 's/^v//')" >>$GITHUB_ENV
+
       - name: Download wheel from GitHub release
         run: |
-          release_url="https://api.github.com/repos/sigstore/sigstore-python/releases/tags/${{ inputs.tag }}"
-          # Do some JSON traversal: get the name and URL of the asset that has a `.whl` file extension.
-          wheel_info=$(curl $release_url | jq '.assets[] | select(.name | test(".whl$")) | {name, browser_download_url}')
-          wheel_path="$RUNNER_TEMP/$(echo $wheel_info | jq -r '.name')"
-          wheel_url=$(echo $wheel_info | jq -r '.browser_download_url')
+          wheel_name="sigstore-${{ env.SIGSTORE_RELEASE_VERSION }}-py3-none-any.whl"
+          wheel_url="https://github.com/sigstore/sigstore-python/releases/download/${{ env.SIGSTORE_RELEASE_TAG }}/$wheel_name"
+          wheel_path="$RUNNER_TEMP/$wheel_name"
 
           curl -o "$wheel_path" -L $wheel_url
-          echo "wheel_path=$wheel_path" >>$GITHUB_ENV
+          echo "SIGSTORE_WHEEL_PATH=$wheel_path" >>$GITHUB_ENV
       - name: Update requirements
         run: |
           cd install
 
           # Pin on the downloaded wheel, as PyPI might not have updated yet.
-          echo "${{ env.wheel_path }}" >requirements.in
+          echo "${{ env.SIGSTORE_WHEEL_PATH }}" >requirements.in
           pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
 
-          # Strip the "v" prefix from the version tag name.
-          version_on_pypi=$(echo "${{ inputs.tag }}" | sed 's/^v//')
           # Replace requirements.in. People should be able to run the `pip-compile` invocation provided in `requirements.txt`.
-          echo "sigstore==$version_on_pypi" >requirements.in
+          echo "sigstore==${{ env.SIGSTORE_RELEASE_VERSION }}" >requirements.in
 
       - name: Open pull request
         id: pr

--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -2,15 +2,32 @@ name: Pin Requirements
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to pin dependencies against.
+        required: true
+        type: string
+
   workflow_call:
+    inputs:
+      tag:
+        description: Tag to pin dependencies against.
+        required: true
+        type: string
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   update-pinned-requirements:
     runs-on: ubuntu-latest
+    env:
+      TMPDIR: ${{ runner.temp }}
+
+    permissions:
+      pull-requests: write # Pull Request creation
+      contents: write # Branch creation for PR
+
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
@@ -18,23 +35,25 @@ jobs:
 
       - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
         with:
-          # NOTE: Update whenever sigstore-python's minimum Python is bumped.
-          python-version: "3.7"
+          python-version-file: install/.python-version
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
       - run: pip install pip-tools
 
-      - name: Determine latest sigstore-python PyPI release
+      - name: Download wheel from GitHub release
         run: |
-          version=$(curl -H "Accept: application/vnd.pypi.simple.v1+json" https://pypi.org/simple/sigstore/ | jq -r '.versions[-1]')
-          echo "sigstore_python_version=$version" >>$GITHUB_ENV
+          release_url="https://api.github.com/repos/sigstore/sigstore-python/releases/tags/${{ inputs.tag }}"
+          wheel_url=$(curl $release_url | jq -r '.assets[] | select(.name | test(".whl$")) | .browser_download_url')
+
+          curl -L "$TMPDIR/sigstore.whl" -L $wheel_url
+
       - name: Update requirements
         run: |
           cd install
-          echo "sigstore==${{ env.sigstore_python_version }}" >requirements.in
+          echo "$TMPDIR/sigstore.whl" >requirements.in
           pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
-
+          echo "sigstore==${{ env.sigstore_python_version }}" >requirements.in
       - name: Open pull request
         id: pr
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
@@ -42,11 +61,8 @@ jobs:
           title: |
             Update pinned requirements for v${{ env.sigstore_python_version }}
           body: |
-            Pins dependencies for <url>.
+            Pins dependencies for <https://github.com/sigstore/sigstore-python/releases/tag/v${{ env.sigstore_python_version }}>.
           commit-message: "[BOT] install: update pinned requirements"
           branch: "pin-requirements/sigstore/${{ env.sigstore_python_version }}"
           signoff: true
           delete-branch: true
-      - if: ${{ steps.pr.outputs.pull-request-number }}
-        run: |
-          echo "Created PR \#${{ steps.pr.outputs.pull-request-number }}"

--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -42,17 +42,19 @@ jobs:
       - name: Download wheel from GitHub release
         run: |
           release_url="https://api.github.com/repos/sigstore/sigstore-python/releases/tags/${{ inputs.tag }}"
-          # Do some JSON traversal: get the URL of the asset that has a `.whl` file extension.
-          wheel_url=$(curl $release_url | jq -r '.assets[] | select(.name | test(".whl$")) | .browser_download_url')
+          # Do some JSON traversal: get the name and URL of the asset that has a `.whl` file extension.
+          wheel_info=$(curl $release_url | jq '.assets[] | select(.name | test(".whl$")) | {name, browser_download_url}')
+          wheel_path="$RUNNER_TEMP/$(echo $wheel_info | jq -r '.name')"
+          wheel_url=$(echo $wheel_info | jq -r '.browser_download_url')
 
-          curl -L "$RUNNER_TEMP/sigstore.whl" -L $wheel_url
-
+          curl -o "$wheel_path" -L $wheel_url
+          echo "wheel_path=$wheel_path" >>$GITHUB_ENV
       - name: Update requirements
         run: |
           cd install
 
           # Pin on the downloaded wheel, as PyPI might not have updated yet.
-          echo "$RUNNER_TEMP/sigstore.whl" >requirements.in
+          echo "${{ env.wheel_path }}" >requirements.in
           pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
 
           # Strip the "v" prefix from the version tag name.
@@ -65,9 +67,9 @@ jobs:
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
         with:
           title: |
-            Update pinned requirements for ${{ env.sigstore_python_version }}
+            Update pinned requirements for ${{ inputs.tag }}
           body: |
-            Pins dependencies for <https://github.com/sigstore/sigstore-python/releases/tag/{{ inputs.tag }}>.
+            Pins dependencies for <https://github.com/sigstore/sigstore-python/releases/tag/${{ inputs.tag }}>.
           commit-message: "[BOT] install: update pinned requirements"
           branch: "pin-requirements/sigstore/${{ inputs.tag }}"
           signoff: true

--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -25,8 +25,8 @@ jobs:
       TMPDIR: ${{ runner.temp }}
 
     permissions:
-      pull-requests: write # Pull Request creation
-      contents: write # Branch creation for PR
+      pull-requests: write # Pull Request creation.
+      contents: write # Branch creation for PR.
 
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -44,6 +44,7 @@ jobs:
       - name: Download wheel from GitHub release
         run: |
           release_url="https://api.github.com/repos/sigstore/sigstore-python/releases/tags/${{ inputs.tag }}"
+          # Do some JSON traversal: get the URL of the asset that has a `.whl` file extension.
           wheel_url=$(curl $release_url | jq -r '.assets[] | select(.name | test(".whl$")) | .browser_download_url')
 
           curl -L "$TMPDIR/sigstore.whl" -L $wheel_url
@@ -51,18 +52,25 @@ jobs:
       - name: Update requirements
         run: |
           cd install
+
+          # Pin on the downloaded wheel, as PyPI might not have updated yet.
           echo "$TMPDIR/sigstore.whl" >requirements.in
           pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
-          echo "sigstore==${{ env.sigstore_python_version }}" >requirements.in
+
+          # Strip the "v" prefix from the version tag name.
+          version_on_pypi=$(echo "${{ inputs.tag }}" | sed 's/^v//')
+          # Replace requirements.in. People should be able to run the `pip-compile` invocation provided in `requirements.txt`.
+          echo "sigstore==$version_on_pypi" >requirements.in
+
       - name: Open pull request
         id: pr
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v4.2.3
         with:
           title: |
-            Update pinned requirements for v${{ env.sigstore_python_version }}
+            Update pinned requirements for ${{ env.sigstore_python_version }}
           body: |
-            Pins dependencies for <https://github.com/sigstore/sigstore-python/releases/tag/v${{ env.sigstore_python_version }}>.
+            Pins dependencies for <https://github.com/sigstore/sigstore-python/releases/tag/{{ inputs.tag }}>.
           commit-message: "[BOT] install: update pinned requirements"
-          branch: "pin-requirements/sigstore/${{ env.sigstore_python_version }}"
+          branch: "pin-requirements/sigstore/${{ inputs.tag }}"
           signoff: true
           delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,10 +148,16 @@ jobs:
             built-packages/*
             smoketest-artifacts/*
 
+  # Trigger workflow to generate pinned requirements.txt.
   pin-requirements:
     permissions:
+      # Needed to create branch and pull request.
       pull-requests: write
       contents: write
-    needs: [release-pypi]
+    # Workflow depends on uploaded release assets.
+    needs: [release-github]
+    # Only trigger workflow on full releases.
     if: ${{ !github.event.release.prerelease }}
     uses: ./.github/workflows/pin-requirements.yml
+    with:
+      tag: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,3 +147,11 @@ jobs:
           files: |
             built-packages/*
             smoketest-artifacts/*
+
+  pin-requirements:
+    permissions:
+      pull-requests: write
+      contents: write
+    needs: [release-pypi]
+    if: ${{ !github.event.release.prerelease }}
+    uses: ./.github/workflows/pin-requirements.yml


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This changeset resolves #115. We introduce a new workflow, `pin-requirements.yml`, which:

- Fetches the latest version of `sigstore-python` from PyPI;
- Updates the version in `requirements.in` from this version;
- Updates the pins in `requirements.txt` with `pip-compile`;
- Opens a pull request to `main` with these updates.

Here's a preview of what this pull request would look like: https://github.com/tnytown/sigstore-python/pull/2

Potential issues:
- Do we want to use a specific Python version for `pip-compile`? Would this affect the resultant `requirements.txt`?
- This workflow should run automatically on new PyPI releases, but I didn't test this end-to-end as I would have had to spin up some infrastructure. The trigger from `release.yml` may or may not work, we'll have to see when a new release rolls around.