### PR TITLE
treewide: switch to `ruff format`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,8 @@ make lint
 
 `sigstore` is automatically linted and formatted with a collection of tools:
 
-* [`black`](https://github.com/psf/black): Code formatting
 * [`isort`](https://github.com/PyCQA/isort): Import sorting, ordering
-* [`ruff`](https://github.com/charliermarsh/ruff): PEP-8 linting, style enforcement
+* [`ruff`](https://github.com/charliermarsh/ruff): Code formatting, PEP-8 linting, style enforcement
 * [`mypy`](https://mypy.readthedocs.io/en/stable/): Static type checking
 * [`bandit`](https://github.com/PyCQA/bandit): Security issue scanning
 * [`interrogate`](https://interrogate.readthedocs.io/en/latest/): Documentation coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,6 @@ make lint
 
 `sigstore` is automatically linted and formatted with a collection of tools:
 
-* [`isort`](https://github.com/PyCQA/isort): Import sorting, ordering
 * [`ruff`](https://github.com/charliermarsh/ruff): Code formatting, PEP-8 linting, style enforcement
 * [`mypy`](https://mypy.readthedocs.io/en/stable/): Static type checking
 * [`bandit`](https://github.com/PyCQA/bandit): Security issue scanning

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ run: $(VENV)/pyvenv.cfg
 .PHONY: lint
 lint: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
-		black --check $(ALL_PY_SRCS) && \
+		ruff format --check $(ALL_PY_SRCS) && \
 		isort --check $(ALL_PY_SRCS) && \
 		ruff $(ALL_PY_SRCS) && \
 		mypy $(PY_MODULE) && \
@@ -74,7 +74,7 @@ lint: $(VENV)/pyvenv.cfg
 reformat: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
 		ruff --fix $(ALL_PY_SRCS) && \
-		black $(ALL_PY_SRCS) && \
+		ruff format $(ALL_PY_SRCS) && \
 		isort $(ALL_PY_SRCS)
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ run: $(VENV)/pyvenv.cfg
 lint: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
 		ruff format --check $(ALL_PY_SRCS) && \
-		isort --check $(ALL_PY_SRCS) && \
 		ruff $(ALL_PY_SRCS) && \
 		mypy $(PY_MODULE) && \
 		bandit -c pyproject.toml -r $(PY_MODULE) && \
@@ -74,8 +73,7 @@ lint: $(VENV)/pyvenv.cfg
 reformat: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
 		ruff --fix $(ALL_PY_SRCS) && \
-		ruff format $(ALL_PY_SRCS) && \
-		isort $(ALL_PY_SRCS)
+		ruff format $(ALL_PY_SRCS)
 
 .PHONY: test
 test: $(VENV)/pyvenv.cfg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ Documentation = "https://sigstore.github.io/sigstore-python/"
 test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
 lint = [
   "bandit",
-  "isort",
   "interrogate",
   "mypy ~= 1.1",
   # NOTE(ww): ruff is under active development, so we pin conservatively here
@@ -66,11 +65,6 @@ lint = [
 ]
 doc = ["pdoc"]
 dev = ["build", "bump >= 1.3.2", "sigstore[doc,test,lint]"]
-
-[tool.isort]
-multi_line_output = 3
-known_first_party = "sigstore"
-include_trailing_comma = true
 
 [tool.coverage.run]
 # branch coverage in addition to statement coverage.
@@ -128,5 +122,5 @@ exclude_dirs = ["./test"]
 ignore = ["E501"]
 # TODO: Enable "UP" here once Pydantic allows us to:
 # See: https://github.com/pydantic/pydantic/issues/4146
-select = ["E", "F", "W"]
+select = ["E", "F", "I", "W"]
 target-version = "py38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,13 +53,12 @@ Documentation = "https://sigstore.github.io/sigstore-python/"
 test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
 lint = [
   "bandit",
-  "black",
   "isort",
   "interrogate",
   "mypy ~= 1.1",
   # NOTE(ww): ruff is under active development, so we pin conservatively here
   # and let Dependabot periodically perform this update.
-  "ruff < 0.1.2",
+  "ruff < 0.1.4",
   "types-requests",
   # TODO(ww): Re-enable once dependency on types-cryptography is dropped.
   # See: https://github.com/python/typeshed/issues/8699

--- a/sigstore/verify/models.py
+++ b/sigstore/verify/models.py
@@ -390,8 +390,7 @@ class VerificationMaterials:
 
         offline = self._offline
         has_inclusion_promise = (
-            self.has_rekor_entry
-            and self._rekor_entry.inclusion_promise is not None  # type: ignore
+            self.has_rekor_entry and self._rekor_entry.inclusion_promise is not None  # type: ignore
         )
         has_inclusion_proof = (
             self.has_rekor_entry

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -68,9 +68,9 @@ class LogEntryMissing(VerificationFailure):
     with additional lookup context.
     """
 
-    reason: str = (
-        "The transparency log has no entry for the given verification materials"
-    )
+    reason: (
+        str
+    ) = "The transparency log has no entry for the given verification materials"
 
     signature: B64Str
     """

--- a/test/unit/internal/test_sct.py
+++ b/test/unit/internal/test_sct.py
@@ -48,16 +48,19 @@ def test_pack_digitally_signed_precertificate(precert_bytes_len):
     _, l1, l2, l3 = struct.unpack("!4c", struct.pack("!I", len(precert_bytes)))
 
     data = sct._pack_digitally_signed(mock_sct, cert, issuer_key_hash)
-    assert data == (
-        b"\x00"  # version
-        b"\x00"  # signature type
-        b"\x00\x00\x00\x00\x00\x00\x04\xd2"  # timestamp
-        b"\x00\x01"  # entry type
-        b"iamapublickeyshatwofivesixdigest"  # issuer key hash
-        + l1
-        + l2
-        + l3  # tbs cert length
-        + precert_bytes  # tbs cert
-        + b"\x00\x00"  # extensions length
-        + b""  # extensions
+    assert (
+        data
+        == (
+            b"\x00"  # version
+            b"\x00"  # signature type
+            b"\x00\x00\x00\x00\x00\x00\x04\xd2"  # timestamp
+            b"\x00\x01"  # entry type
+            b"iamapublickeyshatwofivesixdigest"  # issuer key hash
+            + l1
+            + l2
+            + l3  # tbs cert length
+            + precert_bytes  # tbs cert
+            + b"\x00\x00"  # extensions length
+            + b""  # extensions
+        )
     )


### PR DESCRIPTION
This speeds up our `lint` and `reformat` targets a bit, and drops a dev dependency (since we're already using ruff).
