### PR TITLE
API: make _StatementBuilder public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ All versions prior to 0.9.0 are untracked.
 ### Added
 
 * API: `dsse.StatementBuilder` has been added. It can be used to construct an
-  in-toto `Statement` for subsequent enveloping and signing
+  in-toto `Statement` for subsequent enveloping and signing.
+  This API is public but is **not considered stable until the next major
+  release.**
   ([#1077](https://github.com/sigstore/sigstore-python/pull/1077))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Added
+
+* API: `dsse.StatementBuilder` has been added. It can be used to construct an
+  in-toto `Statement` for subsequent enveloping and signing
+  ([#1077](https://github.com/sigstore/sigstore-python/pull/1077))
+
 ### Changed
 
 * API: `verify_dsse` now rejects bundles with DSSE envelopes that have more than

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -20,7 +20,7 @@ import pytest
 from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 
 import sigstore.oidc
-from sigstore.dsse import _StatementBuilder, _Subject
+from sigstore.dsse import StatementBuilder, _Subject
 from sigstore.errors import VerificationError
 from sigstore.hashes import Hashed
 from sigstore.sign import SigningContext
@@ -152,7 +152,7 @@ def test_sign_dsse(staging):
 
     ctx = sign_ctx()
     stmt = (
-        _StatementBuilder()
+        StatementBuilder()
         .subjects(
             [_Subject(name="null", digest={"sha256": hashlib.sha256(b"").hexdigest()})]
         )

--- a/test/unit/verify/test_verifier.py
+++ b/test/unit/verify/test_verifier.py
@@ -18,7 +18,7 @@ import hashlib
 import pretend
 import pytest
 
-from sigstore.dsse import _StatementBuilder, _Subject
+from sigstore.dsse import StatementBuilder, _Subject
 from sigstore.errors import VerificationError
 from sigstore.models import Bundle
 from sigstore.verify import policy
@@ -159,7 +159,7 @@ def test_verifier_dsse_roundtrip(staging):
 
     ctx = signer_cls()
     stmt = (
-        _StatementBuilder()
+        StatementBuilder()
         .subjects(
             [_Subject(name="null", digest={"sha256": hashlib.sha256(b"").hexdigest()})]
         )


### PR DESCRIPTION
Adds the public `StatementBuilder` API, created by making `_StatementBuilder` public. Also adds an alternative construction route for `Statement`, allowing it to be directly constructed from an internal (still private) `_Statement`, avoiding an unnecessary serde round-trip.

Note: This makes `StatementBuilder` public, but explicitly doesn't commit it to SemVer just yet; I don't expect it to change very much, but in the event it does I don't want us locked into design decisions for the entire 3.x lifetime 🙂 

Closes #1076.

