### PR TITLE
sigstore, test: drastically simplify error types

### DIFF
--- a/sigstore/_internal/merkle.py
+++ b/sigstore/_internal/merkle.py
@@ -30,17 +30,10 @@ import typing
 from typing import List, Tuple
 
 from sigstore._utils import HexStr
+from sigstore.errors import VerificationError
 
 if typing.TYPE_CHECKING:
     from sigstore.transparency import LogEntry
-
-
-class InvalidInclusionProofError(Exception):
-    """
-    Raised if the Merkle inclusion proof fails.
-    """
-
-    pass
 
 
 _LEAF_HASH_PREFIX = 0
@@ -112,8 +105,8 @@ def verify_merkle_inclusion(entry: LogEntry) -> None:
 
     # Check against the number of hashes.
     if len(inclusion_proof.hashes) != (inner + border):
-        raise InvalidInclusionProofError(
-            f"Inclusion proof has wrong size: expected {inner + border}, got "
+        raise VerificationError(
+            f"inclusion proof has wrong size: expected {inner + border}, got "
             f"{len(inclusion_proof.hashes)}"
         )
 
@@ -132,7 +125,7 @@ def verify_merkle_inclusion(entry: LogEntry) -> None:
     )
 
     if calc_hash != inclusion_proof.root_hash:
-        raise InvalidInclusionProofError(
-            f"Inclusion proof contains invalid root hash: expected {inclusion_proof}, calculated "
+        raise VerificationError(
+            f"inclusion proof contains invalid root hash: expected {inclusion_proof}, calculated "
             f"{calc_hash}"
         )

--- a/sigstore/_internal/sct.py
+++ b/sigstore/_internal/sct.py
@@ -19,7 +19,6 @@ Utilities for verifying signed certificate timestamps.
 import logging
 import struct
 from datetime import timezone
-from textwrap import dedent
 from typing import List, Optional
 
 from cryptography.hazmat.primitives import hashes, serialization
@@ -36,20 +35,14 @@ from cryptography.x509.certificate_transparency import (
 )
 from cryptography.x509.oid import ExtendedKeyUsageOID
 
-from sigstore._internal.trustroot import (
-    CTKeyring,
-    KeyringError,
-    KeyringLookupError,
-    KeyringSignatureError,
-)
+from sigstore._internal.trustroot import CTKeyring
 from sigstore._utils import (
     DERCert,
-    InvalidCertError,
     KeyID,
     cert_is_ca,
     key_id,
 )
-from sigstore.errors import Error
+from sigstore.errors import VerificationError
 
 _logger = logging.getLogger(__name__)
 
@@ -66,7 +59,7 @@ def _pack_signed_entry(
         cert_der = DERCert(cert.public_bytes(encoding=serialization.Encoding.DER))
     elif sct.entry_type == LogEntryType.PRE_CERTIFICATE:
         if not issuer_key_id or len(issuer_key_id) != 32:
-            raise InvalidSCTError("API misuse: issuer key ID missing")
+            raise VerificationError("API misuse: issuer key ID missing")
 
         # When dealing with a precertificate, our signed entry looks like this:
         #
@@ -78,7 +71,7 @@ def _pack_signed_entry(
         cert_der = DERCert(cert.tbs_precertificate_bytes)
         fields.append(issuer_key_id)
     else:
-        raise InvalidSCTError(f"unknown SCT log entry type: {sct.entry_type!r}")
+        raise VerificationError(f"unknown SCT log entry type: {sct.entry_type!r}")
 
     # The `opaque` length is a u24, which isn't directly supported by `struct`.
     # So we have to decompose it into 3 bytes.
@@ -87,7 +80,9 @@ def _pack_signed_entry(
         struct.pack("!I", len(cert_der)),
     )
     if unused:
-        raise InvalidSCTError(f"Unexpectedly large certificate length: {len(cert_der)}")
+        raise VerificationError(
+            f"Unexpectedly large certificate length: {len(cert_der)}"
+        )
 
     pack_format = pack_format.format(cert_der_len=len(cert_der))
     fields.extend((len1, len2, len3, cert_der))
@@ -111,7 +106,7 @@ def _pack_digitally_signed(
     # No extensions are currently specified, so we treat the presence
     # of any extension bytes as suspicious.
     if len(sct.extension_bytes) != 0:
-        raise InvalidSCTError("Unexpected trailing extension bytes")
+        raise VerificationError("Unexpected trailing extension bytes")
 
     # This constructs the "core" `signed_entry` field, which is either
     # the public bytes of the cert *or* the TBSPrecertificate (with some
@@ -186,81 +181,10 @@ def _cert_is_ca(cert: Certificate) -> bool:
     _logger.debug(f"Found {cert.subject} as issuer, verifying if it is a ca")
     try:
         cert_is_ca(cert)
-    except InvalidCertError as e:
+    except VerificationError as e:
         _logger.debug(f"Invalid {cert.subject}: failed to validate as a CA: {e}")
         return False
     return True
-
-
-class InvalidSCTError(Error):
-    """
-    Raised during SCT verification if an SCT is invalid in some way.
-    """
-
-    def diagnostics(self) -> str:
-        """Returns diagnostics for the error."""
-
-        ctx = f"\nContext: {self.__context__}" if self.__context__ else ""
-        return dedent(
-            f"""
-            SCT verification failed.
-
-            Additional context:
-
-            Message: {str(self)}
-            """
-            + ctx
-        )
-
-
-class InvalidSCTKeyError(InvalidSCTError):
-    """
-    Raised during SCT verification if the SCT can't be validated against the given keyring.
-
-    We specialize this error case, since it usually indicates one of
-    two conditions: either the current sigstore client is out-of-date,
-    or that the SCT is well-formed but invalid for the current configuration
-    (indicating that the user has asked for the wrong instance).
-    """
-
-    def diagnostics(self) -> str:
-        """Returns diagnostics for the error."""
-        return dedent(
-            f"""
-                Invalid key ID in SCT: not found in current keyring.
-
-                This may be a result of an outdated `sigstore` installation.
-
-                Consider upgrading with:
-
-                    python -m pip install --upgrade sigstore
-
-                Additional context:
-
-                {self.__cause__}
-                """
-        )
-
-
-class SCTSignatureError(InvalidSCTError):
-    """
-    Raised during SCT verification if the signature of the SCT is invalid.
-    """
-
-    def diagnostics(self) -> str:
-        """Returns diagnostics for the error."""
-        return dedent(
-            f"""
-            Invalid signature on SCT.
-
-            If validating a certificate, the certificate associated with this
-            SCT should not be trusted.
-
-            Additional context:
-
-            {self.__cause__}
-            """
-        )
 
 
 def verify_sct(
@@ -288,13 +212,13 @@ def verify_sct(
         issuer_pubkey = issuer_cert.public_key()
 
         if not _cert_is_ca(issuer_cert):
-            raise InvalidSCTError(
-                f"Invalid issuer pubkey basicConstraint (not a CA): {issuer_pubkey}"
+            raise VerificationError(
+                f"SCT verify: Invalid issuer pubkey basicConstraint (not a CA): {issuer_pubkey}"
             )
 
         if not isinstance(issuer_pubkey, (rsa.RSAPublicKey, ec.EllipticCurvePublicKey)):
-            raise InvalidSCTError(
-                f"invalid issuer pubkey format (not ECDSA or RSA): {issuer_pubkey}"
+            raise VerificationError(
+                f"SCT verify: invalid issuer pubkey format (not ECDSA or RSA): {issuer_pubkey}"
             )
 
         issuer_key_id = key_id(issuer_pubkey)
@@ -302,7 +226,7 @@ def verify_sct(
     digitally_signed = _pack_digitally_signed(sct, cert, issuer_key_id)
 
     if not isinstance(sct.signature_hash_algorithm, hashes.SHA256):
-        raise InvalidSCTError(
+        raise VerificationError(
             "Found unexpected hash algorithm in SCT: only SHA256 is supported "
             f"(expected {hashes.SHA256}, got {sct.signature_hash_algorithm})"
         )
@@ -316,9 +240,5 @@ def verify_sct(
         ct_keyring.verify(
             key_id=KeyID(sct.log_id), signature=sct.signature, data=digitally_signed
         )
-    except KeyringLookupError as exc:
-        raise InvalidSCTKeyError from exc
-    except KeyringSignatureError as exc:
-        raise SCTSignatureError from exc
-    except KeyringError as exc:
-        raise InvalidSCTError from exc
+    except VerificationError as exc:
+        raise VerificationError(f"SCT verify failed: {exc}")

--- a/sigstore/errors.py
+++ b/sigstore/errors.py
@@ -117,3 +117,9 @@ class RootError(Error):
         Unable to establish root of trust.
 
         This error may occur when the resources embedded in this distribution of sigstore-python are out of date."""
+
+
+class VerificationError(Error):
+    """
+    Raised whenever any phase or subcomponent of Sigstore verification fails.
+    """

--- a/sigstore/verify/models.py
+++ b/sigstore/verify/models.py
@@ -123,17 +123,6 @@ class InvalidBundle(Error):
         )
 
 
-class RekorEntryMissing(Exception):
-    """
-    Raised if `VerificationMaterials.rekor_entry()` fails to find an entry
-    in the Rekor log.
-
-    This is an internal exception; users should not see it.
-    """
-
-    pass
-
-
 class InvalidRekorEntry(InvalidBundle):
     """
     Raised if the effective Rekor entry in `VerificationMaterials.rekor_entry()`

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -20,9 +20,8 @@ import pytest
 from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
 import sigstore.oidc
-from sigstore._internal.sct import InvalidSCTError, InvalidSCTKeyError
-from sigstore._internal.trustroot import KeyringError, KeyringLookupError
 from sigstore.dsse import _StatementBuilder, _Subject
+from sigstore.errors import VerificationError
 from sigstore.hashes import Hashed
 from sigstore.sign import SigningContext
 from sigstore.verify.policy import UnsafeNoOp
@@ -67,20 +66,15 @@ def test_sct_verify_keyring_lookup_error(signer_and_ident, monkeypatch):
     # a signer whose keyring always fails to lookup a given key.
     ctx: SigningContext = ctx()
     mock = pretend.stub(
-        ct_keyring=lambda: pretend.stub(verify=pretend.raiser(KeyringLookupError))
+        ct_keyring=lambda: pretend.stub(verify=pretend.raiser(VerificationError))
     )
     ctx._trusted_root = mock
     assert identity is not None
 
     payload = secrets.token_bytes(32)
-    with pytest.raises(
-        InvalidSCTError,
-    ) as excinfo:
+    with pytest.raises(VerificationError, match=r"SCT verify failed:"):
         with ctx.signer(identity) as signer:
             signer.sign(payload)
-
-    # The exception subclass is the one we expect.
-    assert isinstance(excinfo.value, InvalidSCTKeyError)
 
 
 @pytest.mark.online
@@ -91,15 +85,15 @@ def test_sct_verify_keyring_error(signer_and_ident, monkeypatch):
     # a signer whose keyring throws an internal error.
     ctx: SigningContext = ctx()
     mock = pretend.stub(
-        ct_keyring=lambda: pretend.stub(verify=pretend.raiser(KeyringLookupError))
+        ct_keyring=lambda: pretend.stub(verify=pretend.raiser(VerificationError))
     )
     ctx._trusted_root = mock
-    ctx._rekor._ct_keyring = pretend.stub(verify=pretend.raiser(KeyringError))
+    ctx._rekor._ct_keyring = pretend.stub(verify=pretend.raiser(VerificationError))
     assert identity is not None
 
     payload = secrets.token_bytes(32)
 
-    with pytest.raises(InvalidSCTError):
+    with pytest.raises(VerificationError):
         with ctx.signer(identity) as signer:
             signer.sign(payload)
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -22,6 +22,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 
 from sigstore import _utils as utils
+from sigstore.errors import VerificationError
 
 
 def test_key_id():
@@ -76,7 +77,7 @@ def test_sha256_streaming(size):
 def test_load_pem_public_key_format():
     keybytes = b"-----BEGIN PUBLIC KEY-----\n" b"bleh\n" b"-----END PUBLIC KEY-----"
     with pytest.raises(
-        utils.InvalidKeyError, match="could not load PEM-formatted public key"
+        VerificationError, match="could not load PEM-formatted public key"
     ):
         utils.load_pem_public_key([keybytes])
 
@@ -93,7 +94,7 @@ def test_load_pem_public_key_serialization(monkeypatch):
         b"-----END PUBLIC KEY-----"
     )
 
-    with pytest.raises(utils.InvalidKeyError, match="invalid key format: not one of"):
+    with pytest.raises(VerificationError, match="invalid key format: not one of"):
         utils.load_pem_public_key([keybytes])
 
 
@@ -122,7 +123,7 @@ def test_cert_is_ca(x509_testcase, testcase, valid):
 def test_cert_is_ca_invalid_states(x509_testcase, testcase):
     cert = x509_testcase(testcase)
 
-    with pytest.raises(utils.InvalidCertError):
+    with pytest.raises(VerificationError, match="invalid X.509 certificate"):
         utils.cert_is_ca(cert)
 
 
@@ -169,7 +170,7 @@ def test_cert_is_leaf(x509_testcase, testcase, valid):
 def test_cert_is_leaf_invalid_states(x509_testcase, testcase):
     cert = x509_testcase(testcase)
 
-    with pytest.raises(utils.InvalidCertError):
+    with pytest.raises(VerificationError):
         utils.cert_is_leaf(cert)
 
 
@@ -179,7 +180,7 @@ def test_cert_is_leaf_invalid_states(x509_testcase, testcase):
 def test_cert_is_leaf_invalid_version(helper):
     cert = pretend.stub(version=x509.Version.v1)
 
-    with pytest.raises(utils.InvalidCertError):
+    with pytest.raises(VerificationError, match="invalid X.509 version"):
         helper(cert)
 
 


### PR DESCRIPTION
WIP.

Another chore/refactor PR: this drastically reduces the number of error types we have floating around the codebase, in favor of a single unified `VerificationError` (which we can specialize in the future, as necessary).

Additionally, this changes the `verify(...)` API from returning a `VerificationResult` to using exceptional error handling. There are three justifications for this:

1. It allows us to remove the `VerificationResult` model and its subclasses, which are mostly just duplication over existing error types
2. It reduces the likelyhood of `VerificationError`s leaking through the API accidentally
3. It aligns the API with that the DSSE/in-toto API will do, which is use a return value on the success case and exceptions for all errors.

In the process, this also brings our coverage up a bit.