### PR TITLE
prep 3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,20 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+## [3.6.2]
+
+### Fixed
+
 * Fixed issue where a trust root with multiple rekor keys was not considered valid:
   Now any rekor key listed in the trust root is considered good to verify entries
   [#1350](https://github.com/sigstore/sigstore-python/pull/1350)
+
+### Changed
+
+* Upgraded python-tuf dependency to 6.0: Connections to TUF repository
+  now use system certificates (instead of certifi) and have automatic
+  retries
+* Updated the embedded TUF root to version 12
 
 ## [3.6.1]
 
@@ -597,8 +608,9 @@ This is a corrective release for [2.1.1].
 
 
 <!--Release URLs -->
-[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.6.1...HEAD
-[3.6.0]: https://github.com/sigstore/sigstore-python/compare/v3.6.0...v3.6.1
+[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.6.2...HEAD
+[3.6.2]: https://github.com/sigstore/sigstore-python/compare/v3.6.1...v3.6.2
+[3.6.1]: https://github.com/sigstore/sigstore-python/compare/v3.6.0...v3.6.1
 [3.6.0]: https://github.com/sigstore/sigstore-python/compare/v3.5.3...v3.6.0
 [3.5.3]: https://github.com/sigstore/sigstore-python/compare/v3.5.2...v3.5.3
 [3.5.2]: https://github.com/sigstore/sigstore-python/compare/v3.5.1...v3.5.2

--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -25,4 +25,4 @@ Otherwise, here are some quick starting points:
 * `sigstore.sign`: creation of Sigstore signatures
 """
 
-__version__ = "3.6.1"
+__version__ = "3.6.2"


### PR DESCRIPTION
Minor bump, the only noteworthy change is the tuf dependency bump.


---

* I'd like to do this since ephemeral CDN failures in various sigstore infra tests end up showing a lot more python-tuf tracebacks than I'd like
* the urllib3 changes should help there because of the default retry policy
* that said, there's no real urgency: happy to wait for some other changes too


