### PR TITLE
Disable staging in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           unshare --map-root-user --net make test TEST_ARGS="--skip-online -vv --showlocals"
 
       - name: test
-        run: make test TEST_ARGS="-vv --showlocals"
+        run: make test TEST_ARGS="-vv --showlocals --skip-staging"
 
       - name: test (interactive)
         if: (github.event_name != 'pull_request') || !github.event.pull_request.head.repo.fork

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -84,20 +84,42 @@ def pytest_addoption(parser):
         action="store_true",
         help="skip tests that require network connectivity",
     )
+    parser.addoption(
+        "--skip-staging",
+        action="store_true",
+        help="skip tests that require Sigstore staging infrastructure",
+    )
 
 
 def pytest_runtest_setup(item):
-    if "online" in item.keywords and item.config.getoption("--skip-online"):
+    # Do we need a network connection?
+    online = False
+    for mark in ["online", "staging", "production"]:
+        if mark in item.keywords:
+            online = True
+
+    if online and item.config.getoption("--skip-online"):
         pytest.skip(
             "skipping test that requires network connectivity due to `--skip-online` flag"
         )
     elif "ambient_oidc" in item.keywords and not _has_oidc_id():
         pytest.skip("skipping test that requires an ambient OIDC credential")
 
+    if "staging" in item.keywords and item.config.getoption("--skip-staging"):
+        pytest.skip(
+            "skipping test that requires staging infrastructure due to `--skip-staging` flag"
+        )
+
 
 def pytest_configure(config):
     config.addinivalue_line(
-        "markers", "online: mark test as requiring network connectivity"
+        "markers", "staging: mark test as requiring Sigstore staging infrastructure"
+    )
+    config.addinivalue_line(
+        "markers", "production: mark test as requiring Sigstore production infrastructure"
+    )
+    config.addinivalue_line(
+        "markers", "online: mark test as requiring network connectivity (but not a specific Sigstore infrastructure)"
     )
     config.addinivalue_line(
         "markers", "ambient_oidc: mark test as requiring an ambient OIDC identity"

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -116,10 +116,12 @@ def pytest_configure(config):
         "markers", "staging: mark test as requiring Sigstore staging infrastructure"
     )
     config.addinivalue_line(
-        "markers", "production: mark test as requiring Sigstore production infrastructure"
+        "markers",
+        "production: mark test as requiring Sigstore production infrastructure",
     )
     config.addinivalue_line(
-        "markers", "online: mark test as requiring network connectivity (but not a specific Sigstore infrastructure)"
+        "markers",
+        "online: mark test as requiring network connectivity (but not a specific Sigstore infrastructure)",
     )
     config.addinivalue_line(
         "markers", "ambient_oidc: mark test as requiring an ambient OIDC identity"
@@ -257,12 +259,16 @@ def tuf_dirs(monkeypatch, tmp_path):
 
     return (data_dir, cache_dir)
 
+
 @pytest.fixture
 def test_fixture(arg) -> str:
     return f"fixture arg was {arg}"
 
+
 @pytest.fixture
-def sign_ctx_and_ident_for_env(env: str) -> tuple[type[SigningContext], type[IdentityToken]]:
+def sign_ctx_and_ident_for_env(
+    env: str,
+) -> tuple[type[SigningContext], type[IdentityToken]]:
     if env == "staging":
         ctx_cls = SigningContext.staging
     elif env == "production":
@@ -276,6 +282,7 @@ def sign_ctx_and_ident_for_env(env: str) -> tuple[type[SigningContext], type[Ide
         token = detect_credential(_DEFAULT_AUDIENCE)
 
     return ctx_cls, IdentityToken(token)
+
 
 @pytest.fixture
 def staging() -> tuple[type[SigningContext], type[Verifier], IdentityToken]:

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -261,11 +261,6 @@ def tuf_dirs(monkeypatch, tmp_path):
 
 
 @pytest.fixture
-def test_fixture(arg) -> str:
-    return f"fixture arg was {arg}"
-
-
-@pytest.fixture
 def sign_ctx_and_ident_for_env(
     env: str,
 ) -> tuple[type[SigningContext], type[IdentityToken]]:

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -235,24 +235,25 @@ def tuf_dirs(monkeypatch, tmp_path):
 
     return (data_dir, cache_dir)
 
+@pytest.fixture
+def test_fixture(arg) -> str:
+    return f"fixture arg was {arg}"
 
-@pytest.fixture(
-    params=[
-        ("production", SigningContext.production),
-        ("staging", SigningContext.staging),
-    ],
-    ids=["production", "staging"],
-)
-def signer_and_ident(request) -> tuple[type[SigningContext], type[IdentityToken]]:
-    env, signer = request.param
-    # Detect env variable for local interactive tests.
+@pytest.fixture
+def sign_ctx_and_ident_for_env(env: str) -> tuple[type[SigningContext], type[IdentityToken]]:
+    if env == "staging":
+        ctx_cls = SigningContext.staging
+    elif env == "production":
+        ctx_cls = SigningContext.production
+    else:
+        raise ValueError(f"Unknown env {env}")
+
     token = os.getenv(f"SIGSTORE_IDENTITY_TOKEN_{env}")
     if not token:
         # If the variable is not defined, try getting an ambient token.
         token = detect_credential(_DEFAULT_AUDIENCE)
 
-    return signer, IdentityToken(token)
-
+    return ctx_cls, IdentityToken(token)
 
 @pytest.fixture
 def staging() -> tuple[type[SigningContext], type[Verifier], IdentityToken]:

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -35,6 +35,7 @@ class TestSigningContext:
     def test_staging(self, mock_staging_tuf):
         assert SigningContext.staging() is not None
 
+
 @pytest.mark.parametrize("env", ["staging", "production"])
 @pytest.mark.ambient_oidc
 def test_sign_rekor_entry_consistent(sign_ctx_and_ident_for_env):

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -28,7 +28,7 @@ from sigstore.verify.policy import UnsafeNoOp
 
 
 class TestSigningContext:
-    @pytest.mark.online
+    @pytest.mark.production
     def test_production(self):
         assert SigningContext.production() is not None
 
@@ -36,7 +36,6 @@ class TestSigningContext:
         assert SigningContext.staging() is not None
 
 @pytest.mark.parametrize("env", ["staging", "production"])
-@pytest.mark.online
 @pytest.mark.ambient_oidc
 def test_sign_rekor_entry_consistent(sign_ctx_and_ident_for_env):
     ctx_cls, identity = sign_ctx_and_ident_for_env
@@ -59,7 +58,6 @@ def test_sign_rekor_entry_consistent(sign_ctx_and_ident_for_env):
 
 
 @pytest.mark.parametrize("env", ["staging", "production"])
-@pytest.mark.online
 @pytest.mark.ambient_oidc
 def test_sct_verify_keyring_lookup_error(sign_ctx_and_ident_for_env, monkeypatch):
     ctx, identity = sign_ctx_and_ident_for_env
@@ -79,7 +77,6 @@ def test_sct_verify_keyring_lookup_error(sign_ctx_and_ident_for_env, monkeypatch
 
 
 @pytest.mark.parametrize("env", ["staging", "production"])
-@pytest.mark.online
 @pytest.mark.ambient_oidc
 def test_sct_verify_keyring_error(sign_ctx_and_ident_for_env, monkeypatch):
     ctx, identity = sign_ctx_and_ident_for_env
@@ -101,7 +98,6 @@ def test_sct_verify_keyring_error(sign_ctx_and_ident_for_env, monkeypatch):
 
 
 @pytest.mark.parametrize("env", ["staging", "production"])
-@pytest.mark.online
 @pytest.mark.ambient_oidc
 def test_identity_proof_claim_lookup(sign_ctx_and_ident_for_env, monkeypatch):
     ctx_cls, identity = sign_ctx_and_ident_for_env
@@ -124,7 +120,7 @@ def test_identity_proof_claim_lookup(sign_ctx_and_ident_for_env, monkeypatch):
     assert expected_entry.log_index == actual_entry.log_index
 
 
-@pytest.mark.online
+@pytest.mark.staging
 @pytest.mark.ambient_oidc
 def test_sign_prehashed(staging):
     sign_ctx_cls, verifier_cls, identity = staging
@@ -149,7 +145,7 @@ def test_sign_prehashed(staging):
     verifier.verify_artifact(hashed, bundle=bundle, policy=UnsafeNoOp())
 
 
-@pytest.mark.online
+@pytest.mark.staging
 @pytest.mark.ambient_oidc
 def test_sign_dsse(staging):
     sign_ctx, _, identity = staging

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -35,11 +35,11 @@ class TestSigningContext:
     def test_staging(self, mock_staging_tuf):
         assert SigningContext.staging() is not None
 
-
+@pytest.mark.parametrize("env", ["staging", "production"])
 @pytest.mark.online
 @pytest.mark.ambient_oidc
-def test_sign_rekor_entry_consistent(signer_and_ident):
-    ctx_cls, identity = signer_and_ident
+def test_sign_rekor_entry_consistent(sign_ctx_and_ident_for_env):
+    ctx_cls, identity = sign_ctx_and_ident_for_env
 
     # NOTE: The actual signer instance is produced lazily, so that parameter
     # expansion doesn't fail in offline tests.
@@ -58,10 +58,11 @@ def test_sign_rekor_entry_consistent(signer_and_ident):
     assert expected_entry.log_index == actual_entry.log_index
 
 
+@pytest.mark.parametrize("env", ["staging", "production"])
 @pytest.mark.online
 @pytest.mark.ambient_oidc
-def test_sct_verify_keyring_lookup_error(signer_and_ident, monkeypatch):
-    ctx, identity = signer_and_ident
+def test_sct_verify_keyring_lookup_error(sign_ctx_and_ident_for_env, monkeypatch):
+    ctx, identity = sign_ctx_and_ident_for_env
 
     # a signer whose keyring always fails to lookup a given key.
     ctx: SigningContext = ctx()
@@ -77,10 +78,11 @@ def test_sct_verify_keyring_lookup_error(signer_and_ident, monkeypatch):
             signer.sign_artifact(payload)
 
 
+@pytest.mark.parametrize("env", ["staging", "production"])
 @pytest.mark.online
 @pytest.mark.ambient_oidc
-def test_sct_verify_keyring_error(signer_and_ident, monkeypatch):
-    ctx, identity = signer_and_ident
+def test_sct_verify_keyring_error(sign_ctx_and_ident_for_env, monkeypatch):
+    ctx, identity = sign_ctx_and_ident_for_env
 
     # a signer whose keyring throws an internal error.
     ctx: SigningContext = ctx()
@@ -98,10 +100,11 @@ def test_sct_verify_keyring_error(signer_and_ident, monkeypatch):
             signer.sign_artifact(payload)
 
 
+@pytest.mark.parametrize("env", ["staging", "production"])
 @pytest.mark.online
 @pytest.mark.ambient_oidc
-def test_identity_proof_claim_lookup(signer_and_ident, monkeypatch):
-    ctx_cls, identity = signer_and_ident
+def test_identity_proof_claim_lookup(sign_ctx_and_ident_for_env, monkeypatch):
+    ctx_cls, identity = sign_ctx_and_ident_for_env
 
     ctx: SigningContext = ctx_cls()
     assert identity is not None

--- a/test/unit/verify/test_verifier.py
+++ b/test/unit/verify/test_verifier.py
@@ -25,7 +25,7 @@ from sigstore.verify.models import Bundle
 from sigstore.verify.verifier import Verifier
 
 
-@pytest.mark.online
+@pytest.mark.production
 def test_verifier_production():
     verifier = Verifier.production()
     assert verifier is not None
@@ -36,7 +36,7 @@ def test_verifier_staging(mock_staging_tuf):
     assert verifier is not None
 
 
-@pytest.mark.online
+@pytest.mark.staging
 def test_verifier_one_verification(signing_materials, null_policy):
     verifier = Verifier.staging()
 
@@ -45,6 +45,7 @@ def test_verifier_one_verification(signing_materials, null_policy):
     verifier.verify_artifact(file.read_bytes(), bundle, null_policy)
 
 
+@pytest.mark.staging
 def test_verifier_inconsistent_log_entry(signing_bundle, null_policy, mock_staging_tuf):
     (file, bundle) = signing_bundle("bundle_cve_2022_36056.txt")
 
@@ -57,7 +58,7 @@ def test_verifier_inconsistent_log_entry(signing_bundle, null_policy, mock_stagi
         verifier.verify_artifact(file.read_bytes(), bundle, null_policy)
 
 
-@pytest.mark.online
+@pytest.mark.staging
 def test_verifier_multiple_verifications(signing_materials, null_policy):
     verifier = Verifier.staging()
 
@@ -78,7 +79,7 @@ def test_verifier_bundle(signing_bundle, null_policy, mock_staging_tuf, filename
     verifier.verify_artifact(file.read_bytes(), bundle, null_policy)
 
 
-@pytest.mark.online
+@pytest.mark.staging
 def test_verifier_email_identity(signing_materials):
     verifier = Verifier.staging()
 
@@ -95,7 +96,7 @@ def test_verifier_email_identity(signing_materials):
     )
 
 
-@pytest.mark.online
+@pytest.mark.staging
 def test_verifier_uri_identity(signing_materials):
     verifier = Verifier.staging()
     (file, bundle) = signing_materials("c.txt", verifier._rekor)
@@ -114,7 +115,7 @@ def test_verifier_uri_identity(signing_materials):
     )
 
 
-@pytest.mark.online
+@pytest.mark.staging
 def test_verifier_policy_check(signing_materials):
     verifier = Verifier.staging()
     (file, bundle) = signing_materials("a.txt", verifier._rekor)
@@ -130,7 +131,7 @@ def test_verifier_policy_check(signing_materials):
         )
 
 
-@pytest.mark.online
+@pytest.mark.staging
 @pytest.mark.xfail
 def test_verifier_fail_expiry(signing_materials, null_policy, monkeypatch):
     # FIXME(jl): can't mock:
@@ -151,7 +152,7 @@ def test_verifier_fail_expiry(signing_materials, null_policy, monkeypatch):
         verifier.verify_artifact(file.read_bytes(), bundle, null_policy)
 
 
-@pytest.mark.online
+@pytest.mark.staging
 @pytest.mark.ambient_oidc
 def test_verifier_dsse_roundtrip(staging):
     signer_cls, verifier_cls, identity = staging


### PR DESCRIPTION
* Add ability to disable staging tests in unit tests
* disable staging temporarily because it's currently not reliable

Possibly open issues:
* I have not taken a hard look at whether our coverage is still good enough without the staging tests or not
* `make test` default is not affected: developers need to `TEST_ARGS=--skip-staging  make test`
* If this is merged, need to file a reminder to remove `--skip-staging` at some point

Fixes #988

