### PR TITLE
_cli: files always take precedence over digests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ All versions prior to 0.9.0 are untracked.
   operations, including routine local TUF repository refreshes
   ([#1143](https://github.com/sigstore/sigstore-python/pull/1143))
 
+### Fixed
+
+* CLI: The `sigstore verify` subcommands now always check for a matching
+  input file, rather than unconditionally falling back to matching on a
+  valid `sha256:...` digest pattern
+  ([#1152](https://github.com/sigstore/sigstore-python/pull/1152))
+
 ## [3.3.0]
 
 ### Added

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -167,16 +167,19 @@ def _add_shared_verify_input_options(group: argparse._ArgumentGroup) -> None:
     )
 
     def file_or_digest(arg: str) -> Hashed | Path:
-        if arg.startswith("sha256:"):
+        path = Path(arg)
+        if path.is_file():
+            return path
+        elif arg.startswith("sha256"):
             digest = bytes.fromhex(arg[len("sha256:") :])
             if len(digest) != 32:
-                raise ValueError()
+                raise ValueError
             return Hashed(
                 digest=digest,
                 algorithm=HashAlgorithm.SHA2_256,
             )
         else:
-            return Path(arg)
+            raise ValueError
 
     group.add_argument(
         "files_or_digest",


### PR DESCRIPTION
This fixes a small edge case where a user supplies `sha256:hash.jsonl` or similar (such as produced by default by `gh attestation`) and the `sigstore verify` subcommands interpret it as an (invalid) hash rather than a file input.

The new behavior is to always interpret the input as a path if a file at that path is extant, and to otherwise interpret it as a hash.

CC @facutuesca 