### PR TITLE
Remove vestigial `attestations: true`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
         with:
           packages-dir: built-packages/
-          attestations: true
 
   release-github:
     needs: [build, generate-provenance]


### PR DESCRIPTION
No longer necessary since `pypa/gh-action-pypi-publish` v1.11.0.

(h/t @haydentherapper)