### PR TITLE
sign: switch to P-256

### DIFF
--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -122,7 +122,7 @@ class Signer:
         """Public API for signing blobs"""
         input_digest = sha256_streaming(input_)
 
-        private_key = ec.generate_private_key(ec.SECP384R1())
+        private_key = ec.generate_private_key(ec.SECP256R1())
 
         logger.debug(
             f"Performing CSR: identity={identity.identity} "


### PR DESCRIPTION
This is faster than P-384, is well-supported, and is well within security margins.

Longer term I'd like to switch to ed25519, but I'm having some trouble getting Rekor to accept `hashedrekord` entries for ed25519 signatures.

cc @alex