### PR TITLE
Aggregate offline and online test coverage.

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -12,7 +12,6 @@ runs:
   steps:
     # FIXME(jl): codecov has the option of including machine information in filename that would solve this unique naming
     # issue more completely.
-    # This method has the limitation of 1 coverage file per run, limiting some coverage between online/offline tests.
     - run: |
         COVERAGE_UUID=$(python3 -c "import uuid; print(uuid.uuid4())")
         echo "COVERAGE_UUID=${COVERAGE_UUID}" >> $GITHUB_OUTPUT

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ reformat: $(VENV)/pyvenv.cfg
 .PHONY: test
 test: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
-		$(TEST_ENV) pytest --cov=$(PY_MODULE) $(T) $(TEST_ARGS) && \
+		$(TEST_ENV) pytest --cov-append --cov=$(PY_MODULE) $(T) $(TEST_ARGS) && \
 		python -m coverage report -m $(COV_ARGS)
 
 .PHONY: test-interactive


### PR DESCRIPTION
Use `pytest --cov-append` to not overwrite the `.coverage` artifact on each `make test` run. Aggregation avoids the problem of only the *last sequential test suite* ran being account for by getting last say on the `.coverage` contents.

Tracking against: https://github.com/sigstore/sigstore-python/actions/runs/4517097044#summary-12269011312

With aggregation: https://github.com/sigstore/sigstore-python/actions/runs/4547521585

Coverage increased by... a whole 1%

(note: thanks for the pointer, @0xalpharush!)