### PR TITLE
pyproject: constrain cryptography < 44

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Security :: Cryptography",
 ]
 dependencies = [
-  "cryptography >= 42",
+  "cryptography >= 42, < 44",
   "id >= 1.1.0",
   "importlib_resources ~= 5.7; python_version < '3.11'",
   "pyasn1 ~= 0.6",


### PR DESCRIPTION
cryptography 44 removes all of the old ABCs, which we currently use for `DetachedFulcioSCT`. This can probably be removed entirely, but this stops the bleeding for the moment by keeping us off the latest stable.

I'll prepare a point release for this ASAP, probably on a new release branch since `main` has the unrelated TSA changes on it.