### PR TITLE
test_sign: disable more staging tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: test (interactive)
         if: (github.event_name != 'pull_request') || !github.event.pull_request.head.repo.fork
-        run: make test-interactive TEST_ARGS="-vv --showlocals"
+        run: make test-interactive TEST_ARGS="-vv --showlocals --skip-staging"
 
       - uses: ./.github/actions/upload-coverage
         # only aggregate test coverage over linux-based tests to avoid any OS-specific filesystem information stored in

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -262,9 +262,12 @@ def tuf_dirs(monkeypatch, tmp_path):
 
 @pytest.fixture
 def sign_ctx_and_ident_for_env(
+    pytestconfig,
     env: str,
 ) -> tuple[type[SigningContext], type[IdentityToken]]:
     if env == "staging":
+        if pytestconfig.getoption("skip-staging"):
+            pytest.skip("skipping staging test variant due to --skip-staging")
         ctx_cls = SigningContext.staging
     elif env == "production":
         ctx_cls = SigningContext.production

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -266,8 +266,6 @@ def sign_ctx_and_ident_for_env(
     env: str,
 ) -> tuple[type[SigningContext], type[IdentityToken]]:
     if env == "staging":
-        # if pytestconfig.getoption("skip-staging"):
-        #     pytest.skip("skipping staging test variant due to --skip-staging")
         ctx_cls = SigningContext.staging
     elif env == "production":
         ctx_cls = SigningContext.production

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -266,8 +266,8 @@ def sign_ctx_and_ident_for_env(
     env: str,
 ) -> tuple[type[SigningContext], type[IdentityToken]]:
     if env == "staging":
-        if pytestconfig.getoption("skip-staging"):
-            pytest.skip("skipping staging test variant due to --skip-staging")
+        # if pytestconfig.getoption("skip-staging"):
+        #     pytest.skip("skipping staging test variant due to --skip-staging")
         ctx_cls = SigningContext.staging
     elif env == "production":
         ctx_cls = SigningContext.production

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -36,11 +36,7 @@ class TestSigningContext:
         assert SigningContext.staging() is not None
 
 
-# TODO: re-add "staging" as an env to each test below, once staging is stabilized.
-# See: https://github.com/sigstore/sigstore-python/issues/995
-
-
-@pytest.mark.parametrize("env", ["production"])
+@pytest.mark.parametrize("env", ["staging", "production"])
 @pytest.mark.ambient_oidc
 def test_sign_rekor_entry_consistent(sign_ctx_and_ident_for_env):
     ctx_cls, identity = sign_ctx_and_ident_for_env
@@ -62,7 +58,7 @@ def test_sign_rekor_entry_consistent(sign_ctx_and_ident_for_env):
     assert expected_entry.log_index == actual_entry.log_index
 
 
-@pytest.mark.parametrize("env", ["production"])
+@pytest.mark.parametrize("env", ["staging", "production"])
 @pytest.mark.ambient_oidc
 def test_sct_verify_keyring_lookup_error(sign_ctx_and_ident_for_env, monkeypatch):
     ctx, identity = sign_ctx_and_ident_for_env
@@ -81,7 +77,7 @@ def test_sct_verify_keyring_lookup_error(sign_ctx_and_ident_for_env, monkeypatch
             signer.sign_artifact(payload)
 
 
-@pytest.mark.parametrize("env", ["production"])
+@pytest.mark.parametrize("env", ["staging", "production"])
 @pytest.mark.ambient_oidc
 def test_sct_verify_keyring_error(sign_ctx_and_ident_for_env, monkeypatch):
     ctx, identity = sign_ctx_and_ident_for_env
@@ -102,7 +98,7 @@ def test_sct_verify_keyring_error(sign_ctx_and_ident_for_env, monkeypatch):
             signer.sign_artifact(payload)
 
 
-@pytest.mark.parametrize("env", ["production"])
+@pytest.mark.parametrize("env", ["staging", "production"])
 @pytest.mark.ambient_oidc
 def test_identity_proof_claim_lookup(sign_ctx_and_ident_for_env, monkeypatch):
     ctx_cls, identity = sign_ctx_and_ident_for_env

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -36,7 +36,11 @@ class TestSigningContext:
         assert SigningContext.staging() is not None
 
 
-@pytest.mark.parametrize("env", ["staging", "production"])
+# TODO: re-add "staging" as an env to each test below, once staging is stabilized.
+# See: https://github.com/sigstore/sigstore-python/issues/995
+
+
+@pytest.mark.parametrize("env", ["production"])
 @pytest.mark.ambient_oidc
 def test_sign_rekor_entry_consistent(sign_ctx_and_ident_for_env):
     ctx_cls, identity = sign_ctx_and_ident_for_env
@@ -58,7 +62,7 @@ def test_sign_rekor_entry_consistent(sign_ctx_and_ident_for_env):
     assert expected_entry.log_index == actual_entry.log_index
 
 
-@pytest.mark.parametrize("env", ["staging", "production"])
+@pytest.mark.parametrize("env", ["production"])
 @pytest.mark.ambient_oidc
 def test_sct_verify_keyring_lookup_error(sign_ctx_and_ident_for_env, monkeypatch):
     ctx, identity = sign_ctx_and_ident_for_env
@@ -77,7 +81,7 @@ def test_sct_verify_keyring_lookup_error(sign_ctx_and_ident_for_env, monkeypatch
             signer.sign_artifact(payload)
 
 
-@pytest.mark.parametrize("env", ["staging", "production"])
+@pytest.mark.parametrize("env", ["production"])
 @pytest.mark.ambient_oidc
 def test_sct_verify_keyring_error(sign_ctx_and_ident_for_env, monkeypatch):
     ctx, identity = sign_ctx_and_ident_for_env
@@ -98,7 +102,7 @@ def test_sct_verify_keyring_error(sign_ctx_and_ident_for_env, monkeypatch):
             signer.sign_artifact(payload)
 
 
-@pytest.mark.parametrize("env", ["staging", "production"])
+@pytest.mark.parametrize("env", ["production"])
 @pytest.mark.ambient_oidc
 def test_identity_proof_claim_lookup(sign_ctx_and_ident_for_env, monkeypatch):
     ctx_cls, identity = sign_ctx_and_ident_for_env


### PR DESCRIPTION
~~WIP, trying other routes as well.~~

This ensures that tests using `env` to load the staging instance are also skipped by `--skip-staging`.