### PR TITLE
Refactor upload-coverage action

### DIFF
--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
     - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
-        name: coverage-data
+        name: coverage-data-${{ steps.coverage-uuid.outputs.COVERAGE_UUID }}
         path: |
           .coverage.*
           *.lcov

--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -20,7 +20,7 @@ runs:
         fi
       id: coverage-uuid
       shell: bash
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
       with:
         name: coverage-data-${{ steps.coverage-uuid.outputs.COVERAGE_UUID }}
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,12 +93,13 @@ jobs:
       - name: download coverage data
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
-          name: coverage-data
+          path: all-artifacts/
 
       - name: combine coverage data
         id: combinecoverage
         run: |
           set +e
+          cp all-artifacts/coverage-data-*/.coverage.* .
           python -m coverage combine
           echo "## python coverage" >> $GITHUB_STEP_SUMMARY
           python -m coverage report -m --format=markdown >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - run: pip install coverage[toml]
 
       - name: download coverage data
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4 # v4.0.0
         with:
           path: all-artifacts/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,6 @@ jobs:
         id: combinecoverage
         run: |
           set +e
-          cp all-artifacts/coverage-data-*/.coverage.* .
-          python -m coverage combine
+          python -m coverage combine all-artifacts/coverage-data-*
           echo "## python coverage" >> $GITHUB_STEP_SUMMARY
           python -m coverage report -m --format=markdown >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,14 +83,14 @@ jobs:
           echo "hashes=$(sha256sum ./dist/* | base64 -w0)" >> $GITHUB_OUTPUT
 
       - name: Upload built packages
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: built-packages
           path: ./dist/
           if-no-files-found: warn
 
       - name: Upload smoketest-artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: smoketest-artifacts
           path: smoketest-artifacts/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts directories # goes to current working directory
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4 # v4.0.0
 
       - name: publish
         uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf # v1.8.11
@@ -134,7 +134,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifacts directories # goes to current working directory
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4 # v4.0.0
 
       - name: Upload artifacts to github
         # Confusingly, this action also supports updating releases, not

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -44,7 +44,7 @@ jobs:
 
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
#### Summary

Refactor upload-coverage to enable upgrading the upload-artifact and download-artifact actions (as the new upload-artifact does not allow uploading with the same name several times).
* Use unique artifact names, then download all artifacts before combining them for coverage
* Upgrade the actions

#### Release Note

N/A
