### PR TITLE
tuf, trust: allow custom TUF base dir

### DIFF
--- a/sigstore/_internal/trust.py
+++ b/sigstore/_internal/trust.py
@@ -268,38 +268,45 @@ class TrustedRoot:
         cls,
         url: str,
         offline: bool = False,
+        base_dir: Path | None = None,
     ) -> TrustedRoot:
         """Create a new trust root from a TUF repository.
 
-        If `offline`, will use trust root in local TUF cache. Otherwise will
-        update the trust root from remote TUF repository.
+        If `offline`, TUF will use the trust root in the local cache. Otherwise
+        TUFF will update the trust root from remote TUF repository.
+
+        If `base_dir` is given, TUF will use it for appropriate local
+        subdirectories. If not given, appropriate subdirectories within
+        the user's data and cache directories will be used instead.
         """
-        path = TrustUpdater(url, offline).get_trusted_root_path()
+        path = TrustUpdater(
+            url, offline=offline, base_dir=base_dir
+        ).get_trusted_root_path()
         return cls.from_file(path)
 
     @classmethod
     def production(
         cls,
         offline: bool = False,
+        base_dir: Path | None = None,
     ) -> TrustedRoot:
         """Create new trust root from Sigstore production TUF repository.
 
-        If `offline`, will use trust root in local TUF cache. Otherwise will
-        update the trust root from remote TUF repository.
+        See `from_tuf` for the behavior of `offline` and `base_dir`.
         """
-        return cls.from_tuf(DEFAULT_TUF_URL, offline)
+        return cls.from_tuf(DEFAULT_TUF_URL, offline=offline, base_dir=base_dir)
 
     @classmethod
     def staging(
         cls,
         offline: bool = False,
+        base_dir: Path | None = None,
     ) -> TrustedRoot:
         """Create new trust root from Sigstore staging TUF repository.
 
-        If `offline`, will use trust root in local TUF cache. Otherwise will
-        update the trust root from remote TUF repository.
+        See `from_tuf` for the behavior of `offline` and `base_dir`.
         """
-        return cls.from_tuf(STAGING_TUF_URL, offline)
+        return cls.from_tuf(STAGING_TUF_URL, offline=offline, base_dir=base_dir)
 
     def _get_tlog_keys(
         self, tlogs: list[TransparencyLogInstance], purpose: KeyringPurpose

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -306,6 +306,10 @@ class SigningContext:
 
         `rekor` is a `RekorClient` capable of connecting to a Rekor instance
         and creating transparency log entries.
+
+        `trusted_root` is a `TrustedRoot` that conveys the Sigstore root of trust.
+
+        @private
         """
         self._fulcio = fulcio
         self._rekor = rekor

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -66,8 +66,9 @@ class Verifier:
         `rekor` is a `RekorClient` capable of connecting to a Rekor instance
         containing logs for the file(s) being verified.
 
-        `fulcio_certificate_chain` is a list of PEM-encoded X.509 certificates,
-        establishing the trust chain for the signing certificate and signature.
+        `trusted_root` is a `TrustedRoot` that conveys the Sigstore root of trust.
+
+        @private
         """
         self._rekor = rekor
         self._fulcio_certificate_chain: List[X509] = [

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -254,11 +254,11 @@ def mock_staging_tuf(monkeypatch, tuf_dirs):
 
 @pytest.fixture
 def tuf_dirs(monkeypatch, tmp_path):
-    # Patch _get_dirs as well, to avoid polluting the user's actual cache
+    # Patch _get_user_tuf_dirs as well, to avoid polluting the user's actual cache
     # with test assets.
     data_dir = tmp_path / "data" / "tuf"
     cache_dir = tmp_path / "cache" / "tuf"
-    monkeypatch.setattr(tuf, "_get_dirs", lambda u: (data_dir, cache_dir))
+    monkeypatch.setattr(tuf, "_get_user_tuf_dirs", lambda u: (data_dir, cache_dir))
 
     return (data_dir, cache_dir)
 


### PR DESCRIPTION
This adds `base_dir` kwargs where appropriate, trickling down to the TUF `TrustUpdater`'s initialization. When supplied, TUF will initialize into appropriate subdirectories within `base_dir`, rather than attempting to initialize under the current `$HOME`.

~~Needs tests.~~

Closes #1067.