### PR TITLE
Read Fulcio certificate chain as bytes in verify command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* CLI: Read the Fulcio certificate chain as `bytes` instead of `str`
+  as expected by `cryptography.x509.load_pem_x509_certificates`
+  when loading the chain in the `sigstore verify` subcommands.
+
 ## [2.0.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@ All versions prior to 0.9.0 are untracked.
 
 ### Fixed
 
-* CLI: Read the Fulcio certificate chain as `bytes` instead of `str`
-  as expected by `cryptography.x509.load_pem_x509_certificates`
-  when loading the chain in the `sigstore verify` subcommands.
+* CLI: When using `--certificate-chain`, read as `bytes` instead of `str`
+  as expected by the underlying API ([#796](https://github.com/sigstore/sigstore-python/pull/796))
 
 ## [2.0.0]
 

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -422,7 +422,7 @@ def _parser() -> argparse.ArgumentParser:
     instance_options.add_argument(
         "--certificate-chain",
         metavar="FILE",
-        type=argparse.FileType("r"),
+        type=argparse.FileType("rb"),
         help=(
             "Path to a list of CA certificates in PEM format which will be needed when building "
             "the certificate chain for the Fulcio signing certificate"
@@ -488,7 +488,7 @@ def _parser() -> argparse.ArgumentParser:
     instance_options.add_argument(
         "--certificate-chain",
         metavar="FILE",
-        type=argparse.FileType("r"),
+        type=argparse.FileType("rb"),
         help=(
             "Path to a list of CA certificates in PEM format which will be needed when building "
             "the certificate chain for the Fulcio signing certificate"


### PR DESCRIPTION
#### Summary

Fixes #795

Fix opening the PEM file argument of the `--certificate-chain` option in `sigstore verify <identity, github>` as `bytes` instead of `str`.

#### Release Note
None
