### PR TITLE
Handle the case of missing EKU in _is_preissuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ All versions prior to 0.9.0 are untracked.
   reducing the number of cryptographic operations and network roundtrips
   required when signing more than one input
   ([#645](https://github.com/sigstore/sigstore-python/pull/645))
-  
+
 * `sigstore sign` now uses an ephemeral P-256 keypair, rather than P-384
   ([#662](https://github.com/sigstore/sigstore-python/pull/662))
 
@@ -68,6 +68,11 @@ All versions prior to 0.9.0 are untracked.
 * Removed an unnecessary and backwards-incompatible parameter from the
   `sigstore.oidc.detect_credential` API
   ([#641](https://github.com/sigstore/sigstore-python/pull/641))
+
+* Fixed a case where `sigstore sign` (and `sigstore verify`) could fail while
+  using a private instance due to a missing due to a missing `ExtendedKeyUsage`
+  in the CA. We now enforce the fact that the TBSPrecertificate signer must be
+  a valid CA ([#658](https://github.com/sigstore/sigstore-python/pull/658))
 
 ## [1.1.2]
 

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -226,28 +226,24 @@ def cert_is_ca(cert: Certificate) -> bool:
         # No BasicConstrains means that this can't possibly be a CA.
         return False
 
-    digital_signature = False
     key_cert_sign = False
     try:
         key_usage = cert.extensions.get_extension_for_oid(ExtensionOID.KEY_USAGE)
         key_cert_sign = key_usage.value.key_cert_sign  # type: ignore
-        digital_signature = key_usage.value.digital_signature  # type: ignore
     except ExtensionNotFound:
         raise InvalidCertError("invalid X.509 certificate: missing KeyUsage")
 
-    # If all three states are set, this is a CA.
-    if ca and key_cert_sign and digital_signature:
+    # If both states are set, this is a CA.
+    if ca and key_cert_sign:
         return True
 
-    # Non-CA in the Sigstore ecosystem have `digitalSignature` but neither of
-    # the CA states.
-    if digital_signature and not (ca or key_cert_sign):
+    if not (ca or key_cert_sign):
         return False
 
     # Anything else is an invalid state that should never occur.
     raise InvalidCertError(
-        f"invalid certificate states: KeyUsage.digitalSignature={digital_signature}, "
-        f"KeyUsage.keyCertSign={key_cert_sign}, BasicConstraints.ca={ca}"
+        f"invalid certificate states: KeyUsage.keyCertSign={key_cert_sign}"
+        f", BasicConstraints.ca={ca}"
     )
 
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -119,7 +119,6 @@ def test_cert_is_ca(x509_testcase, testcase, valid):
         "bogus-root-noncritical-bc.pem",
         "bogus-root-invalid-ku.pem",
         "bogus-root-missing-ku.pem",
-        "bogus-leaf-invalid-ku.pem",
     ],
 )
 def test_cert_is_ca_invalid_states(x509_testcase, testcase):
@@ -135,6 +134,7 @@ def test_cert_is_ca_invalid_states(x509_testcase, testcase):
         ("bogus-root.pem", True),
         ("bogus-intermediate.pem", False),
         ("bogus-leaf.pem", False),
+        ("bogus-leaf-invalid-ku.pem", False),
     ],
 )
 def test_cert_is_root_ca(x509_testcase, testcase, valid):


### PR DESCRIPTION
#### Summary
Previously, TBSCertificate signed with the same CA than the final certificate was failing if no `ExtendedKeyUsage` were present

#### Release Note
Fix a case where signing an artifact against a private sigstore instance was failing if no `ExtendedKeyUsage` was present in the Sigining CA

#### Documentation
NONE


Resolves: sigstore/sigstore-python#658
