### PR TITLE
Fix some mypy linting failures

### DIFF
--- a/sigstore/_internal/fulcio/client.py
+++ b/sigstore/_internal/fulcio/client.py
@@ -232,11 +232,12 @@ class FulcioSigningCert(_Endpoint):
         try:
             resp.raise_for_status()
         except requests.HTTPError as http_error:
-            try:
+            # See if we can optionally add a message
+            if http_error.response:
                 text = json.loads(http_error.response.text)
-                raise FulcioClientError(text["message"]) from http_error
-            except (AttributeError, KeyError):
-                raise FulcioClientError from http_error
+                if "message" in http_error.response.text:
+                    raise FulcioClientError(text["message"]) from http_error
+            raise FulcioClientError from http_error
 
         if resp.json().get("signedCertificateEmbeddedSct"):
             sct_embedded = True

--- a/sigstore/_internal/rekor/client.py
+++ b/sigstore/_internal/rekor/client.py
@@ -185,7 +185,7 @@ class RekorEntriesRetrieve(_Endpoint):
         try:
             resp.raise_for_status()
         except requests.HTTPError as http_error:
-            if http_error.response.status_code == 404:
+            if http_error.response and http_error.response.status_code == 404:
                 return None
             raise RekorClientError(resp.text) from http_error
 


### PR DESCRIPTION
Raised in https://github.com/sigstore/sigstore-python/actions/runs/6535290203/job/17744388682?pr=792:

```
sigstore/_internal/fulcio/client.py:236: error: Item "None" of "Optional[Response]" has no attribute "text"  [union-attr]
sigstore/_internal/rekor/client.py:188: error: Item "None" of "Optional[Response]" has no attribute "status_code"  [union-attr]
```