### PR TITLE
pyproject: pin protobuf-specs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ dependencies = [
   "requests",
   "rich ~= 13.0",
   "rfc8785 ~= 0.1.2",
-  "sigstore-protobuf-specs ~= 0.3.2",
-  # NOTE(ww): Under active development, so strictly pinned.
+  # NOTE(ww): Both under active development, so strictly pinned.
+  "sigstore-protobuf-specs == 0.3.2",
   "sigstore-rekor-types == 0.0.13",
   "tuf ~= 5.0",
   "platformdirs ~= 4.2",


### PR DESCRIPTION
This project's versioning isn't semver and is subject to big changes due to protobuf/codegen, so we should keep it strictly pinned.

