### PR TITLE
Add VerificationMaterials.to_bundle()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All versions prior to 0.9.0 are untracked.
 * Version `0.2` of the Sigstore bundle format is now supported
   ([#705](https://github.com/sigstore/sigstore-python/pull/705))
 
+* API addition: `VerificationMaterials.to_bundle()` is a new public API for
+  producing a standard Sigstore bundle from `sigstore-python`'s internal
+  representation ([#719](https://github.com/sigstore/sigstore-python/pull/719))
+
 ### Changed
 
 * `sigstore verify` now performs additional verification of Rekor's inclusion

--- a/sigstore/verify/models.py
+++ b/sigstore/verify/models.py
@@ -462,6 +462,26 @@ class VerificationMaterials:
                 "Must have Rekor entry before converting to a Bundle"
             )
         rekor_entry = self._rekor_entry
+        assert rekor_entry is not None
+
+        inclusion_proof: InclusionProof | None = None
+        if rekor_entry.inclusion_proof is not None:
+            inclusion_proof = InclusionProof(
+                log_index=rekor_entry.inclusion_proof.log_index,
+                root_hash=bytes.fromhex(rekor_entry.inclusion_proof.root_hash),
+                tree_size=rekor_entry.inclusion_proof.tree_size,
+                hashes=[
+                    bytes.fromhex(hash_hex)
+                    for hash_hex in rekor_entry.inclusion_proof.hashes
+                ],
+                checkpoint=Checkpoint(envelope=rekor_entry.inclusion_proof.checkpoint),
+            )
+
+        inclusion_promise: InclusionPromise | None = None
+        if rekor_entry.inclusion_promise:
+            inclusion_promise = InclusionPromise(
+                signed_entry_timestamp=base64.b64decode(rekor_entry.inclusion_promise)
+            )
 
         bundle = Bundle(
             media_type="application/vnd.dev.sigstore.bundle+json;version=0.2",
@@ -480,25 +500,8 @@ class VerificationMaterials:
                         log_id=LogId(key_id=bytes.fromhex(rekor_entry.log_id)),
                         kind_version=KindVersion(kind="hashedrekord", version="0.0.1"),
                         integrated_time=rekor_entry.integrated_time,
-                        inclusion_promise=InclusionPromise(
-                            signed_entry_timestamp=base64.b64decode(
-                                rekor_entry.inclusion_promise
-                            )
-                        ),
-                        inclusion_proof=InclusionProof(
-                            log_index=rekor_entry.inclusion_proof.log_index,
-                            root_hash=bytes.fromhex(
-                                rekor_entry.inclusion_proof.root_hash
-                            ),
-                            tree_size=rekor_entry.inclusion_proof.tree_size,
-                            hashes=[
-                                bytes.fromhex(hash_hex)
-                                for hash_hex in rekor_entry.inclusion_proof.hashes
-                            ],
-                            checkpoint=Checkpoint(
-                                envelope=rekor_entry.inclusion_proof.checkpoint
-                            ),
-                        ),
+                        inclusion_promise=inclusion_promise,
+                        inclusion_proof=inclusion_proof,
                         canonicalized_body=base64.b64decode(rekor_entry.body),
                     )
                 ],

--- a/sigstore/verify/models.py
+++ b/sigstore/verify/models.py
@@ -461,8 +461,7 @@ class VerificationMaterials:
             raise InvalidMaterials(
                 "Must have Rekor entry before converting to a Bundle"
             )
-        rekor_entry = self._rekor_entry
-        assert rekor_entry is not None
+        rekor_entry: LogEntry = self._rekor_entry  # type: ignore[assignment]
 
         inclusion_proof: InclusionProof | None = None
         if rekor_entry.inclusion_proof is not None:

--- a/sigstore/verify/models.py
+++ b/sigstore/verify/models.py
@@ -32,10 +32,25 @@ from cryptography.x509 import (
     load_pem_x509_certificate,
 )
 from pydantic import BaseModel
-from sigstore_protobuf_specs.dev.sigstore.bundle.v1 import Bundle
+from sigstore_protobuf_specs.dev.sigstore.bundle.v1 import (
+    Bundle,
+    VerificationMaterial,
+)
+from sigstore_protobuf_specs.dev.sigstore.common.v1 import (
+    HashAlgorithm,
+    HashOutput,
+    LogId,
+    MessageSignature,
+    PublicKeyIdentifier,
+    X509Certificate,
+    X509CertificateChain,
+)
 from sigstore_protobuf_specs.dev.sigstore.rekor.v1 import (
+    Checkpoint,
     InclusionPromise,
     InclusionProof,
+    KindVersion,
+    TransparencyLogEntry,
 )
 
 from sigstore._internal.rekor import RekorClient
@@ -171,8 +186,6 @@ class VerificationMaterials:
     certificate: Certificate
     """
     The certificate that attests to and contains the public signing key.
-
-    # TODO: Support a certificate chain here, with optional intermediates.
     """
 
     signature: bytes
@@ -438,3 +451,64 @@ class VerificationMaterials:
             raise InvalidRekorEntry
 
         return entry
+
+    def to_bundle(self) -> Bundle:
+        """Converts VerificationMaterials into a Bundle. Requires that
+        the VerificationMaterials have a Rekor entry loaded. This is
+        the reverse operation of VerificationMaterials.from_bundle()
+        """
+        if not self.has_rekor_entry:
+            raise InvalidMaterials(
+                "Must have Rekor entry before converting to a Bundle"
+            )
+        rekor_entry = self._rekor_entry
+
+        bundle = Bundle(
+            media_type="application/vnd.dev.sigstore.bundle+json;version=0.2",
+            verification_material=VerificationMaterial(
+                public_key=PublicKeyIdentifier(),
+                x509_certificate_chain=X509CertificateChain(
+                    certificates=[
+                        X509Certificate(
+                            raw_bytes=self.certificate.public_bytes(Encoding.DER)
+                        )
+                    ]
+                ),
+                tlog_entries=[
+                    TransparencyLogEntry(
+                        log_index=rekor_entry.log_index,
+                        log_id=LogId(key_id=bytes.fromhex(rekor_entry.log_id)),
+                        kind_version=KindVersion(kind="hashedrekord", version="0.0.1"),
+                        integrated_time=rekor_entry.integrated_time,
+                        inclusion_promise=InclusionPromise(
+                            signed_entry_timestamp=base64.b64decode(
+                                rekor_entry.inclusion_promise
+                            )
+                        ),
+                        inclusion_proof=InclusionProof(
+                            log_index=rekor_entry.inclusion_proof.log_index,
+                            root_hash=bytes.fromhex(
+                                rekor_entry.inclusion_proof.root_hash
+                            ),
+                            tree_size=rekor_entry.inclusion_proof.tree_size,
+                            hashes=[
+                                bytes.fromhex(hash_hex)
+                                for hash_hex in rekor_entry.inclusion_proof.hashes
+                            ],
+                            checkpoint=Checkpoint(
+                                envelope=rekor_entry.inclusion_proof.checkpoint
+                            ),
+                        ),
+                        canonicalized_body=base64.b64decode(rekor_entry.body),
+                    )
+                ],
+            ),
+            message_signature=MessageSignature(
+                message_digest=HashOutput(
+                    algorithm=HashAlgorithm.SHA2_256,
+                    digest=self.input_digest,
+                ),
+                signature=self.signature,
+            ),
+        )
+        return bundle

--- a/test/unit/verify/test_models.py
+++ b/test/unit/verify/test_models.py
@@ -21,6 +21,7 @@ from sigstore.verify.models import (
     InvalidMaterials,
     InvalidRekorEntry,
     RekorEntryMissing,
+    VerificationMaterials,
 )
 
 
@@ -86,3 +87,24 @@ class TestVerificationMaterials:
             InvalidMaterials, match="expected checkpoint in inclusion proof"
         ):
             signing_bundle("bundle_no_checkpoint.txt", offline=True)
+
+    def test_verification_materials_to_bundle_round_trip(self, asset, signing_bundle):
+        bundle = signing_bundle("bundle.txt").to_bundle()
+
+        with asset("bundle.txt").open(mode="rb", buffering=0) as io:
+            round_tripped_bundle = VerificationMaterials.from_bundle(
+                input_=io, bundle=bundle, offline=False
+            ).to_bundle()
+
+        assert bundle == round_tripped_bundle
+
+    def test_verification_materials_to_bundle_no_rekor_entry(
+        self, asset, signing_materials
+    ):
+        materials = signing_materials("bundle.txt")
+
+        with pytest.raises(
+            InvalidMaterials,
+            match="Must have Rekor entry before converting to a Bundle",
+        ):
+            materials.to_bundle()

--- a/test/unit/verify/test_models.py
+++ b/test/unit/verify/test_models.py
@@ -93,7 +93,7 @@ class TestVerificationMaterials:
 
         with asset("bundle.txt").open(mode="rb", buffering=0) as io:
             round_tripped_bundle = VerificationMaterials.from_bundle(
-                input_=io, bundle=bundle, offline=False
+                input_=io, bundle=bundle, offline=True
             ).to_bundle()
 
         assert bundle == round_tripped_bundle


### PR DESCRIPTION
#### Summary

Part of https://github.com/sigstore/sigstore-python/issues/718, adds the API to convert `VerificationMaterials` that have a Rekor entry loaded into a `Bundle`.

#### Release Note

Will add a release note.

#### Documentation

I don't think this needs a docs update?