### PR TITLE
don't parse error messages as json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ All versions prior to 0.9.0 are untracked.
 * `sigstore sign` now uses an ephemeral P-256 keypair, rather than P-384
   ([#662](https://github.com/sigstore/sigstore-python/pull/662))
 
+* API change: `RekorClientError` does not try to always parse response
+  content as JSON
+  ([#694](https://github.com/sigstore/sigstore-python/pull/694))
+
 ### Fixed
 
 * Fixed a case where `sigstore verify` would fail to verify an otherwise valid

--- a/sigstore/_internal/rekor/client.py
+++ b/sigstore/_internal/rekor/client.py
@@ -226,7 +226,7 @@ class RekorEntriesRetrieve(_Endpoint):
         except requests.HTTPError as http_error:
             if http_error.response.status_code == 404:
                 return None
-            raise RekorClientError(resp.json()) from http_error
+            raise RekorClientError(resp.text) from http_error
 
         results = resp.json()
 


### PR DESCRIPTION
#### Summary
I don't think we need to pass a parsed JSON object up to the caller in the context of `RekorClientError`

@woodruffw thoughts?