### PR TITLE
Upgrade to tuf 6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   # NOTE(ww): Both under active development, so strictly pinned.
   "sigstore-protobuf-specs == 0.3.2",
   "sigstore-rekor-types == 0.0.18",
-  "tuf ~= 5.0",
+  "tuf ~= 6.0",
   "platformdirs ~= 4.2",
 ]
 requires-python = ">=3.9"

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -31,8 +31,7 @@ from id import (
     detect_credential,
 )
 from tuf.api.exceptions import DownloadHTTPError
-from tuf.ngclient import FetcherInterface
-from tuf.ngclient.updater import requests_fetcher
+from tuf.ngclient import FetcherInterface, updater
 
 from sigstore._internal import tuf
 from sigstore._internal.rekor import _hashedrekord_from_parts
@@ -157,9 +156,7 @@ def mock_staging_tuf(monkeypatch, tuf_dirs):
             failure[filename] += 1
             raise DownloadHTTPError("File not found", 404)
 
-    monkeypatch.setattr(
-        requests_fetcher, "RequestsFetcher", lambda app_user_agent: MockFetcher()
-    )
+    monkeypatch.setattr(updater, "Urllib3Fetcher", lambda app_user_agent: MockFetcher())
 
     return success, failure
 

--- a/test/unit/internal/test_trust.py
+++ b/test/unit/internal/test_trust.py
@@ -80,7 +80,13 @@ def test_trust_root_tuf_caches_and_requests(mock_staging_tuf, tuf_dirs):
 
     trust_root = TrustedRoot.staging()
     # metadata was "downloaded" from staging
-    expected = ["root.json", "snapshot.json", "targets.json", "timestamp.json"]
+    expected = [
+        "root.json",
+        "root_history",
+        "snapshot.json",
+        "targets.json",
+        "timestamp.json",
+    ]
     assert sorted(os.listdir(data_dir)) == expected
 
     # Expect requests of top-level metadata (and 404 for the next root version)
@@ -126,9 +132,8 @@ def test_trust_root_tuf_offline(mock_staging_tuf, tuf_dirs):
 
     trust_root = TrustedRoot.staging(offline=True)
 
-    # Only the embedded root is in local TUF metadata, nothing is downloaded
-    expected = ["root.json"]
-    assert sorted(os.listdir(data_dir)) == expected
+    # local TUF metadata is not initialized, nothing is downloaded
+    assert not os.path.exists(data_dir)
     assert reqs == {}
     assert fail_reqs == {}
 


### PR DESCRIPTION
This is not really urgent but I wanted to open this before the dependabot update comes in.

I think the potentially annoying part here is the certificate source: it's not ideal that some parts of sigstore-python will now be using certifi certs and the tuf client will be using system certs... but the choice made here is in line with #1040 

### Details 

The big changes in tuf 6.0 are dependencies:
* no longer uses requests but directly urllib3
* no longer uses certifi

The included code change in this PR is not strictly necessary but is potentially a little more secure (tuf client no longer trusts the metadata cache but always initializes the Updater from the embedded root).

The test changes are related to
* assumptions we make on the tuf metadata cache content
* our tests mocking a feature that was changed in TUF (RequestsFetcher got changed to Urllib3Fetcher)
