### PR TITLE
Pass `--upgrade` to pip-compile in `pin-requirements.yml`

### DIFF
--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -58,7 +58,7 @@ jobs:
           cd install
 
           echo "sigstore==${SIGSTORE_RELEASE_VERSION}" > requirements.in
-          pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt requirements.in
+          pip-compile --allow-unsafe --generate-hashes --upgrade --output-file=requirements.txt requirements.in
 
       - name: Commit changes and push to branch
         run: |


### PR DESCRIPTION
Without this, we won't actually update the existing requirements file with new versions when they become available.