### PR TITLE
conformance: remove old id-token permission

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -12,9 +12,6 @@ permissions:  # added using https://github.com/step-security/secure-workflows
 
 jobs:
   conformance:
-    permissions:
-      # Needed to access the workflow's OIDC identity.
-      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2


### PR DESCRIPTION
This should no longer be necessary.