### PR TITLE
Use official GH action to generate build provenances

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    outputs:
-      hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -75,15 +73,6 @@ jobs:
             rm -rf smoketest-env
           done
 
-      - name: Generate hashes for provenance
-        shell: bash
-        id: hash
-        run: |
-          # sha256sum generates sha256 hash for all artifacts.
-          # base64 -w0 encodes to base64 and outputs on a single line.
-          # sha256sum artifact1 artifact2 ... | base64 -w0
-          echo "hashes=$(sha256sum ./dist/* | base64 -w0)" >> $GITHUB_OUTPUT
-
       - name: Upload built packages
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
@@ -100,18 +89,17 @@ jobs:
 
   generate-provenance:
     needs: [build]
-    name: Generate build provenance
+    runs-on: ubuntu-latest
     permissions:
-      actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
-      contents: write # To add assets to a release.
-    # Currently this action needs to be referred by tag. More details at:
-    # https://github.com/slsa-framework/slsa-github-generator#verification-of-provenance
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
-    with:
-      provenance-name: provenance-sigstore-${{ github.event.release.tag_name }}.intoto.jsonl
-      base64-subjects: "${{ needs.build.outputs.hashes }}"
-      upload-assets: true
+      attestations: write # To persist the attestation files.
+    steps:
+      - name: Download artifacts directories # goes to current working directory
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      - name: Generate build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'built-packages/*'
 
   release-pypi:
     needs: [build, generate-provenance]


### PR DESCRIPTION
Replace `slsa-framework/slsa-github-generator` with `actions/attest-build-provenance`.

Tested here: https://github.com/trail-of-forks/sigstore-python/actions/runs/11915239762/job/33205076343

cc @woodruffw 

