### PR TITLE
_cli: use rich's logging handler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "pyjwt >= 2.1",
   "pyOpenSSL >= 23.0.0",
   "requests",
+  "rich ~= 13.0",
   "securesystemslib",
   "sigstore-protobuf-specs ~= 0.2.2",
   "sigstore-rekor-types >= 0.0.11",

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -24,6 +24,7 @@ from textwrap import dedent
 from typing import NoReturn, Optional, TextIO, Union, cast
 
 from cryptography.x509 import load_pem_x509_certificates
+from rich.logging import RichHandler
 from sigstore_protobuf_specs.dev.sigstore.bundle.v1 import Bundle
 
 from sigstore import __version__
@@ -61,7 +62,7 @@ from sigstore.verify import (
 )
 from sigstore.verify.models import VerificationFailure
 
-logging.basicConfig()
+logging.basicConfig(format="%(message)s", datefmt="[%X]", handlers=[RichHandler()])
 logger = logging.getLogger(__name__)
 
 # NOTE: We configure the top package logger, rather than the root logger,


### PR DESCRIPTION
This adds `rich` as a dependency, using its `RichHandler` logging handler to make our logging much prettier by default (when invoked from the CLI).

I'm not 100% sure this is worth it; opening for discussion/consideration 🙂 

Pros:

* Makes our logging much easier to read/visually distinguish. This is particularly helpful for cases where we use `logger.warning(...)` to emit deprecation notices, which otherwise could be missed in the monochromatic/unformatted output.

Cons:

* Heavyweight?

Demo:

[![asciicast](https://asciinema.org/a/SLESuadskrCIMJMnZvLFOaI0N.svg)](https://asciinema.org/a/SLESuadskrCIMJMnZvLFOaI0N)