### PR TITLE
Add minimum version to interrogate dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,7 @@ Documentation = "https://sigstore.github.io/sigstore-python/"
 test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
 lint = [
   "bandit",
-  # HACK(ww): interrogate needs setuptools to provide `pkg_resources` on Python 3.12+;
-  # remove this when https://github.com/econchick/interrogate/issues/164 is resolved.
-  "setuptools",
-  "interrogate",
+  "interrogate >= 1.7.0",
   "mypy ~= 1.1",
   # NOTE(ww): ruff is under active development, so we pin conservatively here
   # and let Dependabot periodically perform this update.


### PR DESCRIPTION
Before, `setuptools` was included in the `lint` dependencies due to a bug in `interrogate`. Since that bug was [fixed](https://github.com/econchick/interrogate/issues/164#issuecomment-2041231552), we remove `setuptools` and add a constraint to the `interrogate` version to ensure we use a version with the fix.

cc @woodruffw 