### PR TITLE
bump minimum Python to 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         conf:
-          - { py: "3.8", os: "ubuntu-latest" }
           - { py: "3.9", os: "ubuntu-latest" }
           - { py: "3.10", os: "ubuntu-latest" }
           - { py: "3.11", os: "ubuntu-latest" }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
       # since it changes slightly between Python versions.
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
-          python-version: "3.8"
+          python-version: "3.9"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
@@ -73,7 +73,7 @@ jobs:
       # NOTE: We intentionally check test certificates against our minimum supported Python.
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
-          python-version: "3.8"
+          python-version: "3.9"
           cache: "pip"
           cache-dependency-path: pyproject.toml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All versions prior to 0.9.0 are untracked.
   operations, including routine local TUF repository refreshes
   ([#1143](https://github.com/sigstore/sigstore-python/pull/1143))
 
+* `sigstore-python`'s minimum supported Python version is now 3.9
+
 ### Fixed
 
 * CLI: The `sigstore verify` subcommands now always check for a matching

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ as well as performing common development tasks.
 
 ## Requirements
 
-`sigstore`'s only development environment requirement *should* be Python 3.8
+`sigstore`'s only development environment requirement *should* be Python 3.9
 or newer. Development and testing is actively performed on macOS and Linux,
 but Windows and other supported platforms that are supported by Python
 should also work.
@@ -105,7 +105,7 @@ make gen-x509-testcases
 
 ### Documentation
 
-If you're running Python 3.8 or newer, you can run the documentation build locally:
+If you're running Python 3.9 or newer, you can run the documentation build locally:
 
 ```bash
 make doc

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ else!
 
 ## Installation
 
-`sigstore` requires Python 3.8 or newer, and can be installed directly via `pip`:
+`sigstore` requires Python 3.9 or newer, and can be installed directly via `pip`:
 
 ```console
 python -m pip install sigstore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -43,7 +42,7 @@ dependencies = [
   "tuf ~= 5.0",
   "platformdirs ~= 4.2",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.scripts]
 sigstore = "sigstore._cli:main"

--- a/test/integration/cli/test_sign.py
+++ b/test/integration/cli/test_sign.py
@@ -64,9 +64,10 @@ def test_sign_success_default_output_bundle(capsys, sigstore, asset_integration)
 
     assert expected_output_bundle.exists()
     verifier = Verifier.staging()
-    with open(expected_output_bundle, "r") as bundle_file, open(
-        artifact, "rb"
-    ) as input_file:
+    with (
+        open(expected_output_bundle, "r") as bundle_file,
+        open(artifact, "rb") as input_file,
+    ):
         bundle = Bundle.from_json(bundle_file.read())
         verifier.verify_artifact(
             input_=input_file.read(), bundle=bundle, policy=UnsafeNoOp()


### PR DESCRIPTION
Python 3.8 is now EOL. 

![image](https://github.com/user-attachments/assets/871e042d-5092-4e99-9d0a-2c722bc5dcd9)
