### PR TITLE
_cli: fix warning check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed a CLI parsing bug introduced in 3.5.0 when attempting
+  to suppress irrelevant warnings
+  ([#1192](https://github.com/sigstore/sigstore-python/pull/1192))
+
 ## [3.5.0]
 
 ### Added

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -931,19 +931,16 @@ def _collect_verification_state(
             legacy_default_bundle = file.parent / f"{file.name}.sigstore"
             bundle = file.parent / f"{file.name}.sigstore.json"
 
-            if (
-                not bundle.is_file()
-                and legacy_default_bundle.is_file()
-                # NOTE(ww): Only show this warning if bare materials
-                # are not provided, since bare materials take precedence over
-                # a .sigstore bundle.
-                and not (cert or sig)
-            ):
-                _logger.warning(
-                    f"{file}: {legacy_default_bundle} should be named {bundle}. "
-                    "Support for discovering 'bare' .sigstore inputs will be deprecated in "
-                    "a future release."
-                )
+            if not bundle.is_file() and legacy_default_bundle.is_file():
+                if not (cert or sig):
+                    # NOTE(ww): Only show this warning if bare materials
+                    # are not provided, since bare materials take precedence over
+                    # a .sigstore bundle.
+                    _logger.warning(
+                        f"{file}: {legacy_default_bundle} should be named {bundle}. "
+                        "Support for discovering 'bare' .sigstore inputs will be deprecated in "
+                        "a future release."
+                    )
                 bundle = legacy_default_bundle
             elif bundle.is_file() and legacy_default_bundle.is_file():
                 # Don't allow the user to implicitly verify `{input}.sigstore.json` if


### PR DESCRIPTION
This fixes the check added in https://github.com/sigstore/sigstore-python/pull/1179 by ensuring that we don't bypass the legacy bundle discovery behavior by accident when trying to suppress the warning.

I'll do a bugfix release after this.