### PR TITLE
sigstore: fix `detect_credential` signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ All versions prior to 0.9.0 are untracked.
   bundle, rather than falling back to deprecated individual targets
   ([#626](https://github.com/sigstore/sigstore-python/pull/626))
 
+### Fixed
+
+* Removed an unnecessary and backwards-incompatible parameter from the
+  `sigstore.oidc.detect_credential` API
+  ([#641](https://github.com/sigstore/sigstore-python/pull/641))
+
 ## [1.1.2]
 
 ### Fixed

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -30,7 +30,6 @@ from sigstore import __version__
 from sigstore._internal.ctfe import CTKeyring
 from sigstore._internal.fulcio.client import DEFAULT_FULCIO_URL, FulcioClient
 from sigstore._internal.keyring import Keyring
-from sigstore._internal.oidc import DEFAULT_AUDIENCE
 from sigstore._internal.rekor.client import (
     DEFAULT_REKOR_URL,
     RekorClient,
@@ -960,7 +959,7 @@ def _verify_github(args: argparse.Namespace) -> None:
 def _get_identity_token(args: argparse.Namespace) -> Optional[str]:
     token = None
     if not args.oidc_disable_ambient_providers:
-        token = detect_credential(DEFAULT_AUDIENCE)
+        token = detect_credential()
 
     if not token:
         if args.staging:

--- a/sigstore/oidc.py
+++ b/sigstore/oidc.py
@@ -30,6 +30,7 @@ import id
 import requests
 from pydantic import BaseModel, StrictStr
 
+from sigstore._internal.oidc import DEFAULT_AUDIENCE
 from sigstore.errors import Error, NetworkError
 
 DEFAULT_OAUTH_ISSUER_URL = "https://oauth2.sigstore.dev/auth"
@@ -233,9 +234,9 @@ class IdentityError(Error):
             """
 
 
-def detect_credential(audience: str) -> Optional[str]:
+def detect_credential() -> Optional[str]:
     """Calls `id.detect_credential`, but wraps exceptions with our own exception type."""
     try:
-        return cast(Optional[str], id.detect_credential(audience))
+        return cast(Optional[str], id.detect_credential(DEFAULT_AUDIENCE))
     except id.IdentityError as exc:
         IdentityError.raise_from_id(exc)


### PR DESCRIPTION
This API accidentally gained a parameter in a point release, which is both a semver breakage and strictly unnecessary (since the parameter is an invariant).
