### PR TITLE
Fix cryptography deprecations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "appdirs ~= 1.4",
-  "cryptography >= 39",
+  "cryptography >= 42",
   "id >= 1.1.0",
   "importlib_resources ~= 5.7; python_version < '3.11'",
   "in-toto-attestation == 0.9.3",

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -139,9 +139,8 @@ class Signer:
         """Get or request a signing certificate from Fulcio."""
         # If it exists, verify if the current certificate is expired
         if self.__cached_signing_certificate:
-            not_valid_after = self.__cached_signing_certificate.cert.not_valid_after
-            not_valid_after_tzutc = not_valid_after.replace(tzinfo=timezone.utc)
-            if datetime.now(timezone.utc) > not_valid_after_tzutc:
+            not_valid_after = self.__cached_signing_certificate.cert.not_valid_after_utc
+            if datetime.now(timezone.utc) > not_valid_after:
                 raise ExpiredCertificate
             return self.__cached_signing_certificate
 

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -19,8 +19,8 @@ Verification API machinery.
 from __future__ import annotations
 
 import base64
-import datetime
 import logging
+from datetime import datetime, timezone
 from typing import List, cast
 
 from cryptography.exceptions import InvalidSignature
@@ -182,7 +182,7 @@ class Verifier:
 
         # 1) Verify that the signing certificate is signed by the root certificate and that the
         #    signing certificate was valid at the time of signing.
-        sign_date = materials.certificate.not_valid_before
+        sign_date = materials.certificate.not_valid_before_utc
         cert_ossl = X509.from_cryptography(materials.certificate)
 
         store.set_time(sign_date)
@@ -289,11 +289,11 @@ class Verifier:
                 )
 
         # 7) Verify that the signing certificate was valid at the time of signing
-        integrated_time = datetime.datetime.utcfromtimestamp(entry.integrated_time)
+        integrated_time = datetime.fromtimestamp(entry.integrated_time, tz=timezone.utc)
         if not (
-            materials.certificate.not_valid_before
+            materials.certificate.not_valid_before_utc
             <= integrated_time
-            <= materials.certificate.not_valid_after
+            <= materials.certificate.not_valid_after_utc
         ):
             return VerificationFailure(
                 reason="invalid signing cert: expired at time of Rekor entry"


### PR DESCRIPTION
`Certificate.not_valid_before` and `Certificate.not_valid_after` have been deprecated in cryptography 42.

* Require cryptography >= 42 (because the replacement fields are only available there)
* Use the new fields in `verify` and `sign`

This seems straight forward to me but review from someone certificate savvy wouldn't hurt.  The only interesting bit to me seems to be that we now give X509Store  a datetime that is explicitly UTC -- but I don't see that changing anything.

Fixes #878