### PR TITLE
bump rfc3161-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Relaxed the transitive dependency on `cryptography` to allow v43 and v44
+  to be resolved
+  ([#1251](https://github.com/sigstore/sigstore-python/pull/1251))
+
 ## [3.6.0]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "rich ~= 13.0",
   "rfc8785 ~= 0.1.2",
   # NOTE(dm): Under very active development, so strictly pinned.
-  "rfc3161-client == 0.1.1",
+  "rfc3161-client == 0.1.2",
   # NOTE(ww): Both under active development, so strictly pinned.
   "sigstore-protobuf-specs == 0.3.2",
   "sigstore-rekor-types == 0.0.18",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ dependencies = [
   "requests",
   "rich ~= 13.0",
   "rfc8785 ~= 0.1.2",
-  # NOTE(dm): Under very active development, so strictly pinned.
-  "rfc3161-client == 0.1.2",
+  "rfc3161-client ~= 0.1.2",
   # NOTE(ww): Both under active development, so strictly pinned.
   "sigstore-protobuf-specs == 0.3.2",
   "sigstore-rekor-types == 0.0.18",


### PR DESCRIPTION
This bumps rfc3161-client, which will both remove a spurious `maturin` runtime dep *and* make us compatible with older versions of `cryptography`, preventing resolution hell.

Signed-off-by: William Woodruff <william@trailofbits.com>