### PR TITLE
sigstore: 2.0.0rc2

### DIFF
--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -25,4 +25,4 @@ Otherwise, here are some quick starting points:
 * `sigstore.sign`: creation of Sigstore signatures
 """
 
-__version__ = "2.0.0rc1"
+__version__ = "2.0.0rc2"


### PR DESCRIPTION
Puts another release candidate out there; this will help us fix the conformance suite's self-tests and hopefully expose us to some more user testing before a final 2.0.0.