### PR TITLE
sigstore: uniform user-agent with sigstore version

### DIFF
--- a/sigstore/_internal/__init__.py
+++ b/sigstore/_internal/__init__.py
@@ -18,3 +18,9 @@ sigstore-python's internal APIs.
 Everything in these APIs is considered internal and unstable, and is not
 subject to any stability guarantees.
 """
+
+from requests import __version__ as requests_version
+
+from sigstore import __version__ as sigstore_version
+
+USER_AGENT = f"sigstore-python/{sigstore_version} (python-requests/{requests_version})"

--- a/sigstore/_internal/fulcio/client.py
+++ b/sigstore/_internal/fulcio/client.py
@@ -44,6 +44,7 @@ from cryptography.x509.certificate_transparency import (
 )
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from sigstore._internal import USER_AGENT
 from sigstore._internal.sct import (
     UnexpectedSctCountException,
     _get_precertificate_signed_certificate_timestamps,
@@ -338,6 +339,11 @@ class FulcioClient:
         _logger.debug(f"Fulcio client using URL: {url}")
         self.url = url
         self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "User-Agent": USER_AGENT,
+            }
+        )
 
     def __del__(self) -> None:
         """

--- a/sigstore/_internal/rekor/client.py
+++ b/sigstore/_internal/rekor/client.py
@@ -28,6 +28,7 @@ from urllib.parse import urljoin
 import rekor_types
 import requests
 
+from sigstore._internal import USER_AGENT
 from sigstore.models import LogEntry
 
 _logger = logging.getLogger(__name__)
@@ -228,7 +229,11 @@ class RekorClient:
         self.url = urljoin(url, "api/v1/")
         self.session = requests.Session()
         self.session.headers.update(
-            {"Content-Type": "application/json", "Accept": "application/json"}
+            {
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "User-Agent": USER_AGENT,
+            }
         )
 
     def __del__(self) -> None:

--- a/sigstore/oidc.py
+++ b/sigstore/oidc.py
@@ -31,6 +31,7 @@ import jwt
 import requests
 from pydantic import BaseModel, StrictStr
 
+from sigstore._internal import USER_AGENT
 from sigstore.errors import Error, NetworkError
 
 DEFAULT_OAUTH_ISSUER_URL = "https://oauth2.sigstore.dev/auth"
@@ -255,12 +256,15 @@ class Issuer:
         which is then used to bootstrap the issuer's state (such
         as authorization and token endpoints).
         """
+        self.session = requests.Session()
+        self.session.headers.update({"User-Agent": USER_AGENT})
+
         oidc_config_url = urllib.parse.urljoin(
             f"{base_url}/", ".well-known/openid-configuration"
         )
 
         try:
-            resp: requests.Response = requests.get(oidc_config_url, timeout=30)
+            resp: requests.Response = self.session.get(oidc_config_url, timeout=30)
         except (requests.ConnectionError, requests.Timeout) as exc:
             raise NetworkError from exc
 
@@ -352,7 +356,7 @@ class Issuer:
         )
         logging.debug(f"PAYLOAD: data={data}")
         try:
-            resp: requests.Response = requests.post(
+            resp = self.session.post(
                 self.oidc_config.token_endpoint,
                 data=data,
                 auth=auth,


### PR DESCRIPTION
This sets the UA in the Fulcio, Rekor, and OIDC clients. I haven't touched the TUF client since I wasn't sure how to access the underlying `requests.Session` there 🙂 

See #985.