### PR TITLE
workflows/release: enable PEP 740 attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@897895f1e160c830e369f9779632ebc134688e1b # v1.10.2
         with:
           packages-dir: built-packages/
+          attestations: true
 
   release-github:
     needs: [build, generate-provenance]
@@ -147,7 +148,6 @@ jobs:
           # smoketest-artifacts/ contains the signatures and certificates.
           files: |
             built-packages/*
-            smoketest-artifacts/*
 
   # Trigger workflow to generate pinned requirements.txt.
   pin-requirements:


### PR DESCRIPTION
This enables attestation generation while uploading to PyPI. Future versions of the `gh-action-pypi-publish` action will enable this by default, but we want to get in on the ground floor.

It also disables uploading of the "smoketest" artifacts to the GitHub-side release, since these don't correspond 1-1 with the PyPI attestations (they're composed only of hashes of the file, and don't use a DSSE payload). This will hopefully eliminate some confusion + guide users towards the PyPI hosted ones as canonical.