### PR TITLE
Minor refactoring of Fulcio SCT handling

### DIFF
--- a/sigstore/_internal/fulcio/client.py
+++ b/sigstore/_internal/fulcio/client.py
@@ -33,10 +33,8 @@ from cryptography.x509 import (
     CertificateSigningRequest,
     load_pem_x509_certificate,
 )
-from cryptography.x509.certificate_transparency import SignedCertificateTimestamp
 
 from sigstore._internal import USER_AGENT
-from sigstore._internal.sct import get_signed_certificate_timestamp
 from sigstore._utils import B64Str
 from sigstore.oidc import IdentityToken
 
@@ -58,7 +56,6 @@ class FulcioCertificateSigningResponse:
 
     cert: Certificate
     chain: List[Certificate]
-    sct: SignedCertificateTimestamp
 
 
 @dataclass(frozen=True)
@@ -137,12 +134,7 @@ class FulcioSigningCert(_Endpoint):
         cert = load_pem_x509_certificate(certificates[0].encode())
         chain = [load_pem_x509_certificate(c.encode()) for c in certificates[1:]]
 
-        try:
-            sct = get_signed_certificate_timestamp(cert)
-        except ValueError as ex:
-            raise FulcioClientError(ex)
-
-        return FulcioCertificateSigningResponse(cert, chain, sct)
+        return FulcioCertificateSigningResponse(cert, chain)
 
 
 class FulcioTrustBundle(_Endpoint):

--- a/sigstore/_internal/sct.py
+++ b/sigstore/_internal/sct.py
@@ -148,32 +148,27 @@ def _get_issuer_cert(chain: List[Certificate]) -> Certificate:
     return issuer
 
 
-class UnexpectedSctCountException(Exception):
-    """
-    Number of percerts scts is wrong
-    """
-
-    pass
-
-
-def _get_precertificate_signed_certificate_timestamps(
+def get_signed_certificate_timestamp(
     certificate: Certificate,
-) -> PrecertificateSignedCertificateTimestamps:
-    # Try to retrieve the embedded SCTs within the cert.
+) -> SignedCertificateTimestamp:
+    """Retrieve the embedded SCT from the certificate.
+
+    Raise ValueError if certificate does not contain exactly one SCT
+    """
     try:
-        precert_scts_extension = certificate.extensions.get_extension_for_class(
+        timestamps = certificate.extensions.get_extension_for_class(
             PrecertificateSignedCertificateTimestamps
         ).value
     except ExtensionNotFound:
         raise ValueError(
-            "No PrecertificateSignedCertificateTimestamps found for the certificate"
+            "Certificate does not contain a signed certificate timestamp extension"
         )
 
-    if len(precert_scts_extension) != 1:
-        raise UnexpectedSctCountException(
-            f"Unexpected embedded SCT count in response: {len(precert_scts_extension)} != 1"
+    if len(timestamps) != 1:
+        raise ValueError(
+            f"Expected one certificate timestamp, found {len(timestamps)}."
         )
-    return precert_scts_extension
+    return timestamps[0]
 
 
 def _cert_is_ca(cert: Certificate) -> bool:

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -161,21 +161,15 @@ class Signer:
                 certificate_request, self._identity_token
             )
 
-            # Verify the SCT
-            sct = certificate_response.sct
-            cert = certificate_response.cert
-            chain = certificate_response.chain
-
             verify_sct(
-                sct,
-                cert,
-                chain,
+                certificate_response.cert,
+                certificate_response.chain,
                 self._signing_ctx._trusted_root.ct_keyring(KeyringPurpose.SIGN),
             )
 
             _logger.debug("Successfully verified SCT...")
 
-            return cert
+            return certificate_response.cert
 
     def _finalize_sign(
         self,

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -43,7 +43,6 @@ from sigstore import dsse
 from sigstore._internal.rekor import _hashedrekord_from_parts
 from sigstore._internal.rekor.client import RekorClient
 from sigstore._internal.sct import (
-    get_signed_certificate_timestamp,
     verify_sct,
 )
 from sigstore._internal.timestamp import TimestampSource, TimestampVerificationResult
@@ -341,12 +340,11 @@ class Verifier:
         # (2): verify the signing certificate's SCT.
         try:
             verify_sct(
-                get_signed_certificate_timestamp(cert),
                 cert,
                 [parent_cert.to_cryptography() for parent_cert in chain],
                 self._trusted_root.ct_keyring(KeyringPurpose.VERIFY),
             )
-        except (ValueError, VerificationError) as e:
+        except VerificationError as e:
             raise VerificationError(f"failed to verify SCT on signing certificate: {e}")
 
         # (3): verify the signing certificate against the Sigstore

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -43,7 +43,7 @@ from sigstore import dsse
 from sigstore._internal.rekor import _hashedrekord_from_parts
 from sigstore._internal.rekor.client import RekorClient
 from sigstore._internal.sct import (
-    _get_precertificate_signed_certificate_timestamps,
+    get_signed_certificate_timestamp,
     verify_sct,
 )
 from sigstore._internal.timestamp import TimestampSource, TimestampVerificationResult
@@ -339,15 +339,14 @@ class Verifier:
             chain = self._verify_chain_at_time(cert_ossl, vts)
 
         # (2): verify the signing certificate's SCT.
-        sct = _get_precertificate_signed_certificate_timestamps(cert)[0]
         try:
             verify_sct(
-                sct,
+                get_signed_certificate_timestamp(cert),
                 cert,
                 [parent_cert.to_cryptography() for parent_cert in chain],
                 self._trusted_root.ct_keyring(KeyringPurpose.VERIFY),
             )
-        except VerificationError as e:
+        except (ValueError, VerificationError) as e:
             raise VerificationError(f"failed to verify SCT on signing certificate: {e}")
 
         # (3): verify the signing certificate against the Sigstore


### PR DESCRIPTION
#### Summary

Simplify SCT management in fulcio client and the sites that need to call verify_sct()
* SCTs are only needed inside `verify_sct()`: Make them an implementation detail and stop exposing them in FulcioCertificateSigningResponse (which is internal, so this is not an API change)
* The only functional change is that `FulcioCertificateSigningResponse` may now exist without a valid SCT: In practice Signer works just like before since we call `verify_sct()`  on the cert immediately after getting the response
* Also remove an unused exception

There are two commits but I recommend reviewing the PR as a whole.
Fixes #1258.


#### Release Note

N/A: No public API changes or CLI changes are expected.  
