### PR TITLE
workflows/requirements: remove a lingering 3.8 reference

### DIFF
--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -23,7 +23,7 @@ jobs:
       SIGSTORE_REF: ${{ inputs.ref }}
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Populate reference from context


### PR DESCRIPTION
This was breaking the pin-requirements workflow.
