### PR TITLE
pyproject: bump sigstore-rekor-types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "rfc3161-client == 0.0.4",
   # NOTE(ww): Both under active development, so strictly pinned.
   "sigstore-protobuf-specs == 0.3.2",
-  "sigstore-rekor-types == 0.0.17",
+  "sigstore-rekor-types == 0.0.18",
   "tuf ~= 5.0",
   "platformdirs ~= 4.2",
 ]


### PR DESCRIPTION
Bumps `sigstore-rekor-types` to `0.0.18`, incorporating minor (non-behavior in this case) codegen changes from `rekor` `v1.3.7`.