### PR TITLE
dependabot: Manage the internal action as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,10 @@ updates:
       interval: daily
     open-pull-requests-limit: 99
     rebase-strategy: "disabled"
+
+  - package-ecosystem: github-actions
+    directory: .github/actions/upload-coverage/
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 99
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Make the internal action in .github/actions/upload-coverage managed by dependabot. 

This (and the resulting dependabot PR) should unblock #835