### PR TITLE
workflows: Use "sudo" with unshare

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           # but not marked as such will fail.
           # We also explicitly exclude the intergration tests, since these are
           # always online.
-          unshare --map-root-user --net make test T="test/unit" TEST_ARGS="--skip-online -vv --showlocals"
+          sudo unshare --map-root-user --net make test T="test/unit" TEST_ARGS="--skip-online -vv --showlocals"
 
       - name: test
         run: make test TEST_ARGS="-vv --showlocals"


### PR DESCRIPTION
latest Ubuntu (that appeared on GitHub this week) says "Operation not permitted"
