### PR TITLE
Print in-toto statement when verifying DSSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Changed
+
+* CLI: The `sigstore verify` command now outputs the inner in-toto statement
+  when verifying DSSE envelopes. If verification is successful, the output
+  will be "OK: $FILENAME" followed by the inner in-toto statement. This allows
+  the user to see the statement's predicate, which `sigstore-python` does not
+  verify and should be verified by the user.
+
 ## [3.2.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
-### Changed
+### Added
 
 * CLI: The `sigstore verify` command now outputs the inner in-toto statement
   when verifying DSSE envelopes. If verification is successful, the output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ All versions prior to 0.9.0 are untracked.
 
 * CLI: The `sigstore verify` command now outputs the inner in-toto statement
   when verifying DSSE envelopes. If verification is successful, the output
-  will be "OK: $FILENAME" followed by the inner in-toto statement. This allows
-  the user to see the statement's predicate, which `sigstore-python` does not
-  verify and should be verified by the user.
+  will be the inner in-toto statement. This allows the user to see the
+  statement's predicate, which `sigstore-python` does not verify and should be
+  verified by the user.
 
 ## [3.2.0]
 

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -812,7 +812,7 @@ def _verify_identity(args: argparse.Namespace) -> None:
 
         try:
             statement = _verify_common(verifier, hashed, bundle, policy_)
-            print(f"OK: {file}")
+            print(f"OK: {file}", file=sys.stderr)
             if statement is not None:
                 print(statement._contents.decode())
         except Error as exc:
@@ -860,7 +860,7 @@ def _verify_github(args: argparse.Namespace) -> None:
     for file, hashed, bundle in materials:
         try:
             statement = _verify_common(verifier, hashed, bundle, policy_)
-            print(f"OK: {file}")
+            print(f"OK: {file}", file=sys.stderr)
             if statement is not None:
                 print(statement._contents)
         except Error as exc:


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

#### Summary
Part of https://github.com/sigstore/sigstore-python/issues/1111. This changes the `sigstore verify` CLI command so that when verifying a bundle containing a DSSE envelope, if verification succeeds the inner in-toto statement is printed to the user.

```sh
$ sigstore verify identity README.md --cert-identity me@example.com --cert-oidc-issuer https://issuer.example.com
OK: README.md
{"_type":"https://in-toto.io/Statement/v1","subject":[{"name":"README.md","digest":{"sha256":"033be49064ed2a5f50bf81950f38741a8c550bc8076447452152c7b9d28728bc"}}],"predicateType":"slsaprovenance0_2","predicate":{"builder":{"id":"https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v2.0.0"},"build_type":"https://github.com/slsa-framework/slsa-github-generator/generic@v1","invocation":{"config_source":{"uri":"git+https://gi.....
....
```


This is done because `sigstore-python` only verifies the subjects of the DSSE envelope match the artifacts being verified, it does not do any verification on the predicate of the statement. This should be done by the user, which is why we print the statement after verification succeeds, so that the user has easy access to it.

#### Release Note

* CLI: The `sigstore verify` command now outputs the inner in-toto statement
  when verifying DSSE envelopes. If verification is successful, the output
  will be "OK: $FILENAME" followed by the inner in-toto statement. This allows
  the user to see the statement's predicate, which `sigstore-python` does not
  verify and should be verified by the user.


cc @woodruffw 
