### PR TITLE
feat: Enable signing with pre-computed hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ All versions prior to 0.9.0 are untracked.
 
 ### Added
 
+* API: `Signer.sign()` can now take a `Hashed` as an input,
+  performing a signature on a pre-computed hash value
+  ([#860](https://github.com/sigstore/sigstore-python/pull/860))
+
 * API: `Signer.sign()` can now take an in-toto `Statement` as an input,
   producing a DSSE-formatted signature rather than a "bare" signature
   ([#804](https://github.com/sigstore/sigstore-python/pull/804))
-
 
 * API: `SigningResult.content` has been added, representing either the
   `hashedrekord` entry's message signature or the `dsse` entry's envelope

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -686,21 +686,9 @@ def _sign(args: argparse.Namespace) -> None:
     with signing_ctx.signer(identity) as signer:
         for file, outputs in output_map.items():
             logger.debug(f"signing for {file.name}")
-            with file.open(mode="rb", buffering=0) as iof:
+            with file.open(mode="rb", buffering=0) as io:
                 try:
-                    import hashlib
-                    import io
-                    from sigstore import hashes as sigstore_hashes
-                    from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
-
-                    hash = hashlib.sha256()
-                    hash.update(iof.read())
-                    digest = hash.digest()
-                    print(digest.hex())
-                    hashed = sigstore_hashes.Hashed(digest=digest, algorithm=HashAlgorithm.SHA2_256)
-                    result = signer.sign(hashed)
-
-                    #result = signer.sign(input_=io)
+                    result = signer.sign(input_=io)
                 except ExpiredIdentity as exp_identity:
                     print("Signature failed: identity token has expired")
                     raise exp_identity

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -686,7 +686,7 @@ def _sign(args: argparse.Namespace) -> None:
     with signing_ctx.signer(identity) as signer:
         for file, outputs in output_map.items():
             logger.debug(f"signing for {file.name}")
-            with file.open(mode="rb", buffering=0) as io:
+            with file.open(mode="rb", buffering=0) as fio:
                 try:
                     result = signer.sign(input_=io)
                 except ExpiredIdentity as exp_identity:

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -686,9 +686,21 @@ def _sign(args: argparse.Namespace) -> None:
     with signing_ctx.signer(identity) as signer:
         for file, outputs in output_map.items():
             logger.debug(f"signing for {file.name}")
-            with file.open(mode="rb", buffering=0) as io:
+            with file.open(mode="rb", buffering=0) as iof:
                 try:
-                    result = signer.sign(input_=io)
+                    import hashlib
+                    import io
+                    from sigstore import hashes as sigstore_hashes
+                    from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
+
+                    hash = hashlib.sha256()
+                    hash.update(iof.read())
+                    digest = hash.digest()
+                    print(digest.hex())
+                    hashed = sigstore_hashes.Hashed(digest=digest, algorithm=HashAlgorithm.SHA2_256)
+                    result = signer.sign(hashed)
+
+                    #result = signer.sign(input_=io)
                 except ExpiredIdentity as exp_identity:
                     print("Signature failed: identity token has expired")
                     raise exp_identity

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -688,7 +688,7 @@ def _sign(args: argparse.Namespace) -> None:
             logger.debug(f"signing for {file.name}")
             with file.open(mode="rb", buffering=0) as io:
                 try:
-                    result = signer.sign(input_=iof)
+                    result = signer.sign(input_=io)
                 except ExpiredIdentity as exp_identity:
                     print("Signature failed: identity token has expired")
                     raise exp_identity

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -688,7 +688,21 @@ def _sign(args: argparse.Namespace) -> None:
             logger.debug(f"signing for {file.name}")
             with file.open(mode="rb", buffering=0) as io:
                 try:
-                    result = signer.sign(input_=io)
+                    # NOTE: This is where signin is performed.
+                    import hashlib, io
+                    from cryptography.hazmat.primitives import hashes
+                    from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+                    class DIRHASH_SHARD1G_SHA256(hashes.HashAlgorithm):
+                        name = "dirhash_shard1G_sha256"
+                        digest_size = 32
+                        block_size = -1
+
+                    hash = hashlib.sha256()
+                    hash.update(iof.read())
+                    content = hash.digest()
+                    contentio = io.BytesIO(content)
+                    result = signer.sign(contentio, Prehashed(DIRHASH_SHARD1G_SHA256()))
+                    #result = signer.sign(input_=iof)
                 except ExpiredIdentity as exp_identity:
                     print("Signature failed: identity token has expired")
                     raise exp_identity

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -686,7 +686,7 @@ def _sign(args: argparse.Namespace) -> None:
     with signing_ctx.signer(identity) as signer:
         for file, outputs in output_map.items():
             logger.debug(f"signing for {file.name}")
-            with file.open(mode="rb", buffering=0) as fio:
+            with file.open(mode="rb", buffering=0) as io:
                 try:
                     result = signer.sign(input_=io)
                 except ExpiredIdentity as exp_identity:

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -688,21 +688,7 @@ def _sign(args: argparse.Namespace) -> None:
             logger.debug(f"signing for {file.name}")
             with file.open(mode="rb", buffering=0) as io:
                 try:
-                    # NOTE: This is where signin is performed.
-                    import hashlib, io
-                    from cryptography.hazmat.primitives import hashes
-                    from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
-                    class DIRHASH_SHARD1G_SHA256(hashes.HashAlgorithm):
-                        name = "dirhash_shard1G_sha256"
-                        digest_size = 32
-                        block_size = -1
-
-                    hash = hashlib.sha256()
-                    hash.update(iof.read())
-                    content = hash.digest()
-                    contentio = io.BytesIO(content)
-                    result = signer.sign(contentio, Prehashed(DIRHASH_SHARD1G_SHA256()))
-                    #result = signer.sign(input_=iof)
+                    result = signer.sign(input_=iof)
                 except ExpiredIdentity as exp_identity:
                     print("Signature failed: identity token has expired")
                     raise exp_identity

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -175,7 +175,7 @@ def get_digest(
     if isinstance(algorithm_, Prehashed):
         # Check we have a 256-bit digest size for compatibility with secp256r1.
         if algorithm_.digest_size != 32:
-            return ValueError(f"invalid digest size ({algorithm_.digest_size()}), expected 32")
+            return ValueError(f"invalid digest size ({algorithm_.digest_size}), expected 32")
         return input_.getvalue(), algorithm_
 
     raise ValueError("invalid arguments")

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -35,6 +35,7 @@ from cryptography.x509 import (
 from cryptography.x509.oid import ExtendedKeyUsageOID, ExtensionOID
 
 from sigstore.errors import Error
+from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
 if sys.version_info < (3, 11):
     import importlib_resources as resources
@@ -157,6 +158,12 @@ def key_id(key: PublicKey) -> KeyID:
     )
 
     return KeyID(hashlib.sha256(public_bytes).digest())
+
+def hazmat_digest_to_bundle(algo: str):
+    lookup = {"sha256": HashAlgorithm.SHA2_256}
+    if algo in lookup:
+        return lookup[algo]
+    return algo
 
 def get_digest(
         input_: IO[bytes],

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -159,11 +159,11 @@ def key_id(key: PublicKey) -> KeyID:
 
     return KeyID(hashlib.sha256(public_bytes).digest())
 
-def hazmat_digest_to_bundle(algo: str):
-    lookup = {"sha256": HashAlgorithm.SHA2_256}
+def hazmat_digest_to_bundle(algo: str) -> HashAlgorithm:
+    lookup = {hashes.SHA256().name: HashAlgorithm.SHA2_256}
     if algo in lookup:
-        return lookup[algo]
-    return algo
+        return HashAlgorithm(lookup[algo])
+    return ValueError(f"unknown digest algorithm {algo}")
 
 def get_digest(
         input_: IO[bytes],

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -25,17 +25,12 @@ from typing import IO, NewType, Union
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
-<<<<<<< HEAD
-from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 from cryptography.x509 import (
     Certificate,
     ExtensionNotFound,
     Version,
     load_der_x509_certificate,
 )
-=======
-from cryptography.x509 import Certificate, ExtensionNotFound, Version
->>>>>>> f67b019 (Change API)
 from cryptography.x509.oid import ExtendedKeyUsageOID, ExtensionOID
 from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -23,8 +23,7 @@ import hashlib
 import sys
 from typing import IO, NewType, Union
 
-import rekor_types
-from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 from cryptography.x509 import (
@@ -162,7 +161,7 @@ def key_id(key: PublicKey) -> KeyID:
 def get_digest(
         input_: IO[bytes],
         algorithm_: Prehashed = None,
-    ) -> (bytes, Prehashed): 
+    ) -> (bytes, Prehashed):
     if algorithm_ is None:
         return sha256_streaming(input_), Prehashed(hashes.SHA256())
 
@@ -171,7 +170,7 @@ def get_digest(
         if algorithm_.digest_size != 32:
             return ValueError(f"invalid digest size ({algorithm_.digest_size()}), expected 32")
         return input_.getvalue(), algorithm_
-    
+
     raise ValueError("invalid arguments")
 
 def sha256_streaming(io: IO[bytes]) -> bytes:

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -164,13 +164,15 @@ def key_id(key: PublicKey) -> KeyID:
 
     return KeyID(hashlib.sha256(public_bytes).digest())
 
+
 def get_digest(input_: IO[bytes] | sigstore_hashes.Hashed) -> sigstore_hashes.Hashed:
     if isinstance(input_, sigstore_hashes.Hashed):
         return input_
 
-    # NOTE: Not able to check for the type `TypeError: Subscripted generics cannot be used with class and instance checks`
-    # when calling isinstance(_input, IO[bytes])
-    return sigstore_hashes.Hashed(digest=sha256_streaming(input_), algorithm=HashAlgorithm.SHA2_256)
+    return sigstore_hashes.Hashed(
+        digest=sha256_streaming(input_), algorithm=HashAlgorithm.SHA2_256
+    )
+
 
 def sha256_streaming(io: IO[bytes]) -> bytes:
     """

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -33,9 +33,9 @@ from cryptography.x509 import (
     load_der_x509_certificate,
 )
 from cryptography.x509.oid import ExtendedKeyUsageOID, ExtensionOID
+from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
 from sigstore.errors import Error
-from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
 if sys.version_info < (3, 11):
     import importlib_resources as resources

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -168,7 +168,7 @@ def get_digest(
 
     if isinstance(algorithm_, Prehashed):
         # Check we have a 256-bit digest size for compatibility with secp256r1.
-        if algorithm_.digest_size() != 32:
+        if algorithm_.digest_size != 32:
             return ValueError(f"invalid digest size ({algorithm_.digest_size()}), expected 32")
         return input_.getvalue(), algorithm_
     

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -161,6 +161,10 @@ def key_id(key: PublicKey) -> KeyID:
 
 
 def get_digest(input_: IO[bytes] | sigstore_hashes.Hashed) -> sigstore_hashes.Hashed:
+    """
+    Compute the SHA256 digest of an input stream or, if given a `Hashed`,
+    return it directly.
+    """
     if isinstance(input_, sigstore_hashes.Hashed):
         return input_
 

--- a/sigstore/hashes.py
+++ b/sigstore/hashes.py
@@ -15,6 +15,7 @@
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 from pydantic import BaseModel
+import rekor_types
 from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
 
@@ -33,11 +34,13 @@ class Hashed(BaseModel):
     The digest representing the hash value.
     """
 
-    def as_prehashed(self) -> Prehashed:
-        return Prehashed(self.hazmat_algorithm())
-
-    def hazmat_algorithm(self) -> hashes.HashAlgorithm:
+    def as_hashedrekord_algorithm(self) -> rekor_types.hashedrekord.Algorithm:
         if self.algorithm == HashAlgorithm.SHA2_256:
-            return hashes.SHA256()
-        # Add more hashes here.
+            return rekor_types.hashedrekord.Algorithm.SHA256
         raise ValueError(f"unknown hash algorithm: {self.algorithm}")
+
+    def as_prehashed(self) -> Prehashed:
+        if self.algorithm == HashAlgorithm.SHA2_256:
+            return Prehashed(hashes.SHA256())
+        raise ValueError(f"unknown hash algorithm: {self.algorithm}")
+

--- a/sigstore/hashes.py
+++ b/sigstore/hashes.py
@@ -19,11 +19,6 @@ from pydantic import BaseModel
 from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
 
-class DIRSHA256_P1(hashes.HashAlgorithm):
-    name = "dirsha256-p1"
-    digest_size = 32
-    block_size = -1
-
 class Hashed(BaseModel):
     """
     Represents hashed value.
@@ -45,6 +40,5 @@ class Hashed(BaseModel):
     def hazmat_algorithm(self) -> hashes.HashAlgorithm:
         if self.algorithm == HashAlgorithm.SHA2_256:
             return hashes.SHA256()
-        if self.algorithm == HashAlgorithm.HASH_ALGORITHM_UNSPECIFIED:
-            return DIRSHA256_P1()
+        # Add more hashes here.
         raise ValueError(f"unknown hash algorithm: {self.algorithm}")

--- a/sigstore/hashes.py
+++ b/sigstore/hashes.py
@@ -35,11 +35,17 @@ class Hashed(BaseModel):
     """
 
     def _as_hashedrekord_algorithm(self) -> rekor_types.hashedrekord.Algorithm:
+        """
+        Returns an appropriate `hashedrekord.Algorithm` for this `Hashed`.
+        """
         if self.algorithm == HashAlgorithm.SHA2_256:
             return rekor_types.hashedrekord.Algorithm.SHA256
         raise ValueError(f"unknown hash algorithm: {self.algorithm}")
 
     def _as_prehashed(self) -> Prehashed:
+        """
+        Returns an appropriate Cryptography `Prehashed` for this `Hashed`.
+        """
         if self.algorithm == HashAlgorithm.SHA2_256:
             return Prehashed(hashes.SHA256())
         raise ValueError(f"unknown hash algorithm: {self.algorithm}")

--- a/sigstore/hashes.py
+++ b/sigstore/hashes.py
@@ -1,0 +1,50 @@
+
+# Copyright 2023 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+from pydantic import BaseModel
+from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
+
+
+class DIRSHA256_P1(hashes.HashAlgorithm):
+    name = "dirsha256-p1"
+    digest_size = 32
+    block_size = -1
+
+class Hashed(BaseModel):
+    """
+    Represents hashed value.
+    """
+
+    algorithm: HashAlgorithm
+    """
+    The digest algorithm uses to compute the digest.
+    """
+
+    digest: bytes
+    """
+    The digest representing the hash value.
+    """
+
+    def as_prehashed(self) -> Prehashed:
+        return Prehashed(self.hazmat_algorithm())
+
+    def hazmat_algorithm(self) -> hashes.HashAlgorithm:
+        if self.algorithm == HashAlgorithm.SHA2_256:
+            return hashes.SHA256()
+        if self.algorithm == HashAlgorithm.HASH_ALGORITHM_UNSPECIFIED:
+            return DIRSHA256_P1()
+        raise ValueError(f"unknown hash algorithm: {self.algorithm}")

--- a/sigstore/hashes.py
+++ b/sigstore/hashes.py
@@ -21,7 +21,7 @@ from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
 class Hashed(BaseModel):
     """
-    Represents hashed value.
+    Represents a hashed value.
     """
 
     algorithm: HashAlgorithm

--- a/sigstore/hashes.py
+++ b/sigstore/hashes.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import rekor_types
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 from pydantic import BaseModel
-import rekor_types
 from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
 
@@ -43,4 +43,3 @@ class Hashed(BaseModel):
         if self.algorithm == HashAlgorithm.SHA2_256:
             return Prehashed(hashes.SHA256())
         raise ValueError(f"unknown hash algorithm: {self.algorithm}")
-

--- a/sigstore/hashes.py
+++ b/sigstore/hashes.py
@@ -1,4 +1,3 @@
-
 # Copyright 2023 The Sigstore Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/sigstore/hashes.py
+++ b/sigstore/hashes.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Hashing APIs.
+"""
+
 import rekor_types
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed

--- a/sigstore/hashes.py
+++ b/sigstore/hashes.py
@@ -34,12 +34,12 @@ class Hashed(BaseModel):
     The digest representing the hash value.
     """
 
-    def as_hashedrekord_algorithm(self) -> rekor_types.hashedrekord.Algorithm:
+    def _as_hashedrekord_algorithm(self) -> rekor_types.hashedrekord.Algorithm:
         if self.algorithm == HashAlgorithm.SHA2_256:
             return rekor_types.hashedrekord.Algorithm.SHA256
         raise ValueError(f"unknown hash algorithm: {self.algorithm}")
 
-    def as_prehashed(self) -> Prehashed:
+    def _as_prehashed(self) -> Prehashed:
         if self.algorithm == HashAlgorithm.SHA2_256:
             return Prehashed(hashes.SHA256())
         raise ValueError(f"unknown hash algorithm: {self.algorithm}")

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -82,7 +82,11 @@ from sigstore._internal.fulcio import (
 from sigstore._internal.rekor.client import RekorClient
 from sigstore._internal.sct import verify_sct
 from sigstore._internal.trustroot import TrustedRoot
+<<<<<<< HEAD
 from sigstore._utils import PEMCert, sha256_streaming
+=======
+from sigstore._utils import B64Str, HexStr, PEMCert, get_digest
+>>>>>>> 442469b (backup)
 from sigstore.oidc import ExpiredIdentity, IdentityToken
 from sigstore.transparency import LogEntry
 

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -57,7 +57,6 @@ from sigstore_protobuf_specs.dev.sigstore.bundle.v1 import (
     VerificationMaterial,
 )
 from sigstore_protobuf_specs.dev.sigstore.common.v1 import (
-    HashAlgorithm,
     HashOutput,
     LogId,
     MessageSignature,
@@ -82,11 +81,7 @@ from sigstore._internal.fulcio import (
 from sigstore._internal.rekor.client import RekorClient
 from sigstore._internal.sct import verify_sct
 from sigstore._internal.trustroot import TrustedRoot
-<<<<<<< HEAD
-from sigstore._utils import PEMCert, sha256_streaming
-=======
-from sigstore._utils import B64Str, HexStr, PEMCert, get_digest
->>>>>>> 442469b (backup)
+from sigstore._utils import PEMCert, get_digest, sha256_streaming
 from sigstore.oidc import ExpiredIdentity, IdentityToken
 from sigstore.transparency import LogEntry
 
@@ -178,10 +173,6 @@ class Signer:
 
             return certificate_response
 
-    # https://github.com/sigstore/rekor/issues/1299
-    # https://github.com/pyca/cryptography/blob/00f8304a3dfe7a2aab6f3150a3c620e87d848044/src/cryptography/hazmat/primitives/hashes.py
-    # https://github.com/pyca/cryptography/blob/00f8304a3dfe7a2aab6f3150a3c620e87d848044/src/cryptography/hazmat/primitives/asymmetric/utils.py#L14
-    # https://github.com/pyca/cryptography/blob/main/src/cryptography/hazmat/primitives/asymmetric/rsa.py#L42
     def sign(
         self,
         input_: IO[bytes] | Statement,

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -221,7 +221,7 @@ class Signer:
             hashed_input = get_digest(input_)
 
             artifact_signature = private_key.sign(
-                hashed_input.digest, ec.ECDSA(hashed_input.as_prehashed())
+                hashed_input.digest, ec.ECDSA(hashed_input._as_prehashed())
             )
 
             content = MessageSignature(
@@ -243,7 +243,7 @@ class Signer:
                     ),
                     data=rekor_types.hashedrekord.Data(
                         hash=rekor_types.hashedrekord.Hash(
-                            algorithm=hashed_input.as_hashedrekord_algorithm(),
+                            algorithm=hashed_input._as_hashedrekord_algorithm(),
                             value=hashed_input.digest.hex(),
                         )
                     ),

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -178,6 +178,7 @@ class Signer:
 
             return certificate_response
 
+    # https://github.com/sigstore/rekor/issues/1299
     # https://github.com/pyca/cryptography/blob/00f8304a3dfe7a2aab6f3150a3c620e87d848044/src/cryptography/hazmat/primitives/hashes.py
     # https://github.com/pyca/cryptography/blob/00f8304a3dfe7a2aab6f3150a3c620e87d848044/src/cryptography/hazmat/primitives/asymmetric/utils.py#L14
     # https://github.com/pyca/cryptography/blob/main/src/cryptography/hazmat/primitives/asymmetric/rsa.py#L42

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -49,7 +49,6 @@ import cryptography.x509 as x509
 import rekor_types
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 from cryptography.x509.oid import NameOID
 from in_toto_attestation.v1.statement import Statement
 from sigstore_protobuf_specs.dev.sigstore.bundle.v1 import (
@@ -57,6 +56,7 @@ from sigstore_protobuf_specs.dev.sigstore.bundle.v1 import (
     VerificationMaterial,
 )
 from sigstore_protobuf_specs.dev.sigstore.common.v1 import (
+    HashAlgorithm,
     HashOutput,
     LogId,
     MessageSignature,
@@ -73,6 +73,7 @@ from sigstore_protobuf_specs.dev.sigstore.rekor.v1 import (
 from sigstore_protobuf_specs.io.intoto import Envelope
 
 from sigstore._internal import dsse
+from sigstore import hashes as sigstore_hashes
 from sigstore._internal.fulcio import (
     ExpiredCertificate,
     FulcioCertificateSigningResponse,

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -174,6 +174,9 @@ class Signer:
 
             return certificate_response
 
+    # https://github.com/pyca/cryptography/blob/00f8304a3dfe7a2aab6f3150a3c620e87d848044/src/cryptography/hazmat/primitives/hashes.py
+    # https://github.com/pyca/cryptography/blob/00f8304a3dfe7a2aab6f3150a3c620e87d848044/src/cryptography/hazmat/primitives/asymmetric/utils.py#L14
+    # https://github.com/pyca/cryptography/blob/main/src/cryptography/hazmat/primitives/asymmetric/rsa.py#L42
     def sign(
         self,
         input_: IO[bytes] | Statement,

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -227,7 +227,7 @@ class Signer:
             content = MessageSignature(
                 message_digest=HashOutput(
                     algorithm=hashed_input.algorithm,
-                    digest=hashed_input.digest.hex(),
+                    digest=hashed_input.digest,
                 ),
                 signature=artifact_signature,
             )

--- a/sigstore/verify/models.py
+++ b/sigstore/verify/models.py
@@ -511,7 +511,7 @@ class VerificationMaterials:
             message_signature=MessageSignature(
                 message_digest=HashOutput(
                     algorithm=self.hashed_input.algorithm,
-                    digest=self.hashed_input.digest.hex(),
+                    digest=self.hashed_input.digest,
                 ),
                 signature=self.signature,
             ),

--- a/sigstore/verify/models.py
+++ b/sigstore/verify/models.py
@@ -39,7 +39,6 @@ from sigstore_protobuf_specs.dev.sigstore.bundle.v1 import (
     VerificationMaterial,
 )
 from sigstore_protobuf_specs.dev.sigstore.common.v1 import (
-    HashAlgorithm,
     HashOutput,
     LogId,
     MessageSignature,

--- a/sigstore/verify/models.py
+++ b/sigstore/verify/models.py
@@ -180,7 +180,7 @@ class VerificationMaterials:
     Represents the materials needed to perform a Sigstore verification.
     """
 
-    digest_algorithm: bytes
+    digest_algorithm: Prehashed
     """
     The digest algorithm to use for the hash.
     """
@@ -425,7 +425,7 @@ class VerificationMaterials:
                 data=rekor_types.hashedrekord.Data(
                     hash=rekor_types.hashedrekord.Hash(
                         #algorithm=sigstore_rekor_types.Algorithm.SHA256,
-                        algorithm=self.digest_algorithm,
+                        algorithm=self.digest_algorithm._algorithm.name,
                         value=self.input_digest.hex(),
                     ),
                 ),

--- a/sigstore/verify/models.py
+++ b/sigstore/verify/models.py
@@ -63,6 +63,7 @@ from sigstore._utils import (
     cert_is_leaf,
     cert_is_root_ca,
     get_digest,
+    hazmat_digest_to_bundle,
 )
 from sigstore.errors import Error
 from sigstore.transparency import LogEntry, LogInclusionProof
@@ -518,7 +519,7 @@ class VerificationMaterials:
             ),
             message_signature=MessageSignature(
                 message_digest=HashOutput(
-                    algorithm=HashAlgorithm.SHA2_256,
+                    algorithm=hazmat_digest_to_bundle(self.digest_algorithm._algorithm.name),
                     digest=self.input_digest,
                 ),
                 signature=self.signature,

--- a/sigstore/verify/models.py
+++ b/sigstore/verify/models.py
@@ -416,7 +416,7 @@ class VerificationMaterials:
                 ),
                 data=rekor_types.hashedrekord.Data(
                     hash=rekor_types.hashedrekord.Hash(
-                        algorithm=self.hashed_input.as_hashedrekord_algorithm(),
+                        algorithm=self.hashed_input._as_hashedrekord_algorithm(),
                         value=self.hashed_input.digest.hex(),
                     ),
                 ),

--- a/sigstore/verify/models.py
+++ b/sigstore/verify/models.py
@@ -416,7 +416,7 @@ class VerificationMaterials:
                 ),
                 data=rekor_types.hashedrekord.Data(
                     hash=rekor_types.hashedrekord.Hash(
-                        algorithm=self.hashed_input.hazmat_algorithm().name,
+                        algorithm=self.hashed_input.as_hashedrekord_algorithm(),
                         value=self.hashed_input.digest.hex(),
                     ),
                 ),
@@ -511,7 +511,7 @@ class VerificationMaterials:
             message_signature=MessageSignature(
                 message_digest=HashOutput(
                     algorithm=self.hashed_input.algorithm,
-                    digest=self.hashed_input.digest,
+                    digest=self.hashed_input.digest.hex(),
                 ),
                 signature=self.signature,
             ),

--- a/sigstore/verify/models.py
+++ b/sigstore/verify/models.py
@@ -26,8 +26,8 @@ from textwrap import dedent
 from typing import IO
 
 import rekor_types
-from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509 import (
     Certificate,
     load_der_x509_certificate,
@@ -184,7 +184,7 @@ class VerificationMaterials:
     """
     The digest algorithm to use for the hash.
     """
-    
+
     input_digest: bytes
     """
     The 'digest_algorithm' hash of the verification input, as raw bytes.
@@ -424,7 +424,6 @@ class VerificationMaterials:
                 ),
                 data=rekor_types.hashedrekord.Data(
                     hash=rekor_types.hashedrekord.Hash(
-                        #algorithm=sigstore_rekor_types.Algorithm.SHA256,
                         algorithm=self.digest_algorithm._algorithm.name,
                         value=self.input_digest.hex(),
                     ),

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -24,9 +24,7 @@ import logging
 from typing import List, cast
 
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 from cryptography.x509 import Certificate, ExtendedKeyUsage, KeyUsage
 from cryptography.x509.oid import ExtendedKeyUsageOID
 from OpenSSL.crypto import (
@@ -227,7 +225,6 @@ class Verifier:
                 materials.signature,
                 materials.input_digest,
                 ec.ECDSA(materials.digest_algorithm),
-                #ec.ECDSA(Prehashed(hashes.SHA256())),
             )
         except InvalidSignature:
             return VerificationFailure(reason="Signature is invalid for input")

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -226,7 +226,8 @@ class Verifier:
             signing_key.verify(
                 materials.signature,
                 materials.input_digest,
-                ec.ECDSA(Prehashed(hashes.SHA256())),
+                ec.ECDSA(materials.digest_algorithm),
+                #ec.ECDSA(Prehashed(hashes.SHA256())),
             )
         except InvalidSignature:
             return VerificationFailure(reason="Signature is invalid for input")

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -224,7 +224,7 @@ class Verifier:
             signing_key.verify(
                 materials.signature,
                 materials.hashed_input.digest,
-                ec.ECDSA(materials.hashed_input.as_prehashed()),
+                ec.ECDSA(materials.hashed_input._as_prehashed()),
             )
         except InvalidSignature:
             return VerificationFailure(reason="Signature is invalid for input")

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -223,8 +223,8 @@ class Verifier:
             signing_key = cast(ec.EllipticCurvePublicKey, signing_key)
             signing_key.verify(
                 materials.signature,
-                materials.input_digest,
-                ec.ECDSA(materials.digest_algorithm),
+                materials.hashed_input.digest,
+                ec.ECDSA(materials.hashed_input.as_prehashed()),
             )
         except InvalidSignature:
             return VerificationFailure(reason="Signature is invalid for input")
@@ -239,7 +239,7 @@ class Verifier:
         except RekorEntryMissingError:
             return LogEntryMissing(
                 signature=B64Str(base64.b64encode(materials.signature).decode()),
-                artifact_hash=HexStr(materials.input_digest.hex()),
+                artifact_hash=HexStr(materials.hashed_input.digest.hex()),
             )
         except InvalidRekorEntryError:
             return VerificationFailure(


### PR DESCRIPTION
closes https://github.com/sigstore/sigstore-python/issues/666

Let me know if you'd like me to add a dedicated unit test for this new option.

Context: I'm working on adding a new hash type to rekor to support hashing directories. I will need to follow up to add support for it in https://github.com/trailofbits/sigstore-rekor-types. 

Test example with pre-computed sha256:
```python
from sigstore import hashes as sigstore_hashes
from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm

with file.open(mode="rb", buffering=0) as io:
    digest = hashlib.sha256(io.read())
    hashed = sigstore_hashes.Hashed(digest=digest, algorithm=HashAlgorithm.SHA2_256)
    result = signer.sign(hashed)
```
#### Summary

This PR enables passing a pre-hashed value instead of the content to be hashed.

#### Release Note
<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->