### PR TITLE
Try separate config for /install directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     schedule:
       interval: daily
 
+  - package-ecosystem: pip
+    directory: /install/
+    schedule:
+      interval: daily
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
I suspect that dependabot is not picking up on the `/install/.python-version` file because it's being run from the root of the repository. A separate config should fix that.