### PR TITLE
Adapt ambient OIDC tests to support interactive flow for local testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: test
         run: make test TEST_ARGS="-vv --showlocals"
 
+      - name: test (interactive)
+        run: make test-interactive TEST_ARGS="-vv --showlocals"
+
       - uses: ./.github/actions/upload-coverage
         # only aggregate test coverage over linux-based tests to avoid any OS-specific filesystem information stored in
         # coverage metadata.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         run: make test TEST_ARGS="-vv --showlocals"
 
       - name: test (interactive)
+        if: (github.event_name != 'pull_request') || !github.event.pull_request.head.repo.fork
         run: make test-interactive TEST_ARGS="-vv --showlocals"
 
       - uses: ./.github/actions/upload-coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All versions prior to 0.9.0 are untracked.
 
 ### Added
 
-* The whole test suite can now be run locally with `make test-oidc`.
+* The whole test suite can now be run locally with `make test-interactive`.
   ([#576](https://github.com/sigstore/sigstore-python/pull/576))
   Users will be prompted to authenticate with their identity provider twice to
   generate staging and production OIDC tokens, which are used to test the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All versions prior to 0.9.0 are untracked.
 
 ### Added
 
+* The whole test suite can now be run locally with `make test-oidc`.
+  ([#576](https://github.com/sigstore/sigstore-python/pull/576))
+  Users will be prompted to authenticate with their identity provider twice to
+  generate staging and production OIDC tokens, which are used to test the
+  `sigstore.sign` module. All signing tests need to be completed before token
+  expiry, which is currently 60 seconds after issuance.
 * Network-related errors from the `sigstore._internal.tuf` module now have better
   diagnostics.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,16 @@ You can run the tests locally with:
 make test
 ```
 
+or:
+
+```bash
+make test-interactive
+```
+
+to run tests that require OIDC credentials (will prompt for authentication to generate tokens).
+Note that `test-interactive` may fail if you have a slow network, as the tokens generated are only
+valid for 60 seconds after their issuance.
+
 You can also filter by a pattern (uses `pytest -k`):
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,14 @@ reformat: $(VENV)/pyvenv.cfg
 .PHONY: test
 test: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
-		pytest --cov=$(PY_MODULE) $(T) $(TEST_ARGS) && \
+		$(TEST_ENV) pytest --cov=$(PY_MODULE) $(T) $(TEST_ARGS) && \
 		python -m coverage report -m $(COV_ARGS)
+
+.PHONY: test-oidc
+test-oidc: TEST_ENV += \
+	SIGSTORE_IDENTITY_TOKEN_production=$$($(MAKE) -s run ARGS="get-identity-token") \
+	SIGSTORE_IDENTITY_TOKEN_staging=$$($(MAKE) -s run ARGS="--staging get-identity-token")
+test-oidc: test
 
 .PHONY: doc
 doc: $(VENV)/pyvenv.cfg

--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,11 @@ test: $(VENV)/pyvenv.cfg
 		$(TEST_ENV) pytest --cov=$(PY_MODULE) $(T) $(TEST_ARGS) && \
 		python -m coverage report -m $(COV_ARGS)
 
-.PHONY: test-oidc
-test-oidc: TEST_ENV += \
+.PHONY: test-interactive
+test-interactive: TEST_ENV += \
 	SIGSTORE_IDENTITY_TOKEN_production=$$($(MAKE) -s run ARGS="get-identity-token") \
 	SIGSTORE_IDENTITY_TOKEN_staging=$$($(MAKE) -s run ARGS="--staging get-identity-token")
-test-oidc: test
+test-interactive: test
 
 .PHONY: doc
 doc: $(VENV)/pyvenv.cfg

--- a/sigstore/oidc.py
+++ b/sigstore/oidc.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 import time
 import urllib.parse
 import webbrowser
@@ -125,11 +126,12 @@ class Issuer:
         with _OAuthFlow(client_id, client_secret, self) as server:
             # Launch web browser
             if not force_oob and webbrowser.open(server.base_uri):
-                print("Waiting for browser interaction...")
+                print("Waiting for browser interaction...", file=sys.stderr)
             else:
                 server.enable_oob()
                 print(
-                    f"Go to the following link in a browser:\n\n\t{server.auth_endpoint}"
+                    f"Go to the following link in a browser:\n\n\t{server.auth_endpoint}",
+                    file=sys.stderr,
                 )
 
             if not server.is_oob():

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -194,7 +194,10 @@ def tuf_dirs(monkeypatch, tmp_path):
     return (data_dir, cache_dir)
 
 
-@pytest.fixture(params=[("production", Signer.production), ("staging", Signer.staging)], ids=["production", "staging"])
+@pytest.fixture(
+    params=[("production", Signer.production), ("staging", Signer.staging)],
+    ids=["production", "staging"],
+)
 def id_config(request):
     env, signer = request.param
     # Detect env variable for local interactive tests.

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -31,6 +31,7 @@ from tuf.ngclient import FetcherInterface
 
 from sigstore._internal import tuf
 from sigstore._internal.oidc import DEFAULT_AUDIENCE
+from sigstore.sign import Signer
 from sigstore.verify import VerificationMaterials
 from sigstore.verify.policy import VerificationSuccess
 
@@ -41,7 +42,11 @@ _TUF_ASSETS = (_ASSETS / "staging-tuf").resolve()
 assert _TUF_ASSETS.is_dir()
 
 
-def _is_ambient_env():
+def _has_oidc_id():
+    # If there are tokens manually defined for us in the environment, use it.
+    if os.getenv("SIGSTORE_IDENTITY_TOKEN_production") is not None:
+        return True
+
     try:
         token = detect_credential(DEFAULT_AUDIENCE)
         if token is None:
@@ -76,7 +81,7 @@ def pytest_runtest_setup(item):
         pytest.skip(
             "skipping test that requires network connectivity due to `--skip-online` flag"
         )
-    elif "ambient_oidc" in item.keywords and not _is_ambient_env():
+    elif "ambient_oidc" in item.keywords and not _has_oidc_id():
         pytest.skip("skipping test that requires an ambient OIDC credential")
 
 
@@ -187,3 +192,15 @@ def tuf_dirs(monkeypatch, tmp_path):
     monkeypatch.setattr(tuf, "_get_dirs", lambda u: (data_dir, cache_dir))
 
     return (data_dir, cache_dir)
+
+
+@pytest.fixture(params=[("production", Signer.production), ("staging", Signer.staging)])
+def id_config(request):
+    env, signer = request.param
+    # Detect env variable for local interactive tests.
+    token = os.getenv(f"SIGSTORE_IDENTITY_TOKEN_{env}")
+    if not token:
+        # If the variable is not defined, try getting an ambient token.
+        token = detect_credential(DEFAULT_AUDIENCE)
+
+    return signer, token

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -194,7 +194,7 @@ def tuf_dirs(monkeypatch, tmp_path):
     return (data_dir, cache_dir)
 
 
-@pytest.fixture(params=[("production", Signer.production), ("staging", Signer.staging)])
+@pytest.fixture(params=[("production", Signer.production), ("staging", Signer.staging)], ids=["production", "staging"])
 def id_config(request):
     env, signer = request.param
     # Detect env variable for local interactive tests.

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -43,7 +43,7 @@ assert _TUF_ASSETS.is_dir()
 
 
 def _has_oidc_id():
-    # If there are tokens manually defined for us in the environment, use it.
+    # If there are tokens manually defined for us in the environment, use them.
     if os.getenv("SIGSTORE_IDENTITY_TOKEN_production") is not None:
         return True
 

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -39,8 +39,7 @@ def test_signer_staging(mock_staging_tuf):
 
 @pytest.mark.online
 @pytest.mark.ambient_oidc
-@pytest.mark.parametrize("signer", [Signer.production, Signer.staging])
-def test_sign_rekor_entry_consistent(signer, id_config):
+def test_sign_rekor_entry_consistent(id_config):
     signer, token = id_config
 
     # NOTE: The actual signer instance is produced lazily, so that parameter
@@ -61,8 +60,7 @@ def test_sign_rekor_entry_consistent(signer, id_config):
 
 @pytest.mark.online
 @pytest.mark.ambient_oidc
-@pytest.mark.parametrize("signer", [Signer.production, Signer.staging])
-def test_sct_verify_keyring_lookup_error(signer, id_config, monkeypatch):
+def test_sct_verify_keyring_lookup_error(id_config, monkeypatch):
     signer, token = id_config
 
     # a signer whose keyring always fails to lookup a given key.
@@ -83,8 +81,7 @@ def test_sct_verify_keyring_lookup_error(signer, id_config, monkeypatch):
 
 @pytest.mark.online
 @pytest.mark.ambient_oidc
-@pytest.mark.parametrize("signer", [Signer.production, Signer.staging])
-def test_sct_verify_keyring_error(signer, id_config, monkeypatch):
+def test_sct_verify_keyring_error(id_config, monkeypatch):
     signer, token = id_config
 
     # a signer whose keyring throws an internal error.
@@ -100,8 +97,7 @@ def test_sct_verify_keyring_error(signer, id_config, monkeypatch):
 
 @pytest.mark.online
 @pytest.mark.ambient_oidc
-@pytest.mark.parametrize("signer", [Signer.production, Signer.staging])
-def test_identity_proof_claim_lookup(signer, id_config, monkeypatch):
+def test_identity_proof_claim_lookup(id_config, monkeypatch):
     signer, token = id_config
 
     signer = signer()

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -18,11 +18,10 @@ import secrets
 import jwt
 import pretend
 import pytest
-from id import IdentityError, detect_credential
+from id import IdentityError
 
 import sigstore._internal.oidc
 from sigstore._internal.keyring import KeyringError, KeyringLookupError
-from sigstore._internal.oidc import DEFAULT_AUDIENCE
 from sigstore._internal.sct import InvalidSCTError, InvalidSCTKeyError
 from sigstore.sign import Signer
 
@@ -41,12 +40,12 @@ def test_signer_staging(mock_staging_tuf):
 @pytest.mark.online
 @pytest.mark.ambient_oidc
 @pytest.mark.parametrize("signer", [Signer.production, Signer.staging])
-def test_sign_rekor_entry_consistent(signer):
+def test_sign_rekor_entry_consistent(signer, id_config):
+    signer, token = id_config
+
     # NOTE: The actual signer instance is produced lazily, so that parameter
     # expansion doesn't fail in offline tests.
     signer = signer()
-
-    token = detect_credential(DEFAULT_AUDIENCE)
     assert token is not None
 
     payload = io.BytesIO(secrets.token_bytes(32))
@@ -63,12 +62,12 @@ def test_sign_rekor_entry_consistent(signer):
 @pytest.mark.online
 @pytest.mark.ambient_oidc
 @pytest.mark.parametrize("signer", [Signer.production, Signer.staging])
-def test_sct_verify_keyring_lookup_error(signer, monkeypatch):
+def test_sct_verify_keyring_lookup_error(signer, id_config, monkeypatch):
+    signer, token = id_config
+
     # a signer whose keyring always fails to lookup a given key.
     signer = signer()
     signer._rekor._ct_keyring = pretend.stub(verify=pretend.raiser(KeyringLookupError))
-
-    token = detect_credential(DEFAULT_AUDIENCE)
     assert token is not None
 
     payload = io.BytesIO(secrets.token_bytes(32))
@@ -85,12 +84,12 @@ def test_sct_verify_keyring_lookup_error(signer, monkeypatch):
 @pytest.mark.online
 @pytest.mark.ambient_oidc
 @pytest.mark.parametrize("signer", [Signer.production, Signer.staging])
-def test_sct_verify_keyring_error(signer, monkeypatch):
+def test_sct_verify_keyring_error(signer, id_config, monkeypatch):
+    signer, token = id_config
+
     # a signer whose keyring throws an internal error.
     signer = signer()
     signer._rekor._ct_keyring = pretend.stub(verify=pretend.raiser(KeyringError))
-
-    token = detect_credential(DEFAULT_AUDIENCE)
     assert token is not None
 
     payload = io.BytesIO(secrets.token_bytes(32))
@@ -102,10 +101,10 @@ def test_sct_verify_keyring_error(signer, monkeypatch):
 @pytest.mark.online
 @pytest.mark.ambient_oidc
 @pytest.mark.parametrize("signer", [Signer.production, Signer.staging])
-def test_identity_proof_claim_lookup(signer, monkeypatch):
-    signer = signer()
+def test_identity_proof_claim_lookup(signer, id_config, monkeypatch):
+    signer, token = id_config
 
-    token = detect_credential(DEFAULT_AUDIENCE)
+    signer = signer()
     assert token is not None
 
     # clear out the known issuers, forcing the `Identity`'s  `proof_claim` to be looked up.


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Introduces a new Makefile target `test-oidc`. This runs ambient OIDC tests with tokens from `sigstore get-identity-token`.

Partially fixes #570.