### PR TITLE
cli: search for `{input}.sigstore.json` by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build
 *.pub
 *.rekor
 *.sigstore
+*.sigstore.json
 
 # Don't ignore these files when we intend to include them
 !sigstore/_store/*.crt


### PR DESCRIPTION
This tweaks the default input collection in `sigstore verify`, allowing `{input}.sigstore.json` to take priority when attempting to discover "implicit" inputs. 

`{input}.sigstore` is also still discovered, preserving compatibility with existing outputs. However, discovering it now produces a logged warning telling the user that a future release will deprecate `.sigstore` in favor of `.sigstore.json`.

See https://github.com/sigstore/sigstore-python/issues/814.