### PR TITLE
prep 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+## [3.3.0]
+
 ### Added
 
 * CLI: The `sigstore verify` command now outputs the inner in-toto statement
@@ -498,7 +500,8 @@ This is a corrective release for [2.1.1].
 
 
 <!--Release URLs -->
-[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.2.0...HEAD
+[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.3.0...HEAD
+[3.3.0]: https://github.com/sigstore/sigstore-python/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/sigstore/sigstore-python/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/sigstore/sigstore-python/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/sigstore/sigstore-python/compare/v2.1.5...v3.0.0

--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -25,4 +25,4 @@ Otherwise, here are some quick starting points:
 * `sigstore.sign`: creation of Sigstore signatures
 """
 
-__version__ = "3.2.0"
+__version__ = "3.3.0"


### PR DESCRIPTION
Release 3.3.0

cc @woodruffw 

Changelog:
* CLI: The `sigstore verify` command now outputs the inner in-toto statement
  when verifying DSSE envelopes. If verification is successful, the output
  will be the inner in-toto statement. This allows the user to see the
  statement's predicate, which `sigstore-python` does not verify and should be
  verified by the user.
* CLI: The `sigstore attest` subcommand has been added. This command is
  similar to `cosign attest` in that it signs over an artifact and a
  predicate using a DSSE envelope. This commands requires the user to pass
  a path to the file containing the predicate, and the predicate type.
  Currently only the SLSA Provenance v0.2 and v1.0 types are supported.
* CLI: The `sigstore verify` command now supports verifying digests. This means
  that the user can now pass a digest like `sha256:aaaa....` instead of the
  path to an artifact, and `sigstore-python` will verify it as if it was the
  artifact with that digest.