### PR TITLE
README: bump tag for gh-action-sigstore-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ add it to your CI manually:
 jobs:
   sigstore-python:
     steps:
-      - uses: sigstore/gh-action-sigstore-python@v0.2.0
+      - uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: foo.txt
 ```


### PR DESCRIPTION
This was referencing a really old version, which was in turn causing some confusion.
