### PR TITLE
cli: allow DSSE verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ All versions prior to 0.9.0 are untracked.
   for representing in-toto statements and DSSE envelopes
   ([#930](https://github.com/sigstore/sigstore-python/pull/930))
 
+* CLI: The `sigstore verify` subcommands can now verify bundles containing
+  DSSE entries, such as those produced by
+  [GitHub Artifact Attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)
+  ([#1015](https://github.com/sigstore/sigstore-python/pull/1015))
+
 ### Removed
 
 * **BREAKING API CHANGE**: `SigningResult` has been removed.
@@ -81,6 +86,11 @@ All versions prior to 0.9.0 are untracked.
 * API: `sigstore.transparency` has been removed, and its pre-existing APIs
   have been re-homed under `sigstore.models`
   ([#990](https://github.com/sigstore/sigstore-python/pull/990))
+
+* CLI: `sigstore verify github` no longer requires the `--cert-identity` option.
+  Passing one or more alternative identity options (such as `--repository`)
+  is now sufficient
+  ([#1015](https://github.com/sigstore/sigstore-python/pull/1015))
 
 ## [2.1.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,8 +91,11 @@ All versions prior to 0.9.0 are untracked.
   to `oidc.IdentityToken.federated_issuer` to better describe what it actually
   contains. No functional changes have been made to it
   ([#1016](https://github.com/sigstore/sigstore-python/pull/1016))
-  
-  * CLI: `sigstore verify github` no longer requires the `--cert-identity` option.
+
+* API: `policy.Identity` now takes an **optional** OIDC issuer, rather than a
+  required one ([#1015](https://github.com/sigstore/sigstore-python/pull/1015))
+
+* CLI: `sigstore verify github` no longer requires the `--cert-identity` option.
   Passing one or more alternative identity options (such as `--repository`)
   is now sufficient
   ([#1015](https://github.com/sigstore/sigstore-python/pull/1015))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,9 +95,8 @@ All versions prior to 0.9.0 are untracked.
 * API: `policy.Identity` now takes an **optional** OIDC issuer, rather than a
   required one ([#1015](https://github.com/sigstore/sigstore-python/pull/1015))
 
-* CLI: `sigstore verify github` no longer requires the `--cert-identity` option.
-  Passing one or more alternative identity options (such as `--repository`)
-  is now sufficient
+* CLI: `sigstore verify github` now requires `--cert-identity` **or**
+  `--repository`, not just `--cert-identity`
   ([#1015](https://github.com/sigstore/sigstore-python/pull/1015))
 
 ## [2.1.5]

--- a/README.md
+++ b/README.md
@@ -205,10 +205,9 @@ to by a particular OIDC provider (like `https://github.com/login/oauth`).
 <!-- @begin-sigstore-verify-identity-help@ -->
 ```
 usage: sigstore verify identity [-h] [-v] [--certificate FILE]
-                                [--signature FILE] [--bundle FILE]
-                                --cert-identity IDENTITY [--offline]
-                                --cert-oidc-issuer URL [--staging]
-                                [--rekor-url URL]
+                                [--signature FILE] [--bundle FILE] [--offline]
+                                --cert-identity IDENTITY --cert-oidc-issuer
+                                URL [--staging] [--rekor-url URL]
                                 FILE [FILE ...]
 
 optional arguments:
@@ -227,11 +226,11 @@ Verification inputs:
   FILE                  The file to verify
 
 Verification options:
+  --offline             Perform offline verification; requires a Sigstore
+                        bundle (default: False)
   --cert-identity IDENTITY
                         The identity to check for in the certificate's Subject
                         Alternative Name (default: None)
-  --offline             Perform offline verification; requires a Sigstore
-                        bundle (default: False)
   --cert-oidc-issuer URL
                         The OIDC issuer URL to check for in the certificate's
                         OIDC issuer extension (default: None)
@@ -258,11 +257,10 @@ claims more precisely than `sigstore verify identity` allows:
 <!-- @begin-sigstore-verify-github-help@ -->
 ```
 usage: sigstore verify github [-h] [-v] [--certificate FILE]
-                              [--signature FILE] [--bundle FILE]
-                              --cert-identity IDENTITY [--offline]
-                              [--trigger EVENT] [--sha SHA] [--name NAME]
-                              [--repository REPO] [--ref REF] [--staging]
-                              [--rekor-url URL]
+                              [--signature FILE] [--bundle FILE] [--offline]
+                              [--cert-identity IDENTITY] [--trigger EVENT]
+                              [--sha SHA] [--name NAME] [--repository REPO]
+                              [--ref REF] [--staging] [--rekor-url URL]
                               FILE [FILE ...]
 
 optional arguments:
@@ -281,11 +279,11 @@ Verification inputs:
   FILE                  The file to verify
 
 Verification options:
+  --offline             Perform offline verification; requires a Sigstore
+                        bundle (default: False)
   --cert-identity IDENTITY
                         The identity to check for in the certificate's Subject
                         Alternative Name (default: None)
-  --offline             Perform offline verification; requires a Sigstore
-                        bundle (default: False)
   --trigger EVENT       The GitHub Actions event name that triggered the
                         workflow (default: None)
   --sha SHA             The `git` commit SHA that the workflow run was invoked

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -834,7 +834,9 @@ def _verify_github(args: argparse.Namespace) -> None:
         inner_policies.append(
             policy.Identity(
                 identity=args.cert_identity,
-                issuer="https://token.actions.githubusercontent.com",
+                # We always explicitly check the issuer below, so configuring
+                # it here is unnecessary.
+                issuer=None,
             )
         )
     if args.workflow_trigger:
@@ -850,6 +852,13 @@ def _verify_github(args: argparse.Namespace) -> None:
 
     if not inner_policies:
         _die(args, "No verification options supplied")
+
+    # No matter what the user configures above, we require the OIDC issuer to
+    # be GitHub Actions. We add this below the check above, since it doesn't
+    # constitute a sufficient policy check on its own.
+    inner_policies.append(
+        policy.OIDCIssuer("https://token.actions.githubusercontent.com")
+    )
 
     policy_ = policy.AllOf(inner_policies)
 

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -886,7 +886,6 @@ def _verify_common(
             bundle=bundle,
             policy=policy_,
         )
-    pass
 
 
 def _get_identity(args: argparse.Namespace) -> Optional[IdentityToken]:

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -839,7 +839,7 @@ def _verify_identity(args: argparse.Namespace) -> None:
                 )
 
             print(f"OK: {file}")
-        except VerificationError as exc:
+        except Error as exc:
             _logger.error(f"FAIL: {file}")
             exc.log_and_exit(_logger, args.verbose >= 1)
 
@@ -896,7 +896,7 @@ def _verify_github(args: argparse.Namespace) -> None:
                     policy=policy_,
                 )
             print(f"OK: {file}")
-        except VerificationError as exc:
+        except Error as exc:
             _logger.error(f"FAIL: {file}")
             exc.log_and_exit(_logger, args.verbose >= 1)
 

--- a/sigstore/dsse.py
+++ b/sigstore/dsse.py
@@ -29,7 +29,7 @@ from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 from sigstore_protobuf_specs.io.intoto import Envelope as _Envelope
 from sigstore_protobuf_specs.io.intoto import Signature
 
-from sigstore.errors import VerificationError
+from sigstore.errors import Error, VerificationError
 from sigstore.hashes import Hashed
 
 _logger = logging.getLogger(__name__)
@@ -101,7 +101,7 @@ class Statement:
         try:
             self._inner = _Statement.model_validate_json(contents)
         except ValidationError:
-            raise ValueError("malformed in-toto statement")
+            raise Error("malformed in-toto statement")
 
     def _matches_digest(self, digest: Hashed) -> bool:
         """
@@ -181,7 +181,7 @@ class _StatementBuilder:
                 predicate=self._predicate,
             )
         except ValidationError as e:
-            raise ValueError(f"invalid statement: {e}")
+            raise Error(f"invalid statement: {e}")
 
         return Statement(stmt.model_dump_json(by_alias=True).encode())
 

--- a/sigstore/dsse.py
+++ b/sigstore/dsse.py
@@ -25,10 +25,12 @@ from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from pydantic import BaseModel, ConfigDict, Field, RootModel, StrictStr, ValidationError
+from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 from sigstore_protobuf_specs.io.intoto import Envelope as _Envelope
 from sigstore_protobuf_specs.io.intoto import Signature
 
 from sigstore.errors import VerificationError
+from sigstore.hashes import Hashed
 
 _logger = logging.getLogger(__name__)
 
@@ -97,9 +99,28 @@ class Statement:
         """
         self._contents = contents
         try:
-            self._statement = _Statement.model_validate_json(contents)
+            self._inner = _Statement.model_validate_json(contents)
         except ValidationError:
             raise ValueError("malformed in-toto statement")
+
+    def _matches_digest(self, digest: Hashed) -> bool:
+        """
+        Returns a boolean indicating whether this in-toto Statement contains a subject
+        matching the given digest. The subject's name is **not** checked.
+
+        No digests other than SHA256 are currently supported.
+        """
+        if digest.algorithm != HashAlgorithm.SHA2_256:
+            raise VerificationError(f"unexpected digest algorithm: {digest.algorithm}")
+
+        for sub in self._inner.subjects:
+            sub_digest = sub.digest.root.get("sha256")
+            if sub_digest is None:
+                continue
+            if sub_digest == digest.digest.hex():
+                return True
+
+        return False
 
     def _pae(self) -> bytes:
         """

--- a/sigstore/hashes.py
+++ b/sigstore/hashes.py
@@ -22,6 +22,8 @@ from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
 from pydantic import BaseModel
 from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
+from sigstore.errors import Error
+
 
 class Hashed(BaseModel):
     """
@@ -44,7 +46,7 @@ class Hashed(BaseModel):
         """
         if self.algorithm == HashAlgorithm.SHA2_256:
             return rekor_types.hashedrekord.Algorithm.SHA256
-        raise ValueError(f"unknown hash algorithm: {self.algorithm}")
+        raise Error(f"unknown hash algorithm: {self.algorithm}")
 
     def _as_prehashed(self) -> Prehashed:
         """
@@ -52,4 +54,4 @@ class Hashed(BaseModel):
         """
         if self.algorithm == HashAlgorithm.SHA2_256:
             return Prehashed(hashes.SHA256())
-        raise ValueError(f"unknown hash algorithm: {self.algorithm}")
+        raise Error(f"unknown hash algorithm: {self.algorithm}")

--- a/sigstore/verify/policy.py
+++ b/sigstore/verify/policy.py
@@ -107,7 +107,7 @@ class _SingleX509ExtPolicy(ABC):
             raise VerificationError(
                 (
                     f"Certificate's {self.__class__.__name__} does not match "
-                    f"(got {ext_value}, expected {self._value})"
+                    f"(got '{ext_value}', expected '{self._value}')"
                 )
             )
 

--- a/sigstore/verify/policy.py
+++ b/sigstore/verify/policy.py
@@ -441,26 +441,33 @@ class UnsafeNoOp:
 class Identity:
     """
     Verifies the certificate's "identity", corresponding to the X.509v3 SAN.
-    Identities are verified modulo an OIDC issuer, so the issuer's URI
-    is also required.
+
+    Identities can be verified modulo an OIDC issuer, to prevent an unexpected
+    issuer from offering a particular identity.
 
     Supported SAN types include emails, URIs, and Sigstore-specific "other names".
     """
 
-    def __init__(self, *, identity: str, issuer: str):
+    _issuer: OIDCIssuer | None
+
+    def __init__(self, *, identity: str, issuer: str | None = None):
         """
         Create a new `Identity`, with the given expected identity and issuer values.
         """
 
         self._identity = identity
-        self._issuer = OIDCIssuer(issuer)
+        if issuer:
+            self._issuer = OIDCIssuer(issuer)
+        else:
+            self._issuer = None
 
     def verify(self, cert: Certificate) -> None:
         """
         Verify `cert` against the policy.
         """
 
-        self._issuer.verify(cert)
+        if self._issuer:
+            self._issuer.verify(cert)
 
         # Build a set of all valid identities.
         san_ext = cert.extensions.get_extension_for_class(SubjectAlternativeName).value


### PR DESCRIPTION
This allows for a _very_ limited form of DSSE verification via the `sigstore` CLI. In particular, it allows a DSSE-containing bundle to be verified, but only if:

* The DSSE payload is JSON;
* The JSON is an in-toto statement;
* The in-toto statement has at least one subject matching the input file's digest.

This limited form is compatible with what GitHub Artifact Attestations is doing and, in particular, is compatible with how `gh attestation verify` behaves.

~~WIP while I clean things up a little.~~

Closes #999.

Closes https://github.com/sigstore/sigstore-python/issues/780.