### PR TITLE
models: add type annotation

### DIFF
--- a/sigstore/models.py
+++ b/sigstore/models.py
@@ -249,7 +249,7 @@ class LogEntry:
         )
 
         # Fill in the appropriate kind
-        body_entry = TypeAdapter(ProposedEntry).validate_json(
+        body_entry: ProposedEntry = TypeAdapter(ProposedEntry).validate_json(
             tlog_entry.canonicalized_body
         )
         if not isinstance(body_entry, (Hashedrekord, Dsse)):


### PR DESCRIPTION
Adds an explicit annotation for a type produced through `TypeAdapter`.

As best I can tell, this is the proximate behavior change in pydantic: https://github.com/pydantic/pydantic/pull/9570

(Unblocks our broken CI in the rest of the outstanding PRs.)