### PR TITLE
verify: fix timerange inclusion check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed a case where `sigstore verify` would fail to verify an otherwise valid
+  inclusion proof due to an incorrect timerange check
+  ([#633](https://github.com/sigstore/sigstore-python/pull/633))
+
 ### Changed
 
 * A cached copy of the trust bundle is now included with the distribution

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -267,9 +267,10 @@ class Verifier:
 
         # 7) Verify that the signing certificate was valid at the time of signing
         integrated_time = datetime.datetime.utcfromtimestamp(entry.integrated_time)
-        if (
-            integrated_time < materials.certificate.not_valid_before
-            or integrated_time >= materials.certificate.not_valid_after
+        if not (
+            materials.certificate.not_valid_before
+            <= integrated_time
+            <= materials.certificate.not_valid_after
         ):
             return VerificationFailure(
                 reason="invalid signing cert: expired at time of Rekor entry"


### PR DESCRIPTION
Our previous check was incorrect: it would fail verification on an otherwise valid inclusion proof if the integrated time happened to be at the last moment of `not_valid_after`.

See: https://github.com/sigstore/protobuf-specs/pull/78