### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         conf:
-          - { py: "3.7", os: "ubuntu-latest" }
           - { py: "3.8", os: "ubuntu-latest" }
           - { py: "3.9", os: "ubuntu-latest" }
           - { py: "3.10", os: "ubuntu-latest" }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       # NOTE: We intentionally lint against our minimum supported Python.
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
@@ -34,7 +34,7 @@ jobs:
       # since it changes slightly between Python versions.
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
@@ -65,7 +65,7 @@ jobs:
       # NOTE: We intentionally check test certificates against our minimum supported Python.
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
-          python-version: "3.7"
+          python-version: "3.8"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       # NOTE: We intentionally lint against our minimum supported Python.
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
-          python-version-file: "pyproject.toml"
+          python-version: "3.8"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
@@ -34,7 +34,7 @@ jobs:
       # since it changes slightly between Python versions.
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
-          python-version-file: "pyproject.toml"
+          python-version: "3.8"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
@@ -65,7 +65,7 @@ jobs:
       # NOTE: We intentionally check test certificates against our minimum supported Python.
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
-          python-version-file: "pyproject.toml"
+          python-version: "3.8"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       # NOTE: We intentionally lint against our minimum supported Python.
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
-          python-version: "3.8"
+          python-version-file: "pyproject.toml"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
@@ -34,7 +34,7 @@ jobs:
       # since it changes slightly between Python versions.
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
-          python-version: "3.8"
+          python-version-file: "pyproject.toml"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
@@ -65,7 +65,7 @@ jobs:
       # NOTE: We intentionally check test certificates against our minimum supported Python.
       - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
-          python-version: "3.8"
+          python-version-file: "pyproject.toml"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 

--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -23,7 +23,7 @@ jobs:
       SIGSTORE_REF: ${{ inputs.ref }}
     strategy:
       matrix:
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python_version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Populate reference from context

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ as well as performing common development tasks.
 
 ## Requirements
 
-`sigstore`'s only development environment requirement *should* be Python 3.7
+`sigstore`'s only development environment requirement *should* be Python 3.8
 or newer. Development and testing is actively performed on macOS and Linux,
 but Windows and other supported platforms that are supported by Python
 should also work.
@@ -107,7 +107,7 @@ make gen-x509-testcases
 
 ### Documentation
 
-If you're running Python 3.7 or newer, you can run the documentation build locally:
+If you're running Python 3.8 or newer, you can run the documentation build locally:
 
 ```bash
 make doc

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ positional arguments:
     get-identity-token  retrieve and return a Sigstore-compatible OpenID
                         Connect token
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
   -V, --version         show program's version number and exit
   -v, --verbose         run with additional debug logging; supply multiple

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ else!
 
 ## Installation
 
-`sigstore` requires Python 3.7 or newer, and can be installed directly via `pip`:
+`sigstore` requires Python 3.8 or newer, and can be installed directly via `pip`:
 
 ```console
 python -m pip install sigstore

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ positional arguments:
     get-identity-token  retrieve and return a Sigstore-compatible OpenID
                         Connect token
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -V, --version         show program's version number and exit
   -v, --verbose         run with additional debug logging; supply multiple

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,4 +129,4 @@ ignore = ["E501"]
 # TODO: Enable "UP" here once Pydantic allows us to:
 # See: https://github.com/pydantic/pydantic/issues/4146
 select = ["E", "F", "W"]
-target-version = "py37"
+target-version = "py38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -38,7 +37,7 @@ dependencies = [
   "sigstore-protobuf-specs ~= 0.2.0",
   "tuf >= 2.1,< 4.0",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.scripts]
 sigstore = "sigstore._cli:main"
@@ -61,8 +60,6 @@ lint = [
   # and let Dependabot periodically perform this update.
   "ruff < 0.0.286",
   "types-requests",
-  # Needed for protocol typing in 3.7; remove when our minimum Python is 3.8.
-  "typing-extensions; python_version < '3.8'",
   # TODO(ww): Re-enable once dependency on types-cryptography is dropped.
   # See: https://github.com/python/typeshed/issues/8699
   # "types-pyOpenSSL",


### PR DESCRIPTION
Python 3.7 is currently EOL: https://devguide.python.org/versions/

Current versions of `sigstore-python` (<=1.1.2) will continue to be usable from Python 3.7.