### PR TITLE
bump sigstore-rekor-types, add NOTE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "rfc8785 ~= 0.1.2",
   "sigstore-protobuf-specs ~= 0.3.1",
   # NOTE(ww): Under active development, so strictly pinned.
-  "sigstore-rekor-types == 0.0.12",
+  "sigstore-rekor-types == 0.0.13",
   "tuf ~= 4.0",
   "platformdirs ~= 4.2",
 ]

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -210,8 +210,12 @@ class Signer:
 
         # Create the proposed DSSE log entry
         proposed_entry = rekor_types.Dsse(
-            spec=rekor_types.dsse.DsseV001Schema(
-                proposed_content=rekor_types.dsse.ProposedContent(
+            spec=rekor_types.dsse.DsseSchema(
+                # NOTE: mypy can't see that this kwarg is correct due to two interacting
+                # behaviors/bugs (one pydantic, one datamodel-codegen):
+                # See: <https://github.com/pydantic/pydantic/discussions/7418#discussioncomment-9024927>
+                # See: <https://github.com/koxudaxi/datamodel-code-generator/issues/1903>
+                proposed_content=rekor_types.dsse.ProposedContent(  # type: ignore[call-arg]
                     envelope=content.to_json(),
                     verifiers=[b64_cert.decode()],
                 ),


### PR DESCRIPTION
Addresses https://github.com/sigstore/sigstore-python/pull/957.

See <https://github.com/pydantic/pydantic/discussions/7418#discussioncomment-9024927> and <https://github.com/koxudaxi/datamodel-code-generator/issues/1903> for additional context about the `type: ignore`.