### PR TITLE
swap over to using CDN to fetch TUF roots

### DIFF
--- a/sigstore/_internal/tuf.py
+++ b/sigstore/_internal/tuf.py
@@ -46,8 +46,8 @@ from sigstore.errors import MetadataError, TUFError
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TUF_URL = "https://sigstore-tuf-root.storage.googleapis.com/"
-STAGING_TUF_URL = "https://tuf-root-staging.storage.googleapis.com/"
+DEFAULT_TUF_URL = "https://tuf-repo-cdn.sigstore.dev"
+STAGING_TUF_URL = "https://tuf-repo-cdn.sigstage.dev"
 
 
 @lru_cache()


### PR DESCRIPTION
#### Summary
The TUF roots for both production and staging instances of sigstore are now addressable via a CDN endpoint; this change uses the CDN instead of calling GCS directly via its HTTP endpoint.