### PR TITLE
release: remove pip cache usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
 
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
+          # NOTE: We intentionally don't use a cache in the release step,
+          # to reduce the risk of cache poisoning.
           python-version: "3.x"
-          cache: "pip"
-          cache-dependency-path: pyproject.toml
 
       - name: deps
         run: python -m pip install -U build


### PR DESCRIPTION
This is purely a defense in depth maneuver: an attacker could only poison our cache here by running arbitrary code on `main`. But we probably shouldn't be caching anyways, since it makes the release process/state more opaque 🙂 

Context: https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/