### PR TITLE
pyproject: bump rekor-types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "rfc3161-client == 0.0.3",
   # NOTE(ww): Both under active development, so strictly pinned.
   "sigstore-protobuf-specs == 0.3.2",
-  "sigstore-rekor-types == 0.0.13",
+  "sigstore-rekor-types == 0.0.17",
   "tuf ~= 5.0",
   "platformdirs ~= 4.2",
 ]


### PR DESCRIPTION
No functional changes between these versions, but the build backend changed so this serves as a sanity check.