### PR TITLE
sct, keyring: specialize errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All versions prior to 0.9.0 are untracked.
   ([#535](https://github.com/sigstore/sigstore-python/pull/535))
 * Revamped error diagnostics reporting. All errors with diagnostics now implement
   `sigstore.errors.Error`.
+* Improved diagnostics around Signed Certificate Timestamp verification failures.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All versions prior to 0.9.0 are untracked.
 * Revamped error diagnostics reporting. All errors with diagnostics now implement
   `sigstore.errors.Error`.
 * Improved diagnostics around Signed Certificate Timestamp verification failures.
+  ([#555](https://github.com/sigstore/sigstore-python/pull/555))
 
 ### Fixed
 

--- a/sigstore/_internal/keyring.py
+++ b/sigstore/_internal/keyring.py
@@ -44,6 +44,12 @@ class KeyringLookupError(KeyringError):
     pass
 
 
+class KeyringSignatureError(KeyringError):
+    """
+    Raised when `Keyring.verify()` is passed an invalid signature.
+    """
+
+
 class Keyring:
     """
     Represents a set of CT signing keys, each of which is a potentially
@@ -101,4 +107,4 @@ class Keyring:
                 # NOTE(ww): Unreachable without API misuse.
                 raise KeyringError(f"unsupported key type: {key}")
         except InvalidSignature as exc:
-            raise KeyringError("invalid signature") from exc
+            raise KeyringSignatureError("invalid signature") from exc

--- a/sigstore/_internal/sct.py
+++ b/sigstore/_internal/sct.py
@@ -32,7 +32,11 @@ from cryptography.x509.certificate_transparency import (
 from cryptography.x509.oid import ExtendedKeyUsageOID
 
 from sigstore._internal.ctfe import CTKeyring
-from sigstore._internal.keyring import KeyringError, KeyringLookupError
+from sigstore._internal.keyring import (
+    KeyringError,
+    KeyringLookupError,
+    KeyringSignatureError,
+)
 from sigstore._utils import DERCert, KeyID, key_id
 from sigstore.errors import Error
 
@@ -142,13 +146,34 @@ class InvalidSCTError(Error):
 
     def diagnostics(self) -> str:
         """Returns diagnostics for the error."""
-        # We specialize this error case, since it usually indicates one of
-        # two conditions: either the current sigstore client is out-of-date,
-        # or that the SCT is well-formed but invalid for the current configuration
-        # (indicating that the user has asked for the wrong instance).
-        if isinstance(self.__cause__, KeyringLookupError):
-            return dedent(
-                f"""
+
+        ctx = f"\nContext: {self.__context__}" if self.__context__ else ""
+        return dedent(
+            f"""
+            SCT verification failed.
+
+            Additional context:
+
+            Message: {str(self)}
+            """
+            + ctx
+        )
+
+
+class InvalidSCTKeyError(Error):
+    """
+    Raised during SCT verification if the SCT can't be validated against the given keyring.
+
+    We specialize this error case, since it usually indicates one of
+    two conditions: either the current sigstore client is out-of-date,
+    or that the SCT is well-formed but invalid for the current configuration
+    (indicating that the user has asked for the wrong instance).
+    """
+
+    def diagnostics(self) -> str:
+        """Returns diagnostics for the error."""
+        return dedent(
+            f"""
                 Invalid key ID in SCT: not found in current keyring.
 
                 This may be a result of an outdated `sigstore` installation.
@@ -161,9 +186,27 @@ class InvalidSCTError(Error):
 
                 {self.__cause__}
                 """
-            )
+        )
 
-        return str(self)
+
+class SCTSignatureError(InvalidSCTError):
+    """
+    Raised during SCT verification if the signature of the SCT is invalid.
+    """
+
+    def diagnostics(self) -> str:
+        """Returns diagnostics for the error."""
+        return dedent(
+            f"""
+            Invalid signature on SCT.
+
+            If validating a certificate, the certificate associated with this SCT should not be trusted.
+
+            Additional context:
+
+            {self.__cause__}
+            """
+        )
 
 
 def verify_sct(
@@ -214,8 +257,8 @@ def verify_sct(
             key_id=KeyID(sct.log_id), signature=sct.signature, data=digitally_signed
         )
     except KeyringLookupError as exc:
-        raise InvalidSCTError(
-            "Invalid key ID in SCT: not found in current keyring"
-        ) from exc
+        raise InvalidSCTKeyError from exc
+    except KeyringSignatureError as exc:
+        raise SCTSignatureError from exc
     except KeyringError as exc:
         raise InvalidSCTError from exc

--- a/sigstore/_internal/sct.py
+++ b/sigstore/_internal/sct.py
@@ -160,7 +160,7 @@ class InvalidSCTError(Error):
         )
 
 
-class InvalidSCTKeyError(Error):
+class InvalidSCTKeyError(InvalidSCTError):
     """
     Raised during SCT verification if the SCT can't be validated against the given keyring.
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

See #547, #543.

In the SCT module, we now distinguish between the following kinds of verification errors:
- Invalid (potentially malicious) input signatures,
- Invalid key ID,
- Malformed input or API misuse.