### PR TITLE
oidc: rename expected_certificate_subject -> federated_issuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@ All versions prior to 0.9.0 are untracked.
   have been re-homed under `sigstore.models`
   ([#990](https://github.com/sigstore/sigstore-python/pull/990))
 
+* API: `oidc.IdentityToken.expected_certificate_subject` has been renamed
+  to `oidc.IdentityToken.federated_issuer` to better describe what it actually
+  contains. No functional changes have been made to it
+  ([#1016](https://github.com/sigstore/sigstore-python/pull/1016))
+
 ## [2.1.5]
 
 ## Fixed

--- a/sigstore/oidc.py
+++ b/sigstore/oidc.py
@@ -205,9 +205,9 @@ class IdentityToken:
         return self._iss
 
     @property
-    def expected_certificate_subject(self) -> str:
+    def federated_issuer(self) -> str:
         """
-        Returns a URL identifying the **expected** subject for any Sigstore
+        Returns a URL identifying the **federated** issuer for any Sigstore
         certificate issued against this identity token.
 
         The behavior of this field is slightly subtle: for non-federated
@@ -218,7 +218,7 @@ class IdentityToken:
         implementation-defined claim.
 
         This attribute exists so that clients who wish to inspect the expected
-        subject of their certificates can do so without relying on
+        underlying issuer of their certificates can do so without relying on
         implementation-specific behavior.
         """
         if self._federated_issuer is not None:

--- a/test/unit/test_oidc.py
+++ b/test/unit/test_oidc.py
@@ -267,4 +267,4 @@ class TestIdentityToken:
         assert identity.in_validity_period()
         assert identity.identity == identity_value
         assert identity.issuer == iss
-        assert identity.expected_certificate_subject == iss if not fed_iss else fed_iss
+        assert identity.federated_issuer == iss if not fed_iss else fed_iss


### PR DESCRIPTION
See #970 and #567: this renames `expected_certificate_subject` to `federated_issuer` in an attempt to better clarify what this property is actually returning.