### PR TITLE
sigstore, test: break apart DSSE/artifact sign APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@ All versions prior to 0.9.0 are untracked.
 
 ### Added
 
-* API: `Signer.sign_artifact()` can now take a `Hashed` as an input,
-  performing a signature on a pre-computed hash value
-  ([#860](https://github.com/sigstore/sigstore-python/pull/860))
+* API: `Signer.sign_artifact()` has been added, replacing the removed
+  `Signer.sign()` API
 
 * API: `Signer.sign_intoto()` has been added. It takes an in-toto `Statement`
   as an input, producing a DSSE-formatted signature rather than a "bare"
@@ -43,10 +42,6 @@ All versions prior to 0.9.0 are untracked.
 
 ### Changed
 
-* **BREAKING API CHANGE**: The `Signer.sign_artifact(...)` API now returns
-  a `sigstore.verify.models.Bundle`, instead of a `SigningResult`
-  ([#862](https://github.com/sigstore/sigstore-python/pull/862))
-
 * **BREAKING API CHANGE**: `Verifier.verify(...)`  now takes a `bytes | Hashed`
   as its verification input, rather than implicitly receiving the input through
   the `VerificationMaterials` parameter
@@ -55,10 +50,6 @@ All versions prior to 0.9.0 are untracked.
 * **BREAKING API CHANGE**: `VerificationMaterials.rekor_entry(...)` now takes
   a `Hashed` parameter to convey the digest used for Rekor entry lookup
   ([#904](https://github.com/sigstore/sigstore-python/pull/904))
-
-* **BREAKING API CHANGE**: `Signer.sign_artifact(...)` now takes a `bytes`
-  instead of an `IO[bytes]` for input. The `Hashed` parameter option
-  is unchanged ([#921](https://github.com/sigstore/sigstore-python/pull/921))
 
 * **BREAKING API CHANGE**: `Verifier.verify(...)` now takes a `sigstore.verify.models.Bundle`,
   instead of a `VerificationMaterials` ([#937](https://github.com/sigstore/sigstore-python/pull/937))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,13 @@ All versions prior to 0.9.0 are untracked.
 
 ### Added
 
-* API: `Signer.sign()` can now take a `Hashed` as an input,
+* API: `Signer.sign_artifact()` can now take a `Hashed` as an input,
   performing a signature on a pre-computed hash value
   ([#860](https://github.com/sigstore/sigstore-python/pull/860))
 
-* API: `Signer.sign()` can now take an in-toto `Statement` as an input,
-  producing a DSSE-formatted signature rather than a "bare" signature
-  ([#804](https://github.com/sigstore/sigstore-python/pull/804))
-
-* API: `SigningResult.content` has been added, representing either the
-  `hashedrekord` entry's message signature or the `dsse` entry's envelope
-  ([#804](https://github.com/sigstore/sigstore-python/pull/804))
+* API: `Signer.sign_intoto()` has been added. It takes an in-toto `Statement`
+  as an input, producing a DSSE-formatted signature rather than a "bare"
+  signature ([#804](https://github.com/sigstore/sigstore-python/pull/804))
 
 * API: "v3" Sigstore bundles are now supported during verification
   ([#901](https://github.com/sigstore/sigstore-python/pull/901))
@@ -41,10 +37,15 @@ All versions prior to 0.9.0 are untracked.
 * **BREAKING API CHANGE**: `VerificationMaterials` has been removed.
   The public verification APIs now accept `sigstore.verify.models.Bundle`.
 
+* **BREAKING API CHANGE**: `Signer.sign(...)` has been removed. Use
+  either `sign_artifact(...)` or `sign_intoto(...)`, depending on whether
+  you're signing opaque bytes or an in-toto statement.
+
 ### Changed
 
-* **BREAKING API CHANGE**: The `Signer.sign(...)` API now returns a `sigstore.verify.models.Bundle`,
-  instead of a `SigningResult` ([#862](https://github.com/sigstore/sigstore-python/pull/862))
+* **BREAKING API CHANGE**: The `Signer.sign_artifact(...)` API now returns
+  a `sigstore.verify.models.Bundle`, instead of a `SigningResult`
+  ([#862](https://github.com/sigstore/sigstore-python/pull/862))
 
 * **BREAKING API CHANGE**: `Verifier.verify(...)`  now takes a `bytes | Hashed`
   as its verification input, rather than implicitly receiving the input through
@@ -55,9 +56,9 @@ All versions prior to 0.9.0 are untracked.
   a `Hashed` parameter to convey the digest used for Rekor entry lookup
   ([#904](https://github.com/sigstore/sigstore-python/pull/904))
 
-* **BREAKING API CHANGE**: `Signer.sign(...)` now takes a `bytes` instead of
-  an `IO[bytes]` for input. Other input types (such as `Hashed` and
-  `Statement`) are unchanged ([#921](https://github.com/sigstore/sigstore-python/pull/921))
+* **BREAKING API CHANGE**: `Signer.sign_artifact(...)` now takes a `bytes`
+  instead of an `IO[bytes]` for input. The `Hashed` parameter option
+  is unchanged ([#921](https://github.com/sigstore/sigstore-python/pull/921))
 
 * **BREAKING API CHANGE**: `Verifier.verify(...)` now takes a `sigstore.verify.models.Bundle`,
   instead of a `VerificationMaterials` ([#937](https://github.com/sigstore/sigstore-python/pull/937))

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -626,7 +626,7 @@ def _sign(args: argparse.Namespace) -> None:
                 # digest and sign the prehash rather than buffering it fully.
                 digest = sha256_digest(io)
             try:
-                result = signer.sign(input_=digest)
+                result = signer.sign_artifact(input_=digest)
             except ExpiredIdentity as exp_identity:
                 print("Signature failed: identity token has expired")
                 raise exp_identity

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -31,7 +31,7 @@ artifact = Path("foo.txt").read_bytes()
 
 signing_ctx = SigningContext.production()
 with signing_ctx.signer(identity, cache=True) as signer:
-    result = signer.sign(artifact)
+    result = signer.sign_artifact(artifact)
     print(result)
 ```
 """

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -233,9 +233,9 @@ class Signer:
         2. A `Hashed` object, containing a pre-hashed input (e.g., for inputs
            that are too large to buffer into memory).
 
-        In cases (1) and (2), the signing operation will produce a `hashedrekord`
-        entry within the bundle. In case (3), the signing operation will produce
-        a DSSE envelope and corresponding `dsse` entry within the bundle.
+        Regardless of the input format, the signing operation will produce a
+        `hashedrekord` entry within the bundle. No other entry types
+        are supported by this API.
         """
 
         cert = self._signing_cert()

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -49,7 +49,7 @@ def test_sign_rekor_entry_consistent(signer_and_ident):
 
     payload = secrets.token_bytes(32)
     with ctx.signer(identity) as signer:
-        expected_entry = signer.sign(payload).log_entry
+        expected_entry = signer.sign_artifact(payload).log_entry
 
     actual_entry = ctx._rekor.log.entries.get(log_index=expected_entry.log_index)
 
@@ -77,7 +77,7 @@ def test_sct_verify_keyring_lookup_error(signer_and_ident, monkeypatch):
         InvalidSCTError,
     ) as excinfo:
         with ctx.signer(identity) as signer:
-            signer.sign(payload)
+            signer.sign_artifact(payload)
 
     # The exception subclass is the one we expect.
     assert isinstance(excinfo.value, InvalidSCTKeyError)
@@ -101,7 +101,7 @@ def test_sct_verify_keyring_error(signer_and_ident, monkeypatch):
 
     with pytest.raises(InvalidSCTError):
         with ctx.signer(identity) as signer:
-            signer.sign(payload)
+            signer.sign_artifact(payload)
 
 
 @pytest.mark.online
@@ -118,7 +118,7 @@ def test_identity_proof_claim_lookup(signer_and_ident, monkeypatch):
     payload = secrets.token_bytes(32)
 
     with ctx.signer(identity) as signer:
-        expected_entry = signer.sign(payload).log_entry
+        expected_entry = signer.sign_artifact(payload).log_entry
     actual_entry = ctx._rekor.log.entries.get(log_index=expected_entry.log_index)
 
     assert expected_entry.body == actual_entry.body
@@ -141,7 +141,7 @@ def test_sign_prehashed(staging):
     )
 
     with sign_ctx.signer(identity) as signer:
-        bundle = signer.sign(hashed)
+        bundle = signer.sign_artifact(hashed)
 
     assert bundle._inner.message_signature.message_digest.algorithm == hashed.algorithm
     assert bundle._inner.message_signature.message_digest.digest == hashed.digest
@@ -173,6 +173,6 @@ def test_sign_dsse(staging):
     ).build()
 
     with ctx.signer(identity) as signer:
-        bundle = signer.sign(stmt)
+        bundle = signer.sign_intoto(stmt)
         # Ensures that all of our inner types serialize as expected.
         bundle.to_json()


### PR DESCRIPTION
Per https://github.com/sigstore/sigstore-python/issues/628: this turns `sign(...)` into `sign_artifact(...)` and `sign_intoto(...)` respectively. In doing so, we're also able to simplify and deduplicate the internals of the `Signer` class a bit.