### PR TITLE
Replace appdirs with platformdirs on tuf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
   "Topic :: Security :: Cryptography",
 ]
 dependencies = [
-  "appdirs ~= 1.4",
   "cryptography >= 42",
   "id >= 1.1.0",
   "importlib_resources ~= 5.7; python_version < '3.11'",
@@ -40,6 +39,7 @@ dependencies = [
   # NOTE(ww): Under active development, so strictly pinned.
   "sigstore-rekor-types == 0.0.12",
   "tuf >= 2.1,< 4.0",
+  "platformdirs ~= 4.2"
 ]
 requires-python = ">=3.8"
 

--- a/sigstore/_internal/tuf.py
+++ b/sigstore/_internal/tuf.py
@@ -23,7 +23,7 @@ from functools import lru_cache
 from pathlib import Path
 from urllib import parse
 
-import appdirs
+import platformdirs
 from tuf.api import exceptions as TUFExceptions
 from tuf.ngclient import RequestsFetcher, Updater
 
@@ -55,11 +55,13 @@ def _get_dirs(url: str) -> tuple[Path, Path]:
     These directories are not guaranteed to already exist.
     """
 
-    builder = appdirs.AppDirs("sigstore-python", "sigstore")
+    app_name = "sigstore-python"
+    app_author = "sigstore"
+
     repo_base = parse.quote(url, safe="")
 
-    tuf_data_dir = Path(builder.user_data_dir) / "tuf"
-    tuf_cache_dir = Path(builder.user_cache_dir) / "tuf"
+    tuf_data_dir = Path(platformdirs.user_data_dir(app_name, app_author)) / "tuf"
+    tuf_cache_dir = Path(platformdirs.user_cache_dir(app_name, app_author)) / "tuf"
 
     return (tuf_data_dir / repo_base), (tuf_cache_dir / repo_base)
 


### PR DESCRIPTION
Closes #867 

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Is replaces the lib to generate paths `appdirs` with `platformdirs`. This lib is used only in the tuf file.
As described on the issue #867 the `appdirs` has been deprecated.

#### Release Note
Removed appdirs from dependencies.
Added platformdirs to dependencies.
Updated tuf.py code to use platformdirs instead of appdirs for path generating.

<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->