### PR TITLE
sigstore: use rfc8785 for SET canonicalization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "pyOpenSSL >= 23.0.0",
   "requests",
   "rich ~= 13.0",
-  "securesystemslib",
+  "rfc8785",
   "sigstore-protobuf-specs ~= 0.3",
   # NOTE(ww): Under active development, so strictly pinned.
   "sigstore-rekor-types == 0.0.12",

--- a/sigstore/transparency.py
+++ b/sigstore/transparency.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 
+import rfc8785
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -30,7 +31,6 @@ from pydantic import (
     field_validator,
 )
 from pydantic.dataclasses import dataclass
-from securesystemslib.formats import encode_canonical
 
 from sigstore._utils import B64Str
 
@@ -179,4 +179,5 @@ class LogEntry:
             "logIndex": self.log_index,
         }
 
-        return encode_canonical(payload).encode()  # type: ignore
+        # TODO: Unclear why mypy doesn't understand this.
+        return rfc8785.dumps(payload)  # type: ignore[no-any-return]


### PR DESCRIPTION
SET canonicalization is defined over RFC 8785, but we were using securesystemslib's `encode_canonical`, which uses an entirely different (but coincidentally identical, in this case) canonicalization scheme.


CC @haydentherapper for confirmation that SETs do indeed use RFC 8785 -- that understanding is based on https://github.com/sigstore/rekor/blob/4fcdcaa58fd5263560a82978d781eb64f5c5f93c/openapi.yaml#L467-L471 🙂 