### PR TITLE
ruff settings: select → extend-select

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,8 +121,6 @@ plugins = ["pydantic.mypy"]
 exclude_dirs = ["./test"]
 
 [tool.ruff.lint]
-# Never enforce `E501` (line length violations).
-ignore = ["E501"]
 # TODO: Enable "UP" here once Pydantic allows us to:
 # See: https://github.com/pydantic/pydantic/issues/4146
-select = ["E", "F", "I", "W"]
+extend-select = ["I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,9 @@ plugins = ["pydantic.mypy"]
 exclude_dirs = ["./test"]
 
 [tool.ruff.lint]
-# TODO: Enable "UP" here once Pydantic allows us to:
-# See: https://github.com/pydantic/pydantic/issues/4146
-extend-select = ["I"]
+extend-select = ["I", "UP"]
+ignore = [
+  "UP007",  # https://github.com/pydantic/pydantic/issues/4146
+  "UP011",
+  "UP015",
+]


### PR DESCRIPTION
#### Summary

Instead of explicitly selecting `E` and `F` rules, use ruff default rules, which include `F` rules and `E` rules compatible with formatters:
	https://docs.astral.sh/ruff/settings/#lint_extend-select

According to the Scientific Python Library Development Guide, `W` rules are not needed when using a formatter:
	https://learn.scientific-python.org/development/guides/style/#ruff

Also enforce `UP` ruff rules.

Requires #1319.

#### Release Note

I might be mistaken, but probably not needed.

#### Documentation

N/A