### PR TITLE
Add functionality to sign DSSE envelopes with arbitrary payloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ lint = [
   "mypy ~= 1.1",
   # NOTE(ww): ruff is under active development, so we pin conservatively here
   # and let Dependabot periodically perform this update.
-  "ruff < 0.4.11",
+  "ruff < 0.5.1",
   "types-requests",
   "types-pyOpenSSL",
 ]

--- a/sigstore/dsse.py
+++ b/sigstore/dsse.py
@@ -1,4 +1,5 @@
 # Copyright 2022 The Sigstore Authors
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -1,4 +1,5 @@
 # Copyright 2022 The Sigstore Authors
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -233,6 +234,17 @@ class Signer:
             self,
             envelope: dsse.Envelope,
     ) -> Bundle:
+        """
+        Signs the provided envelope's payload, and returns a
+        `Bundle containing the signed envelope and the verification
+        material.
+
+        Args:
+            envelope (dsse.Envelope): The envelope to be signed.
+
+        Returns:
+            Bundle: The bundle containing the signed DSSE envelope.
+        """
         cert = self._signing_cert()
 
         b64_cert = base64.b64encode(

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -21,7 +21,7 @@ import pytest
 from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
 import sigstore.oidc
-from sigstore.dsse import _StatementBuilder, _Subject, Envelope
+from sigstore.dsse import _StatementBuilder, _Subject, RawPayload
 from sigstore.errors import VerificationError
 from sigstore.hashes import Hashed
 from sigstore.sign import SigningContext
@@ -178,12 +178,11 @@ def test_sign_dsse_envelope(staging):
     sign_ctx, _, identity = staging
 
     ctx = sign_ctx()
-    payload = b"Hello World!"
-    payload_type = "type/custom/my_payload"
-
-    env = Envelope.from_payload(payload_type, payload)
+    payload = RawPayload(
+        payload_type="type/custom/my_payload",
+        payload=b"Hello World!")
 
     with ctx.signer(identity) as signer:
-        bundle = signer.sign_dsse_envelope(env)
+        bundle = signer.sign_dsse(payload)
 
         bundle.to_json()

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -1,4 +1,5 @@
 # Copyright 2022 The Sigstore Authors
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -20,7 +20,7 @@ import pytest
 from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
 import sigstore.oidc
-from sigstore.dsse import _StatementBuilder, _Subject
+from sigstore.dsse import _StatementBuilder, _Subject, Envelope
 from sigstore.errors import VerificationError
 from sigstore.hashes import Hashed
 from sigstore.sign import SigningContext
@@ -168,4 +168,21 @@ def test_sign_dsse(staging):
     with ctx.signer(identity) as signer:
         bundle = signer.sign_dsse(stmt)
         # Ensures that all of our inner types serialize as expected.
+        bundle.to_json()
+
+
+@pytest.mark.staging
+@pytest.mark.ambient_oidc
+def test_sign_dsse_envelope(staging):
+    sign_ctx, _, identity = staging
+
+    ctx = sign_ctx()
+    payload = b"Hello World!"
+    payload_type = "type/custom/my_payload"
+
+    env = Envelope.from_payload(payload_type, payload)
+
+    with ctx.signer(identity) as signer:
+        bundle = signer.sign_dsse_envelope(env)
+
         bundle.to_json()


### PR DESCRIPTION
#### Summary
Added functionality to sign DSSE envelopes with arbitrary payloads. This is to ensure model signing can in the future use sigstore with its own manifest format inside of a DSSE envelope.

Closes #982 


#### Release Note

* sign.py: `sign_dsse_envelope` takes an envelope as input value and adds a signature for its contents to the envelope
* dsse.py: `Envelope` provides a public classmethod to create an envelope based on an arbitrary payload type and payload
