### PR TITLE
Add support for verifying digests to CLI verify commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ All versions prior to 0.9.0 are untracked.
   a path to the file containing the predicate, and the predicate type.
   Currently only the SLSA Provenance v0.2 and v1.0 types are supported.
 
+* CLI: The `sigstore verify` command now supports verifying digests. This means
+  that the user can now pass a digest like `sha256:aaaa....` instead of the
+  path to an artifact, and `sigstore-python` will verify it as if it was the
+  artifact with that digest.
+
 ## [3.2.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ usage: sigstore verify identity [-h] [-v] [--certificate FILE]
                                 [--signature FILE] [--bundle FILE] [--offline]
                                 --cert-identity IDENTITY --cert-oidc-issuer
                                 URL
-                                FILE [FILE ...]
+                                FILE_OR_DIGEST [FILE_OR_DIGEST ...]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -262,7 +262,8 @@ Verification inputs:
                         multiple inputs (default: None)
   --bundle FILE         The Sigstore bundle to verify with; not used with
                         multiple inputs (default: None)
-  FILE                  The file to verify
+  FILE_OR_DIGEST        The file path or the digest to verify. The digest
+                        should start with the 'sha256:' prefix.
 
 Verification options:
   --offline             Perform offline verification; requires a Sigstore
@@ -290,7 +291,7 @@ usage: sigstore verify github [-h] [-v] [--certificate FILE]
                               [--cert-identity IDENTITY] [--trigger EVENT]
                               [--sha SHA] [--name NAME] [--repository REPO]
                               [--ref REF]
-                              FILE [FILE ...]
+                              FILE_OR_DIGEST [FILE_OR_DIGEST ...]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -305,7 +306,8 @@ Verification inputs:
                         multiple inputs (default: None)
   --bundle FILE         The Sigstore bundle to verify with; not used with
                         multiple inputs (default: None)
-  FILE                  The file to verify
+  FILE_OR_DIGEST        The file path or the digest to verify. The digest
+                        should start with the 'sha256:' prefix.
 
 Verification options:
   --offline             Perform offline verification; requires a Sigstore
@@ -419,6 +421,18 @@ Multiple files can be verified at once:
 $ python -m sigstore verify identity foo.txt bar.txt \
     --cert-identity 'hamilcar@example.com' \
     --cert-oidc-issuer 'https://github.com/login/oauth'
+```
+
+### Verifying a digest instead of a file
+
+`sigstore-python` supports verifying digests directly, without requiring the artifact to be
+present. The digest should be prefixed with the `sha256:` string:
+
+```console
+$ python -m sigstore verify identity sha256:ce8ab2822671752e201ea1e19e8c85e73d497e1c315bfd9c25f380b7625d1691 \
+    --cert-identity 'hamilcar@example.com' \
+    --cert-oidc-issuer 'https://github.com/login/oauth'
+    --bundle 'foo.txt.sigstore.json'
 ```
 
 ### Verifying signatures from GitHub Actions

--- a/sigstore/hashes.py
+++ b/sigstore/hashes.py
@@ -25,7 +25,7 @@ from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
 from sigstore.errors import Error
 
 
-class Hashed(BaseModel):
+class Hashed(BaseModel, frozen=True):
     """
     Represents a hashed value.
     """
@@ -55,3 +55,9 @@ class Hashed(BaseModel):
         if self.algorithm == HashAlgorithm.SHA2_256:
             return Prehashed(hashes.SHA256())
         raise Error(f"unknown hash algorithm: {self.algorithm}")
+
+    def __str__(self) -> str:
+        """
+        Returns a str representation of this `Hashed`.
+        """
+        return f"{self.algorithm.name}:{self.digest.hex()}"

--- a/test/unit/test_hashes.py
+++ b/test/unit/test_hashes.py
@@ -1,0 +1,35 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import hashlib
+
+import pytest
+from sigstore_protobuf_specs.dev.sigstore.common.v1 import HashAlgorithm
+
+from sigstore.hashes import Hashed
+
+
+class TestHashes:
+    @pytest.mark.parametrize(
+        ("algorithm", "digest"),
+        [
+            (HashAlgorithm.SHA2_256, hashlib.sha256(b"").hexdigest()),
+            (HashAlgorithm.SHA2_384, hashlib.sha384(b"").hexdigest()),
+            (HashAlgorithm.SHA2_512, hashlib.sha512(b"").hexdigest()),
+            (HashAlgorithm.SHA3_256, hashlib.sha3_256(b"").hexdigest()),
+            (HashAlgorithm.SHA3_384, hashlib.sha3_384(b"").hexdigest()),
+        ],
+    )
+    def test_hashed_repr(self, algorithm, digest):
+        hashed = Hashed(algorithm=algorithm, digest=bytes.fromhex(digest))
+        assert str(hashed) == f"{algorithm.name}:{digest}"


### PR DESCRIPTION
#### Summary
This PR changes the `sigstore verify` CLI command so that it accepts digests as inputs (in addition to files).
Concretely:

```shell
# Before
sigstore verify identity ..... path/to/artifact.zip  # can only verify an artifact

# After
sigstore verify identity ..... path/to/artifact.zip  # can verify an artifact
sigstore verify identity ... --bundle b.sigstore.json sha256:aaabbbb.....  # can also verify an artifact's digest
```

This is useful in scenarios where the user doesn't want/need to download the artifact, but has access to its digest.

Related to https://github.com/sigstore/sigstore-conformance/issues/157

#### Release Note


* CLI: The `sigstore verify` command now supports verifying digests. This means
  that the user can now pass a digest like `sha256:aaaa....` instead of the
  path to an artifact, and `sigstore-python` will verify it as if it was the
  artifact with that digest.


#### Documentation

Example added to the README

cc @woodruffw 