### PR TITLE
workflows: various CQA fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
     runs-on: ${{ matrix.conf.os }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
@@ -88,6 +90,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
@@ -28,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       # NOTE: We intentionally check `--help` rendering against our minimum Python,
       # since it changes slightly between Python versions.
@@ -47,6 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
+
       # adapted from Warehouse's bin/licenses
       - run: |
           for fn in $(find . -type f -name "*.py"); do
@@ -60,6 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       # NOTE: We intentionally check test certificates against our minimum supported Python.
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0

--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -36,6 +36,8 @@ jobs:
           # NOTE: Needed for `git describe` below.
           fetch-depth: 0
           fetch-tags: true
+          # NOTE: Needed to push back to the repo.
+          persist-credentials: true
 
       - name: Get latest tag
         run: |
@@ -118,6 +120,8 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ env.SIGSTORE_PIN_REQUIREMENTS_BRANCH }}
+          # NOTE: Needed to push back to the repo.
+          persist-credentials: true
 
       - name: Reset remote PR branch
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:

--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -29,11 +29,12 @@ jobs:
       - name: Populate reference from context
         if: ${{ env.SIGSTORE_REF == '' }}
         run: |
-          echo "SIGSTORE_REF=${{ github.ref }}" >> "${GITHUB_ENV}"
+          echo "SIGSTORE_REF=${GITHUB_REF}" >> "${GITHUB_ENV}"
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ env.SIGSTORE_REF }}
+          persist-credentials: false
 
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         name: Install Python ${{ matrix.python_version }}

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -8,8 +8,8 @@ on:
   push:
     branches: [ main ]
 
-# Declare default permissions as read only.
-permissions: read-all
+# Clear default permissions.
+permissions: {}
 
 jobs:
   analysis:

--- a/.github/workflows/staging-tests.yml
+++ b/.github/workflows/staging-tests.yml
@@ -1,12 +1,5 @@
 name: Staging Instance Tests
 
-permissions:
-  # Needed to access the workflow's OIDC identity.
-  id-token: write
-
-  # Needed to create an issue, on failure.
-  issues: write
-
 on:
   push:
     branches:
@@ -17,8 +10,16 @@ on:
 jobs:
   staging-tests:
     runs-on: ubuntu-latest
+    permissions:
+      # Needed to access the workflow's OIDC identity.
+      id-token: write
+
+      # Needed to create an issue, on failure.
+      issues: write
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:


### PR DESCRIPTION
A bunch of small quality fixes to our workflows.

* Adds explicit `persist-credential:` settings everywhere, disabling the (default) credential persistence as much as possible.
* Moves all permissions into steps and lowers the default outer permissions where explicit.
* Replaces a shell interpolation of `github.ref` with `GITHUB_REF`.