### PR TITLE
Make `VerificationError` available in the verification API

### DIFF
--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -20,7 +20,6 @@ import logging
 import os
 import sys
 from pathlib import Path
-from textwrap import dedent
 from typing import NoReturn, Optional, TextIO, Union, cast
 
 from cryptography.x509 import load_pem_x509_certificates
@@ -52,14 +51,8 @@ from sigstore.oidc import (
 )
 from sigstore.sign import SigningContext
 from sigstore.transparency import LogEntry
-from sigstore.verify import (
-    CertificateVerificationFailure,
-    LogEntryMissing,
-    VerificationMaterials,
-    Verifier,
-    policy,
-)
-from sigstore.verify.models import VerificationFailure
+from sigstore.verify import VerificationMaterials, Verifier, policy
+from sigstore.verify.models import VerificationError, VerificationFailure
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -851,60 +844,6 @@ def _collect_verification_state(
             all_materials.append((file, materials))
 
     return (verifier, all_materials)
-
-
-class VerificationError(Error):
-    """Raised when the verifier returns a `VerificationFailure` result."""
-
-    def __init__(self, result: VerificationFailure):
-        self.message = f"Verification failed: {result.reason}"
-        self.result = result
-
-    def diagnostics(self) -> str:
-        message = f"Failure reason: {self.result.reason}\n"
-
-        if isinstance(self.result, CertificateVerificationFailure):
-            message += dedent(
-                f"""
-                The given certificate could not be verified against the
-                root of trust.
-
-                This may be a result of connecting to the wrong Fulcio instance
-                (for example, staging instead of production, or vice versa).
-
-                Additional context:
-
-                {self.result.exception}
-                """
-            )
-        elif isinstance(self.result, LogEntryMissing):
-            message += dedent(
-                f"""
-                These signing artifacts could not be matched to a entry
-                in the configured transparency log.
-
-                This may be a result of connecting to the wrong Rekor instance
-                (for example, staging instead of production, or vice versa).
-
-                Additional context:
-
-                Signature: {self.result.signature}
-
-                Artifact hash: {self.result.artifact_hash}
-                """
-            )
-        else:
-            message += dedent(
-                f"""
-                A verification error occurred.
-
-                Additional context:
-
-                {self.result}
-                """
-            )
-
-        return message
 
 
 def _verify_identity(args: argparse.Namespace) -> None:

--- a/sigstore/verify/__init__.py
+++ b/sigstore/verify/__init__.py
@@ -52,16 +52,14 @@ with artifact.open("rb") as a, cert.open("r") as c, signature.open("rb") as s:
 """
 
 from sigstore.verify.models import (
+    CertificateVerificationFailure,
+    LogEntryMissing,
     VerificationFailure,
     VerificationMaterials,
     VerificationResult,
     VerificationSuccess,
 )
-from sigstore.verify.verifier import (
-    CertificateVerificationFailure,
-    LogEntryMissing,
-    Verifier,
-)
+from sigstore.verify.verifier import Verifier
 
 __all__ = [
     "CertificateVerificationFailure",

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -48,7 +48,9 @@ from sigstore._internal.rekor.client import RekorClient
 from sigstore._internal.set import InvalidSETError, verify_set
 from sigstore._internal.tuf import TrustUpdater
 from sigstore._utils import B64Str, HexStr
+from sigstore.verify.models import CertificateVerificationFailure
 from sigstore.verify.models import InvalidRekorEntry as InvalidRekorEntryError
+from sigstore.verify.models import LogEntryMissing
 from sigstore.verify.models import RekorEntryMissing as RekorEntryMissingError
 from sigstore.verify.models import (
     VerificationFailure,
@@ -59,42 +61,6 @@ from sigstore.verify.models import (
 from sigstore.verify.policy import VerificationPolicy
 
 logger = logging.getLogger(__name__)
-
-
-class LogEntryMissing(VerificationFailure):
-    """
-    A specialization of `VerificationFailure` for transparency log lookup failures,
-    with additional lookup context.
-    """
-
-    reason: str = (
-        "The transparency log has no entry for the given verification materials"
-    )
-
-    signature: B64Str
-    """
-    The signature present during lookup failure, encoded with base64.
-    """
-
-    artifact_hash: HexStr
-    """
-    The artifact hash present during lookup failure, encoded as a hex string.
-    """
-
-
-class CertificateVerificationFailure(VerificationFailure):
-    """
-    A specialization of `VerificationFailure` for certificate signature
-    verification failures, with additional exception context.
-    """
-
-    reason: str = "Failed to verify signing certificate"
-    exception: Exception
-
-    class Config:
-        # Needed for the `exception` field above, since exceptions are
-        # not trivially serializable.
-        arbitrary_types_allowed = True
 
 
 class Verifier:


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Make [VerificationError](https://github.com/sigstore/sigstore-python/blob/814bc6ba6081f98aeec90988759e8e233279f6af/sigstore/_cli.py#L856) defined in sigstore/_cli.py available in the verification API.

Fixes: https://github.com/sigstore/sigstore-python/issues/691

Note: I had to move around a number of things along with `VerificationError` because of circular imports, if this change is too important/not useful enough it is fine not to have it in the API.

#### Release Note
 
NONE