### PR TITLE
sigstore/sign: sign API takes bytes, not I/O

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ All versions prior to 0.9.0 are untracked.
   a `Hashed` parameter to convey the digest used for Rekor entry lookup
   ([#904](https://github.com/sigstore/sigstore-python/pull/904))
 
+* **BREAKING API CHANGE**: `Signer.sign(...)` now takes a `bytes` instead of
+  an `IO[bytes]` for input. Other input types (such as `Hashed` and
+  `Statement`) are unchanged ([#921](https://github.com/sigstore/sigstore-python/pull/921))
+
 ## [2.1.2]
 
 This is a corrective release for [2.1.1].

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -601,7 +601,7 @@ def _sign(args: argparse.Namespace) -> None:
 
     # Build up the map of inputs -> outputs ahead of any signing operations,
     # so that we can fail early if overwriting without `--overwrite`.
-    output_map = {}
+    output_map: dict[Path, dict[str, Path | None]] = {}
     for file in args.files:
         if not file.is_file():
             _die(args, f"Input must be a file: {file}")
@@ -686,16 +686,18 @@ def _sign(args: argparse.Namespace) -> None:
     with signing_ctx.signer(identity) as signer:
         for file, outputs in output_map.items():
             logger.debug(f"signing for {file.name}")
-            with file.open(mode="rb", buffering=0) as io:
-                try:
-                    result = signer.sign(input_=io)
-                except ExpiredIdentity as exp_identity:
-                    print("Signature failed: identity token has expired")
-                    raise exp_identity
+            # TODO: Stream and pre-hash here instead, to avoid buffering
+            # large inputs.
+            input_ = file.read_bytes()
+            try:
+                result = signer.sign(input_=input_)
+            except ExpiredIdentity as exp_identity:
+                print("Signature failed: identity token has expired")
+                raise exp_identity
 
-                except ExpiredCertificate as exp_certificate:
-                    print("Signature failed: Fulcio signing certificate has expired")
-                    raise exp_certificate
+            except ExpiredCertificate as exp_certificate:
+                print("Signature failed: Fulcio signing certificate has expired")
+                raise exp_certificate
 
             print("Using ephemeral certificate:")
             cert = result.verification_material.x509_certificate_chain.certificates[0]

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -175,7 +175,7 @@ def key_id(key: PublicKey) -> KeyID:
     return KeyID(hashlib.sha256(public_bytes).digest())
 
 
-def get_digest(
+def sha256_digest(
     input_: bytes | IO[bytes] | sigstore_hashes.Hashed,
 ) -> sigstore_hashes.Hashed:
     """
@@ -193,11 +193,11 @@ def get_digest(
         )
 
     return sigstore_hashes.Hashed(
-        digest=sha256_streaming(input_), algorithm=HashAlgorithm.SHA2_256
+        digest=_sha256_streaming(input_), algorithm=HashAlgorithm.SHA2_256
     )
 
 
-def sha256_streaming(io: IO[bytes]) -> bytes:
+def _sha256_streaming(io: IO[bytes]) -> bytes:
     """
     Compute the SHA256 of a stream.
 

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -81,7 +81,7 @@ from sigstore._internal.fulcio import (
 from sigstore._internal.rekor.client import RekorClient
 from sigstore._internal.sct import verify_sct
 from sigstore._internal.trustroot import TrustedRoot
-from sigstore._utils import BundleType, PEMCert, get_digest
+from sigstore._utils import BundleType, PEMCert, sha256_digest
 from sigstore.oidc import ExpiredIdentity, IdentityToken
 from sigstore.transparency import LogEntry
 
@@ -230,7 +230,7 @@ class Signer:
                 ),
             )
         else:
-            hashed_input = get_digest(input_)
+            hashed_input = sha256_digest(input_)
 
             artifact_signature = private_key.sign(
                 hashed_input.digest, ec.ECDSA(hashed_input._as_prehashed())

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -43,7 +43,7 @@ import base64
 import logging
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import IO, Iterator, Optional
+from typing import Iterator, Optional
 
 import cryptography.x509 as x509
 import rekor_types
@@ -174,9 +174,22 @@ class Signer:
 
     def sign(
         self,
-        input_: IO[bytes] | Statement | sigstore_hashes.Hashed,
+        input_: bytes | Statement | sigstore_hashes.Hashed,
     ) -> Bundle:
-        """Public API for signing blobs"""
+        """
+        Sign an input, and return a `Bundle` corresponding to the signed result.
+
+        The input can be one of three forms:
+
+        1. A `bytes` buffer;
+        2. A `Hashed` object, containing a pre-hashed input (e.g., for inputs
+           that are too large to buffer into memory);
+        3. An in-toto `Statement` object.
+
+        In cases (1) and (2), the signing operation will produce a `hashedrekord`
+        entry within the bundle. In case (3), the signing operation will produce
+        a DSSE envelope and corresponding `dsse` entry within the bundle.
+        """
         private_key = self._private_key
 
         if not self._identity_token.in_validity_period():

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -54,7 +54,7 @@ from sigstore._internal.sct import (
 )
 from sigstore._internal.set import InvalidSETError, verify_set
 from sigstore._internal.trustroot import TrustedRoot
-from sigstore._utils import B64Str, HexStr, get_digest
+from sigstore._utils import B64Str, HexStr, sha256_digest
 from sigstore.hashes import Hashed
 from sigstore.verify.models import InvalidRekorEntry as InvalidRekorEntryError
 from sigstore.verify.models import RekorEntryMissing as RekorEntryMissingError
@@ -168,7 +168,7 @@ class Verifier:
         success.
         """
 
-        hashed_input = get_digest(input_)
+        hashed_input = sha256_digest(input_)
 
         # NOTE: The `X509Store` object currently cannot have its time reset once the `set_time`
         # method been called on it. To get around this, we construct a new one for every `verify`

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -68,7 +68,7 @@ def test_sha256_streaming(size):
     buf = b"x" * size
 
     expected_digest = hashlib.sha256(buf).digest()
-    actual_digest = utils.sha256_streaming(io.BytesIO(buf))
+    actual_digest = utils._sha256_streaming(io.BytesIO(buf))
 
     assert expected_digest == actual_digest
 

--- a/test/unit/verify/test_models.py
+++ b/test/unit/verify/test_models.py
@@ -18,7 +18,7 @@ from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
 from sigstore._internal.rekor.client import RekorClient
 from sigstore._internal.trustroot import TrustedRoot
-from sigstore._utils import sha256_streaming
+from sigstore._utils import _sha256_streaming
 from sigstore.hashes import Hashed
 from sigstore.verify.models import (
     InvalidMaterials,
@@ -36,7 +36,7 @@ class TestVerificationMaterials:
         (file, offline_rekor_materials) = signing_bundle("bundle.txt")
 
         with file.open(mode="rb", buffering=0) as input_:
-            digest = sha256_streaming(input_)
+            digest = _sha256_streaming(input_)
             hashed = Hashed(algorithm=HashAlgorithm.SHA2_256, digest=digest)
 
         # Stuff a valid but incompatible Rekor entry into the verification
@@ -56,7 +56,7 @@ class TestVerificationMaterials:
         client = RekorClient.staging(trust_root)
 
         with file.open(mode="rb", buffering=0) as input_:
-            digest = sha256_streaming(input_)
+            digest = _sha256_streaming(input_)
             hashed = Hashed(algorithm=HashAlgorithm.SHA2_256, digest=digest)
 
         entry = materials.rekor_entry(hashed, client)
@@ -67,7 +67,7 @@ class TestVerificationMaterials:
         file, a_materials = signing_materials("a.txt")
 
         with file.open(mode="rb", buffering=0) as input_:
-            digest = sha256_streaming(input_)
+            digest = _sha256_streaming(input_)
             hashed = Hashed(algorithm=HashAlgorithm.SHA2_256, digest=digest)
 
         # stub retriever post returning None RekorEntry

--- a/test/unit/verify/test_verifier.py
+++ b/test/unit/verify/test_verifier.py
@@ -17,7 +17,7 @@ import pretend
 import pytest
 from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
-from sigstore._utils import sha256_streaming
+from sigstore._utils import _sha256_streaming
 from sigstore.hashes import Hashed
 from sigstore.transparency import LogEntry
 from sigstore.verify import policy
@@ -137,7 +137,7 @@ def test_verifier_invalid_online_missing_inclusion_proof(
     (file, materials) = signing_materials("a.txt")
 
     with file.open(mode="rb", buffering=0) as input_:
-        digest = sha256_streaming(input_)
+        digest = _sha256_streaming(input_)
         hashed = Hashed(algorithm=HashAlgorithm.SHA2_256, digest=digest)
 
     # Retrieve the entry, strip its inclusion proof, stuff it back
@@ -169,7 +169,7 @@ def test_verifier_fail_expiry(signing_materials, null_policy, monkeypatch):
     (file, materials) = signing_materials("a.txt")
 
     with file.open(mode="rb", buffering=0) as input_:
-        digest = sha256_streaming(input_)
+        digest = _sha256_streaming(input_)
         hashed = Hashed(algorithm=HashAlgorithm.SHA2_256, digest=digest)
 
     entry = materials.rekor_entry(hashed, verifier._rekor)


### PR DESCRIPTION
Counterpart to #904: `Signer.sign(...)` takes `bytes` instead of an effectful IO type.