### PR TITLE
Update comments

### DIFF
--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -200,13 +200,11 @@ def cert_is_ca(cert: Certificate) -> bool:
     if cert.version != Version.v3:
         raise InvalidCertError(f"invalid X.509 version: {cert.version}")
 
-    # Valid CA certificates must have *all* of the following set:
+    # Valid CA certificates must have the following set:
     #
-    #  * `BasicKeyUsage.digitalSignature`
     #  * `BasicKeyUsage.keyCertSign`
     #  * `BasicConstraints.ca`
     #
-    # Of those, non-CAs must have *only* `BasicKeyUsage.digitalSignature` set.
     # Any other combination of states is inconsistent and invalid, meaning
     # that we won't consider the certificate a valid non-CA leaf.
 

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -324,8 +324,10 @@ class SigningResult(BaseModel):
         from this `SigningResult`.
         """
 
-        # TODO: Include the current Fulcio intermediate and root in the
-        # chain as well.
+        # NOTE: We explicitly only include the leaf certificate in the bundle's "chain"
+        # here: the specs explicitly forbid the inclusion of the root certificate,
+        # and discourage inclusion of any intermediates (since they're in the root of
+        # trust already).
         cert = x509.load_pem_x509_certificate(self.cert_pem.encode())
         cert_der = cert.public_bytes(encoding=serialization.Encoding.DER)
         chain = X509CertificateChain(certificates=[X509Certificate(raw_bytes=cert_der)])


### PR DESCRIPTION
We don't actually check for `digitalSignature` on CA certs, since the Sigstore profile doesn't require it.

Also changes a TODO around cert chains into a NOTE about our current behavior.