### PR TITLE
ci: fix offline tests on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           # Look at me. I am the captain now.
           sudo sysctl -w kernel.unprivileged_userns_clone=1
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
           # We use `unshare` to "un-share" the default networking namespace,
           # in effect running the tests as if the host is offline.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,17 @@ jobs:
       - name: test (offline)
         if: matrix.conf.os == 'ubuntu-latest'
         run: |
+          # Look at me. I am the captain now.
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+
           # We use `unshare` to "un-share" the default networking namespace,
           # in effect running the tests as if the host is offline.
           # This in turn effectively exercises the correctness of our
           # "online-only" test markers, since any test that's online
           # but not marked as such will fail.
-          # We also explicitly exclude the intergration tests, since these are
+          # We also explicitly exclude the integration tests, since these are
           # always online.
-          sudo unshare --map-current-user --net make test T="test/unit" TEST_ARGS="--skip-online -vv --showlocals"
+          unshare --map-root-user --net make test T="test/unit" TEST_ARGS="--skip-online -vv --showlocals"
 
       - name: test
         run: make test TEST_ARGS="-vv --showlocals"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           # but not marked as such will fail.
           # We also explicitly exclude the intergration tests, since these are
           # always online.
-          unshare --map-root-user --net make test T="test/unit" TEST_ARGS="--skip-online -vv --showlocals"
+          sudo unshare --map-current-user --net make test T="test/unit" TEST_ARGS="--skip-online -vv --showlocals"
 
       - name: test
         run: make test TEST_ARGS="-vv --showlocals"


### PR DESCRIPTION
~~WIP.~~

This "fixes" the CI by effectively undoing the namespace default changes that Ubuntu made between 22.04 and 24.04. Doing this should have no security impact in practice, since we're already running with full root access on these runners.

The other option here would be to remove `unshare` entirely, and continue to test the offline tests without actually enforcing their offline-ness. However, I think it's good to keep this around as a backstop, at least for as long as we can 🙂 