### PR TITLE
conftest: tweak _has_oidc_id to only check our repo

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -51,7 +51,14 @@ def _has_oidc_id():
         # On GitHub Actions, forks do not have access to OIDC identities.
         # We differentiate this case from other GitHub credential errors,
         # since it's a case where we want to skip (i.e. return False).
-        if os.getenv("GITHUB_EVENT_NAME") == "pull_request":
+        #
+        # We also skip when the repo isn't our own, since downstream
+        # regression testers (e.g. PyCA Cryptography) don't necessarily
+        # want to give our unit tests access to an OIDC identity.
+        if (
+            os.getenv("GITHUB_REPOSITORY") != "sigstore/sigstore-python"
+            or os.getenv("GITHUB_EVENT_NAME") == "pull_request"
+        ):
             return False
         return True
     except AmbientCredentialError:


### PR DESCRIPTION
This tweaks the `_has_oidc_id` check slightly to skip, rather than fail, if the repo that triggered the test suite is not our repo. This helps the upstream integration/regression usecase, since upstreams don't necessarily want to pass `id-token: write` to our test suite.