### PR TITLE
sign: Make SigningResult._to_bundle() public

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ Thank you :)
 
 #### Release Note
 <!--
-Add a release note for each of the following conditions:
+Add a release note for each of the following conditions in CHANGELOG.md:
 
 * Config changes (additions, deletions, updates)
 * API additions—new endpoint, new response fields, or newly accepted request parameters
@@ -28,7 +28,7 @@ Add a release note for each of the following conditions:
 * Bug fixes and fixes of previous known issues
 * Deprecation warnings, breaking changes, or compatibility notes
 
-If no release notes are required write NONE. Use past-tense.
+Use past-tense.
 
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ All versions prior to 0.9.0 are untracked.
   producing a standard Sigstore bundle from `sigstore-python`'s internal
   representation ([#719](https://github.com/sigstore/sigstore-python/pull/719))
 
+* API addition: New method `sign.SigningResult.to_bundle()` allows signing
+  applications to serialize to the bundle format that is already usable in
+  verification with `verify.VerificationMaterials.from_bundle()`
+  ([#765](https://github.com/sigstore/sigstore-python/pull/765))
+
 ### Changed
 
 * `sigstore verify` now performs additional verification of Rekor's inclusion

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -720,7 +720,7 @@ def _sign(args: argparse.Namespace) -> None:
 
             if outputs["bundle"] is not None:
                 with outputs["bundle"].open(mode="w") as io:
-                    print(result._to_bundle().to_json(), file=io)
+                    print(result.to_bundle().to_json(), file=io)
                 print(f"Sigstore bundle written to {outputs['bundle']}")
 
 

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -318,7 +318,7 @@ class SigningResult(BaseModel):
     A record of the Rekor log entry for the signing operation.
     """
 
-    def _to_bundle(self) -> Bundle:
+    def to_bundle(self) -> Bundle:
         """
         Creates a Sigstore bundle (as defined by Sigstore's protobuf specs)
         from this `SigningResult`.


### PR DESCRIPTION
#### Summary

This enables signing applications to use the bundle format and seems in line with the other similar decisions:
* The bundle is already part of the CLI interface
* verify already contains similar public API (VerificationMaterials.from_bundle() is public)

Closes #763

#### Release Note
* API addition: `sign.SigningResult.to_bundle()` allows signing applications to serialize to the bundle format that is already usable in verification with `verify.VerificationMaterials.from_bundle()`

#### Documentation

* Method already has a docstring
* A complete example of _sign -> bundle serialization -> bundle deserialization -> verify_ could be useful but I did not add one here