### PR TITLE
Add timezone (utc) info into the cert not_valid_after field

### DIFF
--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -138,11 +138,8 @@ class Signer:
         # If it exists, verify if the current certificate is expired
         if self.__cached_signing_certificate:
             not_valid_after = self.__cached_signing_certificate.cert.not_valid_after
-            not_valid_after_timestamp = not_valid_after.replace(
-                tzinfo=timezone.utc
-            ).timestamp()
-
-            if datetime.now(timezone.utc).timestamp() > not_valid_after_timestamp:
+            not_valid_after_tzutc = not_valid_after.replace(tzinfo=timezone.utc)
+            if datetime.now(timezone.utc) > not_valid_after_tzutc:
                 raise ExpiredCertificate
             return self.__cached_signing_certificate
 

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -137,10 +137,12 @@ class Signer:
         """Get or request a signing certificate from Fulcio."""
         # If it exists, verify if the current certificate is expired
         if self.__cached_signing_certificate:
-            if (
-                datetime.now(timezone.utc).timestamp()
-                > self.__cached_signing_certificate.cert.not_valid_after.timestamp()
-            ):
+            not_valid_after = self.__cached_signing_certificate.cert.not_valid_after
+            not_valid_after_timestamp = not_valid_after.replace(
+                tzinfo=timezone.utc
+            ).timestamp()
+
+            if datetime.now(timezone.utc).timestamp() > not_valid_after_timestamp:
                 raise ExpiredCertificate
             return self.__cached_signing_certificate
 


### PR DESCRIPTION
#### Summary
This commit fixes the issue described in #700 where the certificate `not_valid_after` datetime is not tz-aware, making the call to `timestamp()` to assume local time, triggering the `ExpiredCertificate` exception all the time.

Resolves: #700 

#### Release Note
- Fixes a issue in the certificate expiration timestamp that caused exception during signing process.
