### PR TITLE
Update securityscorecards.dev URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ sigstore-python
 <!--- @begin-badges@ --->
 ![CI](https://github.com/sigstore/sigstore-python/workflows/CI/badge.svg)
 [![PyPI version](https://badge.fury.io/py/sigstore.svg)](https://pypi.org/project/sigstore)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sigstore/sigstore-python/badge)](https://api.securityscorecards.dev/projects/github.com/sigstore/sigstore-python)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sigstore/sigstore-python/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sigstore/sigstore-python)
 [![SLSA](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev/)
 ![Conformance Tests](https://github.com/sigstore/sigstore-python/workflows/Conformance%20Tests/badge.svg)
 [![Documentation](https://github.com/sigstore/sigstore-python/actions/workflows/docs.yml/badge.svg)](https://sigstore.github.io/sigstore-python)


### PR DESCRIPTION
This makes the badge link to the new Scorecard viewer: https://securityscorecards.dev/viewer/?uri=github.com/sigstore/sigstore-python