### PR TITLE
API: remove SigningResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ All versions prior to 0.9.0 are untracked.
 
 ### Changed
 
-* **BREAKING API CHANGE**: `sigstore.sign.SigningResult` has been removed.
+* **BREAKING API CHANGE**: `sigstore.sign.SigningResult` has been removed
+  ([#862](https://github.com/sigstore/sigstore-python/pull/862))
 * **BREAKING API CHANGE**: The `Signer.sign(...)` API now returns a `Bundle`,
-  instead of a `SigningResult`.
+  instead of a `SigningResult` ([#862](https://github.com/sigstore/sigstore-python/pull/862))
 
 ## [2.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Changed
+
+* **BREAKING API CHANGE**: `sigstore.sign.SigningResult` has been removed.
+* **BREAKING API CHANGE**: The `Signer.sign(...)` API now returns a `Bundle`,
+  instead of a `SigningResult`.
+
 ## [2.1.0]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,7 @@ lint = [
   # and let Dependabot periodically perform this update.
   "ruff < 0.1.11",
   "types-requests",
-  # TODO(ww): Re-enable once dependency on types-cryptography is dropped.
-  # See: https://github.com/python/typeshed/issues/8699
-  # "types-pyOpenSSL",
+  "types-pyOpenSSL",
 ]
 doc = ["pdoc"]
 dev = ["build", "bump >= 1.3.2", "sigstore[doc,test,lint]"]

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -25,7 +25,12 @@ from typing import IO, NewType, Union
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
-from cryptography.x509 import Certificate, ExtensionNotFound, Version
+from cryptography.x509 import (
+    Certificate,
+    ExtensionNotFound,
+    Version,
+    load_der_x509_certificate,
+)
 from cryptography.x509.oid import ExtendedKeyUsageOID, ExtensionOID
 
 from sigstore.errors import Error
@@ -124,6 +129,19 @@ def base64_encode_pem_cert(cert: Certificate) -> B64Str:
     return B64Str(
         base64.b64encode(cert.public_bytes(serialization.Encoding.PEM)).decode()
     )
+
+
+def cert_der_to_pem(der: bytes) -> str:
+    """
+    Converts a DER-encoded X.509 certificate into its PEM encoding.
+
+    Returns a string containing a PEM-encoded X.509 certificate.
+    """
+
+    # NOTE: Technically we don't have to round-trip like this, since
+    # the DER-to-PEM transformation is entirely mechanical.
+    cert = load_der_x509_certificate(der)
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
 
 
 def key_id(key: PublicKey) -> KeyID:

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -29,7 +29,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 from cryptography.x509 import Certificate, ExtendedKeyUsage, KeyUsage
 from cryptography.x509.oid import ExtendedKeyUsageOID
-from OpenSSL.crypto import (  # type: ignore[import-untyped]
+from OpenSSL.crypto import (
     X509,
     X509Store,
     X509StoreContext,

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import base64
 import os
 import re

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -238,7 +238,7 @@ def tuf_dirs(monkeypatch, tmp_path):
     ],
     ids=["production", "staging"],
 )
-def id_config(request):
+def id_config(request) -> tuple[SigningContext, IdentityToken]:
     env, signer = request.param
     # Detect env variable for local interactive tests.
     token = os.getenv(f"SIGSTORE_IDENTITY_TOKEN_{env}")

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import io
 import secrets
 
@@ -49,7 +50,7 @@ def test_sign_rekor_entry_consistent(id_config):
 
     actual_entry = ctx._rekor.log.entries.get(log_index=expected_entry.log_index)
 
-    assert expected_entry.canonicalized_body == actual_entry.body
+    assert expected_entry.canonicalized_body == base64.b64decode(actual_entry.body)
     assert expected_entry.integrated_time == actual_entry.integrated_time
     assert expected_entry.log_id == actual_entry.log_id
     assert expected_entry.log_index == actual_entry.log_index
@@ -111,7 +112,7 @@ def test_identity_proof_claim_lookup(id_config, monkeypatch):
         expected_entry = signer.sign(payload).verification_material.tlog_entries[0]
     actual_entry = ctx._rekor.log.entries.get(log_index=expected_entry.log_index)
 
-    assert expected_entry.canonicalized_body == actual_entry.body
+    assert expected_entry.canonicalized_body == base64.b64decode(actual_entry.body)
     assert expected_entry.integrated_time == actual_entry.integrated_time
     assert expected_entry.log_id == actual_entry.log_id
     assert expected_entry.log_index == actual_entry.log_index

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -45,7 +45,7 @@ def test_sign_rekor_entry_consistent(id_config):
 
     payload = io.BytesIO(secrets.token_bytes(32))
     with ctx.signer(identity) as signer:
-        expected_entry = signer.sign(payload).log_entry
+        expected_entry = signer.sign(payload).verification_material.tlog_entries[0]
 
     actual_entry = ctx._rekor.log.entries.get(log_index=expected_entry.log_index)
 
@@ -109,7 +109,7 @@ def test_identity_proof_claim_lookup(id_config, monkeypatch):
     payload = io.BytesIO(secrets.token_bytes(32))
 
     with ctx.signer(identity) as signer:
-        expected_entry = signer.sign(payload).log_entry
+        expected_entry = signer.sign(payload).verification_material.tlog_entries[0]
     actual_entry = ctx._rekor.log.entries.get(log_index=expected_entry.log_index)
 
     assert expected_entry.uuid == actual_entry.uuid

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -52,7 +52,7 @@ def test_sign_rekor_entry_consistent(id_config):
 
     assert expected_entry.canonicalized_body == base64.b64decode(actual_entry.body)
     assert expected_entry.integrated_time == actual_entry.integrated_time
-    assert expected_entry.log_id == actual_entry.log_id
+    assert expected_entry.log_id.key_id == bytes.fromhex(actual_entry.log_id)
     assert expected_entry.log_index == actual_entry.log_index
 
 
@@ -114,5 +114,5 @@ def test_identity_proof_claim_lookup(id_config, monkeypatch):
 
     assert expected_entry.canonicalized_body == base64.b64decode(actual_entry.body)
     assert expected_entry.integrated_time == actual_entry.integrated_time
-    assert expected_entry.log_id == actual_entry.log_id
+    assert expected_entry.log_id.key_id == bytes.fromhex(actual_entry.log_id)
     assert expected_entry.log_index == actual_entry.log_index

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -49,8 +49,7 @@ def test_sign_rekor_entry_consistent(id_config):
 
     actual_entry = ctx._rekor.log.entries.get(log_index=expected_entry.log_index)
 
-    assert expected_entry.uuid == actual_entry.uuid
-    assert expected_entry.body == actual_entry.body
+    assert expected_entry.canonicalized_body == actual_entry.body
     assert expected_entry.integrated_time == actual_entry.integrated_time
     assert expected_entry.log_id == actual_entry.log_id
     assert expected_entry.log_index == actual_entry.log_index
@@ -112,8 +111,7 @@ def test_identity_proof_claim_lookup(id_config, monkeypatch):
         expected_entry = signer.sign(payload).verification_material.tlog_entries[0]
     actual_entry = ctx._rekor.log.entries.get(log_index=expected_entry.log_index)
 
-    assert expected_entry.uuid == actual_entry.uuid
-    assert expected_entry.body == actual_entry.body
+    assert expected_entry.canonicalized_body == actual_entry.body
     assert expected_entry.integrated_time == actual_entry.integrated_time
     assert expected_entry.log_id == actual_entry.log_id
     assert expected_entry.log_index == actual_entry.log_index


### PR DESCRIPTION
This removes the `SigningResult` model, and replaces it with `Bundle` in APIs where a `SigningResult` was previously returned.

Closes #854.

Unblocks #860.

cc @laurentsimon for visibility 🙂 