### PR TITLE
_cli: add `plumbing update-trust-root`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Added
+
+* CLI: The `sigstore plumbing update-trust-root` command has been added.
+  Like other plumbing-level commands, this is considered unstable and
+  changes are not subject to our semver policy until explicitly noted
+  ([#1174](https://github.com/sigstore/sigstore-python/pull/1174))
+
 ## [3.4.0]
 
 ### Changed

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -40,6 +40,7 @@ from sigstore._internal.fulcio.client import ExpiredCertificate
 from sigstore._internal.rekor import _hashedrekord_from_parts
 from sigstore._internal.rekor.client import RekorClient
 from sigstore._internal.trust import ClientTrustConfig
+from sigstore._internal.tuf import DEFAULT_TUF_URL, STAGING_TUF_URL, TrustUpdater
 from sigstore._utils import sha256_digest
 from sigstore.dsse import StatementBuilder, Subject
 from sigstore.dsse._predicate import (
@@ -573,6 +574,14 @@ def _parser() -> argparse.ArgumentParser:
         help="Overwrite the input bundle with its fix instead of emitting to stdout",
     )
 
+    # `sigstore plumbing update-trust-root`
+    plumbing_subcommands.add_parser(
+        "update-trust-root",
+        help="update the local trust root to the latest version via TUF",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        parents=[parent_parser],
+    )
+
     return parser
 
 
@@ -614,6 +623,8 @@ def main(args: list[str] | None = None) -> None:
         elif args.subcommand == "plumbing":
             if args.plumbing_subcommand == "fix-bundle":
                 _fix_bundle(args)
+            elif args.plumbing_subcommand == "update-trust-root":
+                _update_trust_root(args)
         else:
             _invalid_arguments(args, f"Unknown subcommand: {args.subcommand}")
     except Error as e:
@@ -1222,3 +1233,12 @@ def _fix_bundle(args: argparse.Namespace) -> None:
         args.bundle.write_text(bundle.to_json())
     else:
         print(bundle.to_json())
+
+
+def _update_trust_root(args: argparse.Namespace) -> None:
+    # Simply creating the TrustUpdater in online mode is enough to perform
+    # a metadata update.
+    if args.staging:
+        TrustUpdater(STAGING_TUF_URL, offline=False)
+    else:
+        TrustUpdater(DEFAULT_TUF_URL, offline=False)

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import base64
-import datetime
 import json
 import logging
 import os
@@ -41,7 +40,6 @@ from sigstore._internal.fulcio.client import ExpiredCertificate
 from sigstore._internal.rekor import _hashedrekord_from_parts
 from sigstore._internal.rekor.client import RekorClient
 from sigstore._internal.trust import ClientTrustConfig, TrustedRoot
-from sigstore._internal.tuf import DEFAULT_TUF_URL, STAGING_TUF_URL, TrustUpdater
 from sigstore._utils import sha256_digest
 from sigstore.dsse import StatementBuilder, Subject
 from sigstore.dsse._predicate import (

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import datetime
 import json
 import logging
 import os
@@ -39,7 +40,7 @@ from sigstore import __version__, dsse
 from sigstore._internal.fulcio.client import ExpiredCertificate
 from sigstore._internal.rekor import _hashedrekord_from_parts
 from sigstore._internal.rekor.client import RekorClient
-from sigstore._internal.trust import ClientTrustConfig
+from sigstore._internal.trust import ClientTrustConfig, TrustedRoot
 from sigstore._internal.tuf import DEFAULT_TUF_URL, STAGING_TUF_URL, TrustUpdater
 from sigstore._utils import sha256_digest
 from sigstore.dsse import StatementBuilder, Subject
@@ -1236,9 +1237,13 @@ def _fix_bundle(args: argparse.Namespace) -> None:
 
 
 def _update_trust_root(args: argparse.Namespace) -> None:
-    # Simply creating the TrustUpdater in online mode is enough to perform
+    # Simply creating the TrustedRoot in online mode is enough to perform
     # a metadata update.
     if args.staging:
-        TrustUpdater(STAGING_TUF_URL, offline=False)
+        trusted_root = TrustedRoot.staging(offline=False)
     else:
-        TrustUpdater(DEFAULT_TUF_URL, offline=False)
+        trusted_root = TrustedRoot.production(offline=False)
+
+    _console.print(
+        f"Trust root updated: {len(trusted_root.get_fulcio_certs())} Fulcio certificates"
+    )


### PR DESCRIPTION
This adds a new plumbing-level command: `update-trust-root`. When run, `sigstore plumbing update-trust-root` will perform a TUF update for the appropriate production or staging trust root, depending on whether the top-level `--staging` flag is used.

Closes #1172.

CC @mgorny if you can, it'd be great to have you trial this locally to confirm it meets your needs! In particular it'd be useful to know if you'd prefer it to be "louder" in terms of outputs, i.e. print something on `stdout`/`stderr`.