### PR TITLE
verify: Remove a workaround for pre-3.8 Python

### DIFF
--- a/sigstore/verify/policy.py
+++ b/sigstore/verify/policy.py
@@ -21,13 +21,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import cast
-
-try:
-    from typing import Protocol
-except ImportError:  # pragma: no cover
-    # TODO(ww): Remove when our minimum Python is 3.8.
-    from typing_extensions import Protocol  # type: ignore[assignment]
+from typing import Protocol, cast
 
 from cryptography.x509 import (
     Certificate,


### PR DESCRIPTION
After this we have no uses of typing-extensions. It was not actually listed as a (direct) dependency at all.