### PR TITLE
Fix warning for CLI verification of legacy bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed a CLI parsing bug introduced in 3.5.1 where a warning about
+  verifying legacy bundles was never shown 
+  ([#1198](https://github.com/sigstore/sigstore-python/pull/1198))
+
 ## [3.5.1]
 
 ### Fixed

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -932,7 +932,7 @@ def _collect_verification_state(
             bundle = file.parent / f"{file.name}.sigstore.json"
 
             if not bundle.is_file() and legacy_default_bundle.is_file():
-                if not (cert or sig):
+                if not cert.is_file() or not sig.is_file():
                     # NOTE(ww): Only show this warning if bare materials
                     # are not provided, since bare materials take precedence over
                     # a .sigstore bundle.

--- a/test/assets/integration/bundle_v3.txt
+++ b/test/assets/integration/bundle_v3.txt
@@ -1,0 +1,5 @@
+DO NOT MODIFY ME!
+
+this is the input for bundle_v3, which tests support for "v3" bundles.
+
+DO NOT MODIFY ME!

--- a/test/assets/integration/bundle_v3.txt.sigstore
+++ b/test/assets/integration/bundle_v3.txt.sigstore
@@ -1,0 +1,53 @@
+{
+    "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+    "verificationMaterial": {
+        "certificate": {
+            "rawBytes": "MIIC1DCCAlqgAwIBAgIUO3tlVbLtvLPp+6zGOtep1SPkRigwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjQwNDAyMTkxOTA5WhcNMjQwNDAyMTkyOTA5WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENdrfpgNU1Rjmz+j65rpJWKc08ruKYy4FX7nmmOnbauFZimsQXrdyDSXKNRtEXX4X3t/Amt+euwPDBh+eq7BCnqOCAXkwggF1MA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUGRlBhD0wvzAfLb2dMWOgPrrJuRkwHwYDVR0jBBgwFoAUcYYwphR8Ym/599b0BRp/X//rb6wwIwYDVR0RAQH/BBkwF4EVd2lsbGlhbUB5b3NzYXJpYW4ubmV0MCwGCisGAQQBg78wAQEEHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDAuBgorBgEEAYO/MAEIBCAMHmh0dHBzOi8vZ2l0aHViLmNvbS9sb2dpbi9vYXV0aDCBigYKKwYBBAHWeQIEAgR8BHoAeAB2ACswvNxoiMni4dgmKV50H0g5MZYC8pwzy15DQP6yrIZ6AAABjqBAQZ4AAAQDAEcwRQIgeWUmtnD0MFUl5kkX7nbMdLWCsDGIPzdIlN+WaZF0TmkCIQC7+31saqrFe9RmduVZ2dxXhUPrajltuSDHb1vSGOcuHjAKBggqhkjOPQQDAwNoADBlAjEAn2+uuLHsnH9Db7zkIdF65YhiXbgMMF//iHc+B/QETK0HYVcOPTK3p46FUzXFD6xrAjAO2hrkfjBKANKjJJxHV3FVrtS+TR0GCP0HzC3D7Br95TXzfO7+j4Dd8/N/aAr6Ibs="
+        },
+        "tlogEntries": [
+            {
+                "logIndex": "25915956",
+                "logId": {
+                    "keyId": "0y8wo8MtY5wrdiIFohx7sHeI5oKDpK5vQhGHI6G+pJY="
+                },
+                "kindVersion": {
+                    "kind": "hashedrekord",
+                    "version": "0.0.1"
+                },
+                "integratedTime": "1712085549",
+                "inclusionPromise": {
+                    "signedEntryTimestamp": "MEYCIQD2KXW1NppUhkPPzGR8NrUIyN+MzZSSqGZQO7CzvhSnYgIhAO9AHzjbsr1AHXRHmEpdPZcoFHEwwMTgfqwjoOXVMmqN"
+                },
+                "inclusionProof": {
+                    "logIndex": "25901137",
+                    "rootHash": "iGAoHccJIyFemFxmEftti2YC8hvPqixBi5y1EyvfF4c=",
+                    "treeSize": "25901138",
+                    "hashes": [
+                        "UHUr+lvxENI+G902oEsFW5ovQILgqO9mUWWxvvwHZZc=",
+                        "IcMBsbH3GRW8FX2CiL/ljMb45vzmENmhp5Yp/7IW998=",
+                        "SxC6nr0zP+a6kWb6nO2fmEtz8BYAbqEXc+dsqGLdRPM=",
+                        "sppZRSz/vdeLlavgvICrXHLeReMTJw98bs9HJ0I8WnE=",
+                        "c8lCSuBS6MzrRnt6OiyYjqhTyxUI/22gpVB7dblfDis=",
+                        "eJk64J6cMpIljPSX/72kH0kiIeElyypQm5vJ2gMMyHw=",
+                        "hbIK+jmAwQjU7Yi3iKvnfR1u7GNippk7QsRwJXIuRaw=",
+                        "tpHWIEB2vNU5ZmC68dj1Hh9cwQK083ozogA6zJ3cJ8A=",
+                        "arvuzAipUJ14nDj14OBlvkMSicjdsE9Eus3hq9Jpqdk=",
+                        "Edul4W41O3EfxKEEMlX2nW0+GTgCv00nGmcpwhALgVA=",
+                        "rBWB37+HwkTZgDv0rMtGBUoDI0UZqcgDZp48M6CaUlA="
+                    ],
+                    "checkpoint": {
+                        "envelope": "rekor.sigstage.dev - 8050909264565447525\n25901138\niGAoHccJIyFemFxmEftti2YC8hvPqixBi5y1EyvfF4c=\n\n\u2014 rekor.sigstage.dev 0y8wozBFAiAMJJLbnNOnmizMbVBz9/A/qnMK15BudWoZkuE+obD6CAIhAJf6A3h2iOpuhz/duEhG3fbAQG9PXln4wXPHFBT5wT1a\n"
+                    }
+                },
+                "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI1ZTZhZTlkZTU4YzExNzdiZWE2MTViNGZjYmZiMmZkNjg4ZThjNGI1MWMyZTU2YjZhMzhlODE3ODMzZWMyNGEyIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJRFFTSmk5YWVydFFobVQrY2UxaktOZENlNEtTY3NLR3E5ZlBtMzQyMkRCU0FpRUFoajFzeFo5Nm9ySVRzUXh5TUxJRFJKaW1wb3kxSjFNeWZsY1FWd2tremhzPSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTXhSRU5EUVd4eFowRjNTVUpCWjBsVlR6TjBiRlppVEhSMlRGQndLelo2UjA5MFpYQXhVMUJyVW1sbmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcFJkMDVFUVhsTlZHdDRUMVJCTlZkb1kwNU5hbEYzVGtSQmVVMVVhM2xQVkVFMVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVZPWkhKbWNHZE9WVEZTYW0xNksybzJOWEp3U2xkTFl6QTRjblZMV1hrMFJsZzNibTBLYlU5dVltRjFSbHBwYlhOUldISmtlVVJUV0V0T1VuUkZXRmcwV0ROMEwwRnRkQ3RsZFhkUVJFSm9LMlZ4TjBKRGJuRlBRMEZZYTNkblowWXhUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZIVW14Q0NtaEVNSGQyZWtGbVRHSXlaRTFYVDJkUWNuSktkVkpyZDBoM1dVUldVakJxUWtKbmQwWnZRVlZqV1ZsM2NHaFNPRmx0THpVNU9XSXdRbEp3TDFndkwzSUtZalozZDBsM1dVUldVakJTUVZGSUwwSkNhM2RHTkVWV1pESnNjMkpIYkdoaVZVSTFZak5PZWxsWVNuQlpWelIxWW0xV01FMURkMGREYVhOSFFWRlJRZ3BuTnpoM1FWRkZSVWh0YURCa1NFSjZUMms0ZGxveWJEQmhTRlpwVEcxT2RtSlRPWE5pTW1Sd1ltazVkbGxZVmpCaFJFRjFRbWR2Y2tKblJVVkJXVTh2Q2sxQlJVbENRMEZOU0cxb01HUklRbnBQYVRoMldqSnNNR0ZJVm1sTWJVNTJZbE01YzJJeVpIQmlhVGwyV1ZoV01HRkVRMEpwWjFsTFMzZFpRa0pCU0ZjS1pWRkpSVUZuVWpoQ1NHOUJaVUZDTWtGRGMzZDJUbmh2YVUxdWFUUmtaMjFMVmpVd1NEQm5OVTFhV1VNNGNIZDZlVEUxUkZGUU5ubHlTVm8yUVVGQlFncHFjVUpCVVZvMFFVRkJVVVJCUldOM1VsRkpaMlZYVlcxMGJrUXdUVVpWYkRWcmExZzNibUpOWkV4WFEzTkVSMGxRZW1SSmJFNHJWMkZhUmpCVWJXdERDa2xSUXpjck16RnpZWEZ5Um1VNVVtMWtkVlphTW1SNFdHaFZVSEpoYW14MGRWTkVTR0l4ZGxOSFQyTjFTR3BCUzBKblozRm9hMnBQVUZGUlJFRjNUbThLUVVSQ2JFRnFSVUZ1TWl0MWRVeEljMjVJT1VSaU4zcHJTV1JHTmpWWmFHbFlZbWROVFVZdkwybElZeXRDTDFGRlZFc3dTRmxXWTA5UVZFc3pjRFEyUmdwVmVsaEdSRFo0Y2tGcVFVOHlhSEpyWm1wQ1MwRk9TMnBLU25oSVZqTkdWbkowVXl0VVVqQkhRMUF3U0hwRE0wUTNRbkk1TlZSWWVtWlBOeXRxTkVSa0NqZ3ZUaTloUVhJMlNXSnpQUW90TFMwdExVVk9SQ0JEUlZKVVNVWkpRMEZVUlMwdExTMHRDZz09In19fX0="
+            }
+        ]
+    },
+    "messageSignature": {
+        "messageDigest": {
+            "algorithm": "SHA2_256",
+            "digest": "Xmrp3ljBF3vqYVtPy/sv1ojoxLUcLla2o46BeDPsJKI="
+        },
+        "signature": "MEUCIDQSJi9aertQhmT+ce1jKNdCe4KScsKGq9fPm3422DBSAiEAhj1sxZ96orITsQxyMLIDRJimpoy1J1MyflcQVwkkzhs="
+    }
+}

--- a/test/integration/cli/test_verify.py
+++ b/test/integration/cli/test_verify.py
@@ -1,0 +1,50 @@
+# Copyright 2024 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+
+@pytest.mark.staging
+def test_regression_verify_legacy_bundle(capsys, caplog, asset_integration, sigstore):
+    # Check that verification continues to work when legacy bundle is present (*.sigstore) and
+    # no cert, sig and normal bundle (*.sigstore.json) are present.
+    artifact_filename = "bundle_v3.txt"
+    artifact = asset_integration(artifact_filename)
+    legacy_bundle = asset_integration(f"{artifact_filename}.sigstore")
+
+    sig = asset_integration(f"{artifact_filename}.sig")
+    cert = asset_integration(f"{artifact_filename}.crt")
+    bundle = asset_integration(f"{artifact_filename}.sigstore.json")
+    assert not cert.is_file()
+    assert not sig.is_file()
+    assert not bundle.is_file()
+
+    sigstore(
+        "--staging",
+        "verify",
+        "identity",
+        str(artifact),
+        "--cert-identity",
+        "william@yossarian.net",
+        "--cert-oidc-issuer",
+        "https://github.com/login/oauth",
+    )
+
+    captures = capsys.readouterr()
+    assert captures.err == f"OK: {artifact.absolute()}\n"
+
+    assert len(caplog.records) == 1
+    assert (
+        caplog.records[0].message
+        == f"{artifact.absolute()}: {legacy_bundle.absolute()} should be named {bundle.absolute()}. Support for discovering 'bare' .sigstore inputs will be deprecated in a future release."
+    )


### PR DESCRIPTION
This PR fixes a check in the CLI command `sigstore verify` where we should have printed a warning while verifying a legacy bundle (`*.sigstore`) if no bare materials (`*.crt` and `*.sig`) are provided.

The warning was never printed, due to an error in the check that made it always return `False`.

This PR also adds a regression test for the bug fixed in https://github.com/sigstore/sigstore-python/pull/1192, checking that the CLI correctly verifies a legacy bundle and that it logs the expected warning.

This closes https://github.com/sigstore/sigstore-python/issues/1194.

cc @woodruffw 