### PR TITLE
Prepare 2.1.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+## [2.1.4]
+
+## Fixed
+
+* Pinned `securesystemslib` dependency strictly to prevent future breakage
+
 ## [2.1.3]
 
 ## Fixed
@@ -316,7 +322,8 @@ This is a corrective release for [2.1.1].
   ([#351](https://github.com/sigstore/sigstore-python/pull/351))
 
 <!--Release URLs -->
-[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v2.1.3...HEAD
+[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v2.1.4...HEAD
+[2.1.4]: https://github.com/sigstore/sigstore-python/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/sigstore/sigstore-python/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/sigstore/sigstore-python/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/sigstore/sigstore-python/compare/v2.1.0...v2.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "pyOpenSSL >= 23.0.0",
   "requests",
   "rich ~= 13.0",
-  "securesystemslib",
+  "securesystemslib < 0.32.0",
   "sigstore-protobuf-specs >= 0.2.2, < 0.4",
   # NOTE(ww): Under active development, so strictly pinned.
   "sigstore-rekor-types == 0.0.11",

--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -25,4 +25,4 @@ Otherwise, here are some quick starting points:
 * `sigstore.sign`: creation of Sigstore signatures
 """
 
-__version__ = "2.1.3"
+__version__ = "2.1.4"


### PR DESCRIPTION
This is for **series/2.1.x**

Only change is pinning securesystemslib so future major or minor
releases will not be used (current release is 0.31.0)

We can still discuss if this makes sense or is necessary.

Fixes #960