### PR TITLE
fulcio: remove ABC registration

### DIFF
--- a/sigstore/_internal/fulcio/client.py
+++ b/sigstore/_internal/fulcio/client.py
@@ -165,11 +165,6 @@ class DetachedFulcioSCT(BaseModel):
         return self.digitally_signed[4:]
 
 
-# SignedCertificateTimestamp is an ABC, so register our DetachedFulcioSCT as
-# virtual subclass.
-SignedCertificateTimestamp.register(DetachedFulcioSCT)
-
-
 class ExpiredCertificate(Exception):
     """An error raised when the Certificate is expired."""
 
@@ -294,12 +289,7 @@ class FulcioSigningCert(_Endpoint):
                 )
 
             try:
-                sct_json = json.loads(base64.b64decode(sct_b64).decode())
-            except ValueError as exc:
-                raise FulcioClientError from exc
-
-            try:
-                sct = DetachedFulcioSCT.parse_obj(sct_json)
+                sct = DetachedFulcioSCT.model_validate_json(base64.b64decode(sct_b64))
             except Exception as exc:
                 # Ideally we'd catch something less generic here.
                 raise FulcioClientError from exc

--- a/test/unit/internal/fulcio/test_client.py
+++ b/test/unit/internal/fulcio/test_client.py
@@ -21,7 +21,6 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.x509.certificate_transparency import (
     LogEntryType,
     SignatureAlgorithm,
-    SignedCertificateTimestamp,
     Version,
 )
 from pydantic import ValidationError
@@ -48,9 +47,6 @@ class TestSCTHashAlgorithm:
 
 
 class TestDetachedFulcioSCT:
-    def test_fulcio_sct_virtual_subclass(self):
-        assert issubclass(client.DetachedFulcioSCT, SignedCertificateTimestamp)
-
     def test_fields(self):
         blob = enc(b"this is a base64-encoded blob")
         now = datetime.now(tz=timezone.utc)


### PR DESCRIPTION
Per #1231 -- this removes our assumption that `SignedCertificateTimestamp` is an ABC. 

This doesn't perform the cryptography bump yet, but it _does_ unblock an upstream regression test: https://github.com/pyca/cryptography/pull/12054

