### PR TITLE
pyproject: sigstore-rekor-types==0.0.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
   "rich ~= 13.0",
   "securesystemslib",
   "sigstore-protobuf-specs ~= 0.2.2",
-  "sigstore-rekor-types >= 0.0.11",
+  # NOTE(ww): Under active development, so strictly pinned.
+  "sigstore-rekor-types == 0.0.11",
   "tuf >= 2.1,< 4.0",
 ]
 requires-python = ">=3.8"


### PR DESCRIPTION
I've yanked 0.0.12 so the error is no longer manifest, but this will prevent us (meaning me) from accidentally breaking everything when I make incompatible changes.

Once this is in, we should cut a point release to propagate it. From there, we can cut a new release of `sigstore-rekor-types` and conservatively upgrade to it.

xref https://github.com/sigstore/gh-action-sigstore-python/issues/94