### PR TITLE
sigstore: rename more logger instances

### DIFF
--- a/sigstore/_internal/fulcio/client.py
+++ b/sigstore/_internal/fulcio/client.py
@@ -51,7 +51,7 @@ from sigstore._internal.sct import (
 from sigstore._utils import B64Str
 from sigstore.oidc import IdentityToken
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 DEFAULT_FULCIO_URL = "https://fulcio.sigstore.dev"
 STAGING_FULCIO_URL = "https://fulcio.sigstage.dev"
@@ -335,7 +335,7 @@ class FulcioClient:
 
     def __init__(self, url: str = DEFAULT_FULCIO_URL) -> None:
         """Initialize the client"""
-        logger.debug(f"Fulcio client using URL: {url}")
+        _logger.debug(f"Fulcio client using URL: {url}")
         self.url = url
         self.session = requests.Session()
 

--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -33,7 +33,7 @@ from id import IdentityError
 from sigstore._utils import B64Str
 from sigstore.oidc import Issuer
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 # This HTML is copied from the Go Sigstore library and was originally authored by Julien Vermette:
@@ -128,13 +128,13 @@ class _OAuthRedirectHandler(http.server.BaseHTTPRequestHandler):
         pass
 
     def do_GET(self) -> None:
-        logger.debug(f"GET: {self.path} with {dict(self.headers)}")
+        _logger.debug(f"GET: {self.path} with {dict(self.headers)}")
         server = cast(_OAuthRedirectServer, self.server)
 
         # If the auth response has already been populated, the main thread will be stopping this
         # thread and accessing the auth response shortly so we should stop servicing any requests.
         if server.auth_response is not None:
-            logger.debug(f"{self.path} unavailable (teardown)")
+            _logger.debug(f"{self.path} unavailable (teardown)")
             self.send_response(404)
             return None
 
@@ -249,7 +249,7 @@ class _OAuthRedirectServer(http.server.HTTPServer):
         return self.oauth_session.auth_endpoint(self.redirect_uri)
 
     def enable_oob(self) -> None:
-        logger.debug("enabling out-of-band OAuth flow")
+        _logger.debug("enabling out-of-band OAuth flow")
         self._is_out_of_band = True
 
     def is_oob(self) -> bool:

--- a/sigstore/_internal/rekor/client.py
+++ b/sigstore/_internal/rekor/client.py
@@ -30,7 +30,7 @@ import requests
 
 from sigstore.transparency import LogEntry
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 DEFAULT_REKOR_URL = "https://rekor.sigstore.dev"
 STAGING_REKOR_URL = "https://rekor.sigstage.dev"
@@ -152,7 +152,7 @@ class RekorEntries(_Endpoint):
         """
 
         payload = proposed_entry.model_dump(mode="json", by_alias=True)
-        logger.debug(f"proposed: {json.dumps(payload)}")
+        _logger.debug(f"proposed: {json.dumps(payload)}")
 
         resp: requests.Response = self.session.post(self.url, json=payload)
         try:
@@ -161,7 +161,7 @@ class RekorEntries(_Endpoint):
             raise RekorClientError(http_error)
 
         integrated_entry = resp.json()
-        logger.debug(f"integrated: {integrated_entry}")
+        _logger.debug(f"integrated: {integrated_entry}")
         return LogEntry._from_response(integrated_entry)
 
     @property

--- a/sigstore/_internal/sct.py
+++ b/sigstore/_internal/sct.py
@@ -51,7 +51,7 @@ from sigstore._utils import (
 )
 from sigstore.errors import Error
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 def _pack_signed_entry(
@@ -183,11 +183,11 @@ def _get_precertificate_signed_certificate_timestamps(
 
 
 def _cert_is_ca(cert: Certificate) -> bool:
-    logger.debug(f"Found {cert.subject} as issuer, verifying if it is a ca")
+    _logger.debug(f"Found {cert.subject} as issuer, verifying if it is a ca")
     try:
         cert_is_ca(cert)
     except InvalidCertError as e:
-        logger.debug(f"Invalid {cert.subject}: failed to validate as a CA: {e}")
+        _logger.debug(f"Invalid {cert.subject}: failed to validate as a CA: {e}")
         return False
     return True
 
@@ -308,7 +308,7 @@ def verify_sct(
         )
 
     try:
-        logger.debug(f"attempting to verify SCT with key ID {sct.log_id.hex()}")
+        _logger.debug(f"attempting to verify SCT with key ID {sct.log_id.hex()}")
         # NOTE(ww): In terms of the DER structure, the SCT's `LogID` contains a
         # singular `opaque key_id[32]`. Cryptography's APIs don't bother
         # to expose this trivial single member, so we use the `log_id`

--- a/sigstore/_internal/tuf.py
+++ b/sigstore/_internal/tuf.py
@@ -30,7 +30,7 @@ from tuf.ngclient import RequestsFetcher, Updater
 from sigstore._utils import read_embedded
 from sigstore.errors import RootError, TUFError
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 DEFAULT_TUF_URL = "https://tuf-repo-cdn.sigstore.dev"
 STAGING_TUF_URL = "https://tuf-repo-cdn.sigstage.dev"
@@ -122,8 +122,8 @@ class TrustUpdater:
 
             trusted_root_target.write_bytes(trusted_root_json)
 
-        logger.debug(f"TUF metadata: {self._metadata_dir}")
-        logger.debug(f"TUF targets cache: {self._targets_dir}")
+        _logger.debug(f"TUF metadata: {self._metadata_dir}")
+        _logger.debug(f"TUF targets cache: {self._targets_dir}")
 
         self._updater: None | Updater = None
         if not offline:
@@ -144,7 +144,7 @@ class TrustUpdater:
     def get_trusted_root_path(self) -> str:
         """Return local path to currently valid trusted root file"""
         if not self._updater:
-            logger.debug("Using unverified trusted root from cache")
+            _logger.debug("Using unverified trusted root from cache")
             return str(self._targets_dir / "trusted_root.json")
 
         root_info = self._updater.get_targetinfo("trusted_root.json")
@@ -160,5 +160,5 @@ class TrustUpdater:
             ) as e:
                 raise TUFError("Failed to download trusted key bundle") from e
 
-        logger.debug("Found and verified trusted root")
+        _logger.debug("Found and verified trusted root")
         return path


### PR DESCRIPTION
This is for hygiene/consistency: `logger` is never intended to be a public API in any of our modules.

No functional changes.