### PR TITLE
Makefile: Add update-embedded-root rule

### DIFF
--- a/.github/workflows/check-embedded-root.yml
+++ b/.github/workflows/check-embedded-root.yml
@@ -1,0 +1,63 @@
+name: Check embedded root
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '13 13 * * 3'
+
+jobs:
+  check-embedded-root:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: "3.x"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Setup environment
+        run: make dev
+
+      - name: Check if embedded root is up-to-date
+        run: |
+          make update-embedded-root
+          git diff --exit-code
+
+
+      - if: failure()
+        name: Create an issue if embedded root is not up-to-date
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const repo = context.repo.owner + "/" + context.repo.repo
+            const body = `
+            The Sigstore [TUF repository](https://tuf-repo-cdn.sigstore.dev/) contents have changed: the data embedded
+            in sigstore-python sources can be updated. This is not urgent but will improve cold-cache performance.
+            
+            Run \`make update-embedded-root\` to update the embedded data.
+            
+            This issue was filed by _${context.workflow}_ [workflow run](${context.serverUrl}/${repo}/actions/runs/${context.runId}).
+            `
+
+            const issues = await github.rest.search.issuesAndPullRequests({
+              q: "label:embedded-root-update+state:open+type:issue+repo:" + repo,
+            })
+            if (issues.data.total_count > 0) {
+              console.log("Issue for embedded root update exists already.")
+            } else {
+              github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: "Embedded TUF root is not up-to-date",
+                labels: ["embedded-root-update"],
+                body: body,
+              })
+              console.log("New issue created.")
+            }

--- a/Makefile
+++ b/Makefile
@@ -172,3 +172,11 @@ check-readme:
 .PHONY: edit
 edit:
 	$(EDITOR) $(ALL_PY_SRCS)
+
+update-embedded-root: $(VENV)/pyvenv.cfg
+	. $(VENV_BIN)/activate && \
+		python -m sigstore plumbing update-trust-root
+	cp ~/.local/share/sigstore-python/tuf/https%3A%2F%2Ftuf-repo-cdn.sigstore.dev/root.json \
+		sigstore/_store/prod/root.json
+	cp ~/.cache/sigstore-python/tuf/https%3A%2F%2Ftuf-repo-cdn.sigstore.dev/trusted_root.json \
+		sigstore/_store/prod/trusted_root.json


### PR DESCRIPTION
* Add `make update-embedded-root` rule
* Add workflow that files an issue if root is not up-to-date

I'm not sure if the workflow is really needed but I decided to include it. I think automatically making a PR might be a bad idea (since there are test suite tests for this we'd be trusting CI 100% and that doesn't sound right in this case).

--- 

Makefile rule uses the "plumbing" command to ensure the newest root has been downloaded and verified. Then it copies the newest TUF root and the trusted_root.json into the sources. The benefit here is that one does not need to manually find the cache directories when an update should be done.

Makefile rule hard codes XDG_DATA_HOME and XDG_CACHE_HOME for simplicity.

The workflow adds a new CI-dependency (github-script) but I believe the currently used actions do not provide the capabilities needed here.

I've created the "embedded-root-update" label manually in this project already so this should just work.