### PR TITLE
_cli: emit .sigstore.json by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ All versions prior to 0.9.0 are untracked.
 * **BREAKING API CHANGE**: `Verifier.verify(...)` now takes a `sigstore.models.Bundle`,
   instead of a `VerificationMaterials` ([#937](https://github.com/sigstore/sigstore-python/pull/937))
 
+* **BREAKING CLI CHANGE**: `sigstore sign` now emits `{input}.sigstore.json`
+  by default instead of `{input}.sigstore`, per the client specification
+  ([#1007](https://github.com/sigstore/sigstore-python/pull/1007))
+
 * sigstore-python now requires inclusion proofs in all signing and verification
   flows, regardless of bundle version of input types. Inputs that do not
   have an inclusion proof (such as detached materials) cause an online lookup

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ OpenID Connect options:
                         False)
 
 Output options:
-  --no-default-files    Don't emit the default output files ({input}.sigstore)
-                        (default: False)
+  --no-default-files    Don't emit the default output files
+                        ({input}.sigstore.json) (default: False)
   --signature FILE, --output-signature FILE
                         Write a single signature to the given file; does not
                         work with multiple input files (default: None)

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -283,7 +283,7 @@ def _parser() -> argparse.ArgumentParser:
         "--no-default-files",
         action="store_true",
         default=_boolify_env("SIGSTORE_NO_DEFAULT_FILES"),
-        help="Don't emit the default output files ({input}.sigstore)",
+        help="Don't emit the default output files ({input}.sigstore.json)",
     )
     output_options.add_argument(
         "--signature",
@@ -559,7 +559,7 @@ def _sign(args: argparse.Namespace) -> None:
         output_dir.mkdir(parents=True, exist_ok=True)
 
         if not bundle and not args.no_default_files:
-            bundle = output_dir / f"{file.name}.sigstore"
+            bundle = output_dir / f"{file.name}.sigstore.json"
 
         if not args.overwrite:
             extants = []


### PR DESCRIPTION
This completes our migration to both emitting and verifying `{foo}.sigstore.json` by default. 3.0 will include `sigstore verify` falling back to `{foo}.sigstore` if `.sigstore.json` isn't present, but this fallback can be removed in 4.0.

Closes #814.

CC @loosebazooka for viz, since I know you've looked at similar things recently 🙂 

