### PR TITLE
pyproject: bump protobuf specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+## Fixed
+
+* Loosened a version constraint on the `sigstore-protobuf-specs` dependency,
+  to ease use in testing environments
+  ([#943](https://github.com/sigstore/sigstore-python/pull/943))
+
 ## [2.1.2]
 
 This is a corrective release for [2.1.1].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+## [2.1.3]
+
 ## Fixed
 
 * Loosened a version constraint on the `sigstore-protobuf-specs` dependency,
@@ -314,7 +316,8 @@ This is a corrective release for [2.1.1].
   ([#351](https://github.com/sigstore/sigstore-python/pull/351))
 
 <!--Release URLs -->
-[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v2.1.2...HEAD
+[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v2.1.3...HEAD
+[2.1.3]: https://github.com/sigstore/sigstore-python/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/sigstore/sigstore-python/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/sigstore/sigstore-python/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/sigstore/sigstore-python/compare/v2.0.1...v2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "requests",
   "rich ~= 13.0",
   "securesystemslib",
-  "sigstore-protobuf-specs ~= 0.3",
+  "sigstore-protobuf-specs >= 0.2.2, < 0.4",
   # NOTE(ww): Under active development, so strictly pinned.
   "sigstore-rekor-types == 0.0.11",
   "tuf >= 2.1,< 4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "requests",
   "rich ~= 13.0",
   "securesystemslib",
-  "sigstore-protobuf-specs ~= 0.2.2",
+  "sigstore-protobuf-specs ~= 0.3",
   # NOTE(ww): Under active development, so strictly pinned.
   "sigstore-rekor-types == 0.0.11",
   "tuf >= 2.1,< 4.0",

--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -25,4 +25,4 @@ Otherwise, here are some quick starting points:
 * `sigstore.sign`: creation of Sigstore signatures
 """
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"


### PR DESCRIPTION
This will help resolve the mess I've caused in https://github.com/sigstore/sigstore-conformance/pull/136.