### PR TITLE
Upgrade tuf dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "sigstore-protobuf-specs ~= 0.3.2",
   # NOTE(ww): Under active development, so strictly pinned.
   "sigstore-rekor-types == 0.0.13",
-  "tuf ~= 4.0",
+  "tuf ~= 5.0",
   "platformdirs ~= 4.2",
 ]
 requires-python = ">=3.8"

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -33,6 +33,7 @@ from id import (
 )
 from tuf.api.exceptions import DownloadHTTPError
 from tuf.ngclient import FetcherInterface
+from tuf.ngclient.updater import requests_fetcher
 
 from sigstore._internal import tuf
 from sigstore._internal.rekor import _hashedrekord_from_parts
@@ -225,7 +226,7 @@ def null_policy():
 
 @pytest.fixture
 def mock_staging_tuf(monkeypatch, tuf_dirs):
-    """Mock that prevents tuf module from making requests: it returns staging
+    """Mock that prevents python-tuf from making requests: it returns staging
     assets from a local directory instead
 
     Return a tuple of dicts with the requested files and counts"""
@@ -244,7 +245,9 @@ def mock_staging_tuf(monkeypatch, tuf_dirs):
             failure[filename] += 1
             raise DownloadHTTPError("File not found", 404)
 
-    monkeypatch.setattr(tuf, "_get_fetcher", lambda: MockFetcher())
+    monkeypatch.setattr(
+        requests_fetcher, "RequestsFetcher", lambda app_user_agent: MockFetcher()
+    )
 
     return success, failure
 


### PR DESCRIPTION
The ngclient API that we use is fully backwards-compatible but I want to do two small changes so am bumping the required version:
* Don't poke into fetcher internals: the timeout is now the 30 seconds we wanted
* set user-agent through UpdaterConfig: this will end up as "sigstore-python/3.0.0rc2 tuf/5.0.0 python-requests/2.31.0" (a bit verbose perhaps but all of that is useful)
