### PR TITLE
_cli: allow named pipes as inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ All versions prior to 0.9.0 are untracked.
   Sigstore bundles are now preferred.
   ([#614](https://github.com/sigstore/sigstore-python/pull/614))
 
+### Fixed
+
+* The `sigstore` CLI now handles named pipes correctly
+  ([#625](https://github.com/sigstore/sigstore-python/pull/625))
+
 ## [1.1.2]
 
 ### Fixed


### PR DESCRIPTION
Adds a `_path_is_filelike` helper to abstract the check away here.

Fixes #616.
