### PR TITLE
_internal/trust: Fix bug in rekor key lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+* Fixed issue where a trust root with multiple rekor keys was not considered valid:
+  Now any rekor key listed in the trust root is considered good to verify entries
+  [#1350](https://github.com/sigstore/sigstore-python/pull/1350)
+
 ## [3.6.1]
 
 ### Fixed

--- a/sigstore/_internal/trust.py
+++ b/sigstore/_internal/trust.py
@@ -382,8 +382,8 @@ class TrustedRoot:
         """Return keyring with keys for Rekor."""
 
         keys: list[_PublicKey] = list(self._get_tlog_keys(self._inner.tlogs, purpose))
-        if len(keys) != 1:
-            raise MetadataError("Did not find one Rekor key in trusted root")
+        if len(keys) == 0:
+            raise MetadataError("Did not find any Rekor keys in trusted root")
         return RekorKeyring(Keyring(keys))
 
     def ct_keyring(self, purpose: KeyringPurpose) -> CTKeyring:


### PR DESCRIPTION
Rekor keyring can (and in future will) have multiple keys: logs not only get sharded but once rekor-tiles is integrated in the public good instance, there will be two writable logs for a while.

As far as I can tell all calling code is already capable of handling the keyring.

Fixes #1349 