### PR TITLE
dependabot: group GHA updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
       interval: daily
     open-pull-requests-limit: 99
     rebase-strategy: "disabled"
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: .github/actions/upload-coverage/
@@ -19,3 +23,7 @@ updates:
       interval: daily
     open-pull-requests-limit: 99
     rebase-strategy: "disabled"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This will cut our automated PR volume down slightly: GHA updates from Dependabot will now be batched into one big PR, rather than one PR per updated action.