### PR TITLE
sigstore/dsse: reject DSSEs with >1 sig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Changed
+
+* API: `verify_dsse` now rejects bundles with DSSE envelopes that have more than
+  one signature, rather than checking all signatures against the same key
+  ([#1062](https://github.com/sigstore/sigstore-python/pull/1062))
+
 ## [3.0.0]
 
 Maintainers' note: this is a major release, with significant public API and CLI


### PR DESCRIPTION
This makes us more consistent with the protobuf-specs specified behavior, which stipulates that DSSEs should only contain one signature in the context of Sigstore bundles.

See also: https://github.com/sigstore/sigstore-go/issues/225f