### PR TITLE
sigstore: type cleanup

### DIFF
--- a/sigstore/_internal/rekor/checkpoint.py
+++ b/sigstore/_internal/rekor/checkpoint.py
@@ -27,11 +27,11 @@ from typing import List
 
 from pydantic import BaseModel, Field, StrictStr
 
-from sigstore._internal.trust import RekorKeyring
 from sigstore._utils import KeyID
 from sigstore.errors import VerificationError
 
 if typing.TYPE_CHECKING:
+    from sigstore._internal.trust import RekorKeyring
     from sigstore.models import LogEntry
 
 

--- a/sigstore/_internal/sct.py
+++ b/sigstore/_internal/sct.py
@@ -37,7 +37,6 @@ from cryptography.x509.oid import ExtendedKeyUsageOID
 
 from sigstore._internal.trust import CTKeyring
 from sigstore._utils import (
-    DERCert,
     KeyID,
     cert_is_ca,
     key_id,
@@ -56,7 +55,7 @@ def _pack_signed_entry(
         #
         # [0]: opaque ASN.1Cert<1..2^24-1>
         pack_format = "!BBB{cert_der_len}s"
-        cert_der = DERCert(cert.public_bytes(encoding=serialization.Encoding.DER))
+        cert_der = cert.public_bytes(encoding=serialization.Encoding.DER)
     elif sct.entry_type == LogEntryType.PRE_CERTIFICATE:
         if not issuer_key_id or len(issuer_key_id) != 32:
             raise VerificationError("API misuse: issuer key ID missing")
@@ -68,7 +67,7 @@ def _pack_signed_entry(
         pack_format = "!32sBBB{cert_der_len}s"
 
         # Precertificates must have their SCT list extension filtered out.
-        cert_der = DERCert(cert.tbs_precertificate_bytes)
+        cert_der = cert.tbs_precertificate_bytes
         fields.append(issuer_key_id)
     else:
         raise VerificationError(f"unknown SCT log entry type: {sct.entry_type!r}")

--- a/sigstore/_utils.py
+++ b/sigstore/_utils.py
@@ -56,14 +56,6 @@ B64Str = NewType("B64Str", str)
 """
 A newtype for `str` objects that contain base64 encoded strings.
 """
-PEMCert = NewType("PEMCert", str)
-"""
-A newtype for `str` objects that contain PEM-encoded certificates.
-"""
-DERCert = NewType("DERCert", bytes)
-"""
-A newtype for `bytes` objects that contain DER-encoded certificates.
-"""
 KeyID = NewType("KeyID", bytes)
 """
 A newtype for `bytes` objects that contain a key id.


### PR DESCRIPTION
Just some small type-checking related cleanup: removes two almost completely unused `NewType`s and puts an import into a `TYPE_CHECKING` block.

