### PR TITLE
bump sigstore-protobuf-specs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   "requests",
   "rich ~= 13.0",
   "rfc8785 ~= 0.1.2",
-  "sigstore-protobuf-specs ~= 0.3.1",
+  "sigstore-protobuf-specs ~= 0.3.2",
   # NOTE(ww): Under active development, so strictly pinned.
   "sigstore-rekor-types == 0.0.13",
   "tuf ~= 4.0",

--- a/sigstore/_internal/trustroot.py
+++ b/sigstore/_internal/trustroot.py
@@ -105,6 +105,11 @@ class Key:
         Construct a key from the given Sigstore PublicKey message.
         """
 
+        # NOTE: `raw_bytes` is marked as `optional` in the `PublicKey` message,
+        # for unclear reasons.
+        if not public_key.raw_bytes:
+            raise VerificationError("public key is empty")
+
         hash_algorithm: hashes.HashAlgorithm
         if public_key.key_details in self._RSA_SHA_256_DETAILS:
             hash_algorithm = hashes.SHA256()

--- a/sigstore/dsse.py
+++ b/sigstore/dsse.py
@@ -187,8 +187,7 @@ class Envelope:
         """
         Return a JSON string with this DSSE envelope's contents.
         """
-        # TODO: Unclear why mypy thinks this is returning `Any`.
-        return self._inner.to_json()  # type: ignore[no-any-return]
+        return self._inner.to_json()
 
 
 def _pae(type_: str, body: bytes) -> bytes:
@@ -217,7 +216,7 @@ def _sign(key: ec.EllipticCurvePrivateKey, stmt: Statement) -> Envelope:
         _Envelope(
             payload=stmt._contents,
             payload_type=Envelope._TYPE,
-            signatures=[Signature(sig=signature, keyid=None)],
+            signatures=[Signature(sig=signature)],
         )
     )
 
@@ -244,6 +243,4 @@ def _verify(key: ec.EllipticCurvePublicKey, evp: Envelope) -> bytes:
         except InvalidSignature:
             raise VerificationError("DSSE: invalid signature")
 
-    # TODO: Remove ignore when protobuf-specs contains a py.typed marker.
-    # See: <https://github.com/sigstore/protobuf-specs/pull/287>
-    return evp._inner.payload  # type: ignore[no-any-return]
+    return evp._inner.payload

--- a/sigstore/models.py
+++ b/sigstore/models.py
@@ -243,7 +243,7 @@ class LogEntry:
             log_index=self.log_index,
             log_id=common_v1.LogId(key_id=bytes.fromhex(self.log_id)),
             integrated_time=self.integrated_time,
-            inclusion_promise=inclusion_promise,
+            inclusion_promise=inclusion_promise,  # type: ignore[arg-type]
             inclusion_proof=inclusion_proof,
             canonicalized_body=base64.b64decode(self.body),
         )
@@ -494,8 +494,7 @@ class Bundle:
         """
         Return a JSON encoding of this bundle.
         """
-        # TODO: Unclear why mypy doesn't like this.
-        return self._inner.to_json()  # type: ignore[no-any-return]
+        return self._inner.to_json()
 
     @classmethod
     def from_parts(cls, cert: Certificate, sig: bytes, log_entry: LogEntry) -> Bundle:


### PR DESCRIPTION
Bumps us to `~= 0.3.2`. This patch release enables type hinting, allowing us to refine the types a bit here.