### PR TITLE
`pin-requirements` workflow self-test

### DIFF
--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -65,7 +65,7 @@ jobs:
           git commit --all -s -m "[BOT] install: update pinned requirements"
           git push -f origin "main:${SIGSTORE_NEW_BRANCH}"
 
-  test-install:
+  test-requirements:
     needs: update-pinned-requirements
     uses: ./.github/workflows/requirements.yml
     with:

--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -15,6 +15,10 @@ on:
         required: true
         type: string
 
+env:
+  SIGSTORE_RELEASE_TAG: ${{ inputs.tag }}
+  SIGSTORE_NEW_BRANCH: "pin-requirements/sigstore/${{ inputs.tag }}"
+
 permissions:
   contents: read
 
@@ -22,17 +26,20 @@ jobs:
   update-pinned-requirements:
     runs-on: ubuntu-latest
 
-    env:
-      SIGSTORE_RELEASE_TAG: ${{ inputs.tag }}
-
     permissions:
-      pull-requests: write # Pull Request creation.
       contents: write # Branch creation for PR.
 
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           ref: main
+
+      - name: Configure git
+        run: |
+          # Set up committer info.
+          # https://github.com/orgs/community/discussions/26560
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
 
       - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
         with:
@@ -53,15 +60,44 @@ jobs:
           echo "sigstore==${SIGSTORE_RELEASE_VERSION}" > requirements.in
           pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
 
+      - name: Commit changes and push to branch
+        run: |
+          git commit --all -s -m "[BOT] install: update pinned requirements"
+          git push -f origin "main:${SIGSTORE_NEW_BRANCH}"
+
+  test-install:
+    needs: update-pinned-requirements
+    uses: ./.github/workflows/requirements.yml
+    with:
+      # We can't use `env` variables in this context.
+      # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
+      ref: "pin-requirements/sigstore/${{ inputs.tag }}"
+
+  create-pr:
+    needs: test-install
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # Pull Request branch modification.
+      pull-requests: write # Pull Request creation.
+
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ env.SIGSTORE_NEW_BRANCH }}
+
+      - name: Reset remote PR branch
+        run: |
+          git fetch origin main
+          git push -f origin "origin/main:${SIGSTORE_NEW_BRANCH}"
+
       - name: Open pull request
-        id: pr
         uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
         with:
           title: |
             Update pinned requirements for ${{ env.SIGSTORE_RELEASE_TAG }}
           body: |
             Pins dependencies for <https://github.com/sigstore/sigstore-python/releases/tag/${{ env.SIGSTORE_RELEASE_TAG }}>.
-          commit-message: "[BOT] install: update pinned requirements"
-          branch: "pin-requirements/sigstore/${{ env.SIGSTORE_RELEASE_TAG }}"
-          signoff: true
+          base: main
+          branch: ${{ env.SIGSTORE_NEW_BRANCH }}
           delete-branch: true

--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_call:
+    inputs:
+      ref:
+        description: The branch, tag, or revision to test.
+        type: string
+        required: true
   pull_request:
   schedule:
     - cron: '0 12 * * *'
@@ -12,12 +18,22 @@ jobs:
   test_requirements:
     name: requirements.txt / ${{ matrix.python_version }}
     runs-on: ubuntu-latest
+
+    env:
+      SIGSTORE_REF: ${{ inputs.ref }}
     strategy:
       matrix:
         python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
+      - name: Populate reference from context
+        if: ${{ env.SIGSTORE_REF == '' }}
+        run: |
+          echo "SIGSTORE_REF=${{ github.ref }}" >> "${GITHUB_ENV}"
+
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        with:
+          ref: ${{ env.SIGSTORE_REF }}
 
       - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
         name: Install Python ${{ matrix.python_version }}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

We now invoke the `requirements` workflow from `pin-requirements` to test install-ability. If any install fails, the requirements pinning PR is not opened.

Fixes #563.