### PR TITLE
More proto updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All versions prior to 0.9.0 are untracked.
 * API: Make Rekor APIs compatible with Rekor v2 by removing trailing slashes
   from endpoints ([#1366](https://github.com/sigstore/sigstore-python/pull/1366))
 
+### Changed
+
+* `--trust-config` now requires a file with SigningConfig v0.2, and is able to fully
+  configure the used Sigstore instance [#1358]/(https://github.com/sigstore/sigstore-python/pull/1358)
+
 ## [3.6.2]
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "rfc8785 ~= 0.1.2",
   "rfc3161-client >= 0.1.2,< 1.1.0",
   # NOTE(ww): Both under active development, so strictly pinned.
-  "sigstore-protobuf-specs == 0.3.2",
+  "sigstore-protobuf-specs == 0.3.5",
   "sigstore-rekor-types == 0.0.18",
   "tuf ~= 6.0",
   "platformdirs ~= 4.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "rfc8785 ~= 0.1.2",
   "rfc3161-client >= 0.1.2,< 1.1.0",
   # NOTE(ww): Both under active development, so strictly pinned.
-  "sigstore-protobuf-specs == 0.3.5",
+  "sigstore-protobuf-specs == 0.4.1",
   "sigstore-rekor-types == 0.0.18",
   "tuf ~= 6.0",
   "platformdirs ~= 4.2",

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -1202,7 +1202,7 @@ def _fix_bundle(args: argparse.Namespace) -> None:
     # for custom Rekor instances.
     rekor = RekorClient.staging() if args.staging else RekorClient.production()
 
-    raw_bundle = RawBundle().from_json(args.bundle.read_text())
+    raw_bundle = RawBundle.from_dict(json.loads(args.bundle.read_bytes()))
 
     if len(raw_bundle.verification_material.tlog_entries) != 1:
         _fatal("unfixable bundle: must have exactly one log entry")

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -714,7 +714,7 @@ def _sign_common(
                 sig_output = sys.stdout
 
             signature = base64.b64encode(
-                result._inner.message_signature.signature
+                result._inner.message_signature.signature  # type: ignore[union-attr]
             ).decode()
             print(signature, file=sig_output)
             if outputs.signature is not None:

--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -713,9 +713,7 @@ def _sign_common(
             else:
                 sig_output = sys.stdout
 
-            signature = base64.b64encode(
-                result._inner.message_signature.signature  # type: ignore[union-attr]
-            ).decode()
+            signature = base64.b64encode(result.signature).decode()
             print(signature, file=sig_output)
             if outputs.signature is not None:
                 print(f"Signature written to {outputs.signature}")

--- a/sigstore/_internal/trust.py
+++ b/sigstore/_internal/trust.py
@@ -93,14 +93,14 @@ class Key:
     key: PublicKey
     key_id: KeyID
 
-    _RSA_SHA_256_DETAILS: ClassVar[set[_PublicKeyDetails]] = {
+    _RSA_SHA_256_DETAILS: ClassVar = {
         _PublicKeyDetails.PKCS1_RSA_PKCS1V5,
         _PublicKeyDetails.PKIX_RSA_PKCS1V15_2048_SHA256,
         _PublicKeyDetails.PKIX_RSA_PKCS1V15_3072_SHA256,
         _PublicKeyDetails.PKIX_RSA_PKCS1V15_4096_SHA256,
     }
 
-    _EC_DETAILS_TO_HASH: ClassVar[dict[_PublicKeyDetails, hashes.HashAlgorithm]] = {
+    _EC_DETAILS_TO_HASH: ClassVar = {
         _PublicKeyDetails.PKIX_ECDSA_P256_SHA_256: hashes.SHA256(),
         _PublicKeyDetails.PKIX_ECDSA_P384_SHA_384: hashes.SHA384(),
         _PublicKeyDetails.PKIX_ECDSA_P521_SHA_512: hashes.SHA512(),

--- a/sigstore/_internal/trust.py
+++ b/sigstore/_internal/trust.py
@@ -45,7 +45,12 @@ from sigstore_protobuf_specs.dev.sigstore.trustroot.v1 import (
     ClientTrustConfig as _ClientTrustConfig,
 )
 from sigstore_protobuf_specs.dev.sigstore.trustroot.v1 import (
+    Service,
+    ServiceSelector,
     TransparencyLogInstance,
+)
+from sigstore_protobuf_specs.dev.sigstore.trustroot.v1 import (
+    SigningConfig as _SigningConfig,
 )
 from sigstore_protobuf_specs.dev.sigstore.trustroot.v1 import (
     TrustedRoot as _TrustedRoot,
@@ -278,6 +283,114 @@ class CertificateAuthority:
         return self._certificates
 
 
+class SigningConfig:
+    """
+    Signing configuration for a Sigstore instance.
+    """
+
+    class SigningConfigType(str, Enum):
+        """
+        Known Sigstore signing config media types.
+        """
+
+        SIGNING_CONFIG_0_2 = "application/vnd.dev.sigstore.signingconfig.v0.2+json"
+
+        def __str__(self) -> str:
+            """Returns the variant's string value."""
+            return self.value
+
+    def __init__(self, inner: _SigningConfig):
+        """
+        Construct a new `SigningConfig`.
+
+        @api private
+        """
+        self._inner = inner
+        self._verify()
+
+    def _verify(self) -> None:
+        """
+        Performs various feats of heroism to ensure that the signing config
+        is well-formed.
+        """
+
+        # must have a recognized media type.
+        try:
+            SigningConfig.SigningConfigType(self._inner.media_type)
+        except ValueError:
+            raise Error(f"unsupported signing config format: {self._inner.media_type}")
+
+        # currently not supporting other select modes
+        # TODO: Support other modes ensuring tsa_urls() and tlog_urls() work
+        if self._inner.rekor_tlog_config.selector != ServiceSelector.ANY:
+            raise Error(
+                f"unsupported tlog selector {self._inner.rekor_tlog_config.selector}"
+            )
+        if self._inner.tsa_config.selector != ServiceSelector.ANY:
+            raise Error(f"unsupported TSA selector {self._inner.tsa_config.selector}")
+
+    @classmethod
+    def from_file(
+        cls,
+        path: str,
+    ) -> SigningConfig:
+        """Create a new signing config from file"""
+        inner = _SigningConfig().from_json(Path(path).read_bytes())
+        return cls(inner)
+
+    @staticmethod
+    def _get_valid_service_url(services: list[Service]) -> str | None:
+        for service in services:
+            if service.major_api_version != 1:
+                continue
+
+            if not _is_timerange_valid(service.valid_for, allow_expired=False):
+                continue
+            return service.url
+        return None
+
+    def get_tlog_urls(self) -> list[str]:
+        """
+        Returns the rekor transparency logs that client should sign with.
+        Currently only returns a single one but could in future return several
+        """
+
+        url = self._get_valid_service_url(self._inner.rekor_tlog_urls)
+        if not url:
+            raise Error("No valid Rekor transparency log found in signing config")
+        return [url]
+
+    def get_fulcio_url(self) -> str:
+        """
+        Returns url for the fulcio instance that client should use to get a
+        signing certificate from
+        """
+        url = self._get_valid_service_url(self._inner.ca_urls)
+        if not url:
+            raise Error("No valid Fulcio CA found in signing config")
+        return url
+
+    def get_oidc_url(self) -> str:
+        """
+        Returns url for the OIDC provider that client should use to interactively
+        authenticate.
+        """
+        url = self._get_valid_service_url(self._inner.oidc_urls)
+        if not url:
+            raise Error("No valid OIDC provider found in signing config")
+        return url
+
+    def get_tsa_urls(self) -> list[str]:
+        """
+        Returns timestamp authority API end points. Currently returns a single one
+        but may return more in future.
+        """
+        url = self._get_valid_service_url(self._inner.tsa_urls)
+        if not url:
+            raise Error("No valid Timestamp Authority found in signing config")
+        return [url]
+
+
 class TrustedRoot:
     """
     The cryptographic root(s) of trust for a Sigstore instance.
@@ -473,3 +586,10 @@ class ClientTrustConfig:
         Return the interior root of trust, as a `TrustedRoot`.
         """
         return TrustedRoot(self._inner.trusted_root)
+
+    @property
+    def signing_config(self) -> SigningConfig:
+        """
+        Return the interior root of trust, as a `SigningConfig`.
+        """
+        return SigningConfig(self._inner.signing_config)

--- a/sigstore/hashes.py
+++ b/sigstore/hashes.py
@@ -60,4 +60,4 @@ class Hashed(BaseModel, frozen=True):
         """
         Returns a str representation of this `Hashed`.
         """
-        return f"{self.algorithm.name}:{self.digest.hex()}"
+        return f"{HashAlgorithm(self.algorithm)}:{self.digest.hex()}"

--- a/sigstore/models.py
+++ b/sigstore/models.py
@@ -667,9 +667,10 @@ class Bundle:
 
         # Fill in the appropriate variants.
         if isinstance(content, common_v1.MessageSignature):
-            content = {"message_signature": content}
+            # mypy will be mystified if types are specified here
+            content_dict: dict[str, Any] = {"message_signature": content}
         else:
-            content = {"dsse_envelope": content._inner}
+            content_dict = {"dsse_envelope": content._inner}
 
         inner = _Bundle(
             media_type=Bundle.BundleType.BUNDLE_0_3.value,
@@ -678,7 +679,7 @@ class Bundle:
                 tlog_entries=[log_entry._to_rekor()],
                 timestamp_verification_data=timestamp_verifcation_data,
             ),
-            **content,
+            **content_dict,
         )
 
         return cls(inner)

--- a/sigstore/models.py
+++ b/sigstore/models.py
@@ -19,6 +19,7 @@ Common models shared between signing and verification.
 from __future__ import annotations
 
 import base64
+import json
 import logging
 import typing
 from enum import Enum
@@ -466,6 +467,9 @@ class Bundle:
             Bundle.BundleType.BUNDLE_0_3_ALT,
         ):
             # For "v3" bundles, the signing certificate is the only one present.
+            if not self._inner.verification_material.certificate:
+                raise InvalidBundle("expected certificate in bundle")
+
             leaf_cert = load_der_x509_certificate(
                 self._inner.verification_material.certificate.raw_bytes
             )
@@ -473,11 +477,8 @@ class Bundle:
             # In older bundles, there is an entire pool (misleadingly called
             # a chain) of certificates, the first of which is the signing
             # certificate.
-            certs = (
-                self._inner.verification_material.x509_certificate_chain.certificates
-            )
-
-            if len(certs) == 0:
+            chain = self._inner.verification_material.x509_certificate_chain
+            if not chain or not chain.certificates:
                 raise InvalidBundle("expected non-empty certificate chain in bundle")
 
             # Per client policy in protobuf-specs: the first entry in the chain
@@ -489,7 +490,7 @@ class Bundle:
             # and intermediate CAs, so we issue warnings and not hard errors
             # in those cases.
             leaf_cert, *chain_certs = (
-                load_der_x509_certificate(cert.raw_bytes) for cert in certs
+                load_der_x509_certificate(cert.raw_bytes) for cert in chain.certificates
             )
             if not cert_is_leaf(leaf_cert):
                 raise InvalidBundle(
@@ -589,7 +590,7 @@ class Bundle:
         return (
             self._dsse_envelope.signature
             if self._dsse_envelope
-            else self._inner.message_signature.signature
+            else self._inner.message_signature.signature  # type: ignore[union-attr]
         )
 
     @property
@@ -604,7 +605,7 @@ class Bundle:
         """
         Deserialize the given Sigstore bundle.
         """
-        inner = _Bundle().from_json(raw)
+        inner = _Bundle.from_dict(json.loads(raw))
         return cls(inner)
 
     def to_json(self) -> str:
@@ -623,7 +624,10 @@ class Bundle:
         """
 
         content: common_v1.MessageSignature | dsse.Envelope
-        content = self._dsse_envelope or self._inner.message_signature
+        if self._dsse_envelope:
+            content = self._dsse_envelope
+        else:
+            content = self._inner.message_signature  # type: ignore[assignment]
 
         return (self.signing_certificate, content, self.log_entry)
 

--- a/sigstore/models.py
+++ b/sigstore/models.py
@@ -578,7 +578,7 @@ class Bundle:
         @private
         """
         if self._inner.is_set("dsse_envelope"):
-            return dsse.Envelope(self._inner.dsse_envelope)
+            return dsse.Envelope(self._inner.dsse_envelope)  # type: ignore[arg-type]
         return None
 
     @property

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -352,13 +352,13 @@ class SigningContext:
 
         @api private
         """
+        signing_config = trust_config.signing_config
         return cls(
-            fulcio=FulcioClient(trust_config._inner.signing_config.ca_url),
-            rekor=RekorClient(trust_config._inner.signing_config.tlog_urls[0]),
+            fulcio=FulcioClient(signing_config.get_fulcio_url()),
+            rekor=RekorClient(signing_config.get_tlog_urls()[0]),
             trusted_root=trust_config.trusted_root,
             tsa_clients=[
-                TimestampAuthorityClient(tsa_url)
-                for tsa_url in trust_config._inner.signing_config.tsa_urls
+                TimestampAuthorityClient(url) for url in signing_config.get_tsa_urls()
             ],
         )
 

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -500,7 +500,7 @@ class Verifier:
             signing_key = bundle.signing_certificate.public_key()
             signing_key = cast(ec.EllipticCurvePublicKey, signing_key)
             signing_key.verify(
-                bundle._inner.message_signature.signature,
+                bundle._inner.message_signature.signature,  # type: ignore[union-attr]
                 hashed_input.digest,
                 ec.ECDSA(hashed_input._as_prehashed()),
             )
@@ -515,7 +515,7 @@ class Verifier:
 
         expected_body = _hashedrekord_from_parts(
             bundle.signing_certificate,
-            bundle._inner.message_signature.signature,
+            bundle._inner.message_signature.signature,  # type: ignore[union-attr]
             hashed_input,
         )
         actual_body = rekor_types.Hashedrekord.model_validate_json(

--- a/test/assets/signing_config/signingconfig.v2.json
+++ b/test/assets/signing_config/signingconfig.v2.json
@@ -1,0 +1,60 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
+  "caUrls": [
+    {
+      "url": "https://fulcio.example.com",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2023-04-14T21:38:40Z"
+      }
+    },
+    {
+      "url": "https://fulcio-old.example.com",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2022-04-14T21:38:40Z",
+        "end": "2023-04-14T21:38:40Z"
+      }
+    }
+  ],
+  "oidcUrls": [
+    {
+      "url": "https://oauth2.example.com/auth",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2025-04-16T00:00:00Z"
+      }
+    }
+  ],
+  "rekorTlogUrls": [
+    {
+      "url": "https://rekor.example.com",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2021-01-12T11:53:27Z"
+      }
+    },
+    {
+      "url": "https://rekor-v2.example.com",
+      "majorApiVersion": 2,
+      "validFor": {
+        "start": "2021-01-12T11:53:27Z"
+      }
+    }
+  ],
+  "tsaUrls": [
+    {
+      "url": "https://timestamp.example.com/api/v1/timestamp",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2025-04-09T00:00:00Z"
+      }
+    }
+  ],
+  "rekorTlogConfig": {
+    "selector": "ANY"
+  },
+  "tsaConfig": {
+    "selector": "ANY"
+  }
+}

--- a/test/assets/trust_config/config.badtype.json
+++ b/test/assets/trust_config/config.badtype.json
@@ -114,14 +114,64 @@
             }
         ]
     },
-    "signingConfig": {
-        "caUrl": "https://fakeca.example.com",
-        "oidcUrl": "https://fakeoidc.example.com",
-        "tlogUrls": [
-            "https://fakelog.example.com"
+    "signing_config": {
+        "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
+        "caUrls": [
+            {
+                "url": "https://fulcio.example.com",
+                "majorApiVersion": 1,
+                "validFor": {
+                "start": "2023-04-14T21:38:40Z"
+                }
+            },
+            {
+                "url": "https://fulcio-old.example.com",
+                "majorApiVersion": 1,
+                "validFor": {
+                "start": "2022-04-14T21:38:40Z",
+                "end": "2023-04-14T21:38:40Z"
+                }
+            }
+        ],
+        "oidcUrls": [
+            {
+                "url": "https://oauth2.example.com/auth",
+                "majorApiVersion": 1,
+                "validFor": {
+                    "start": "2025-04-16T00:00:00Z"
+                }
+            }
+        ],
+        "rekorTlogUrls": [
+            {
+                "url": "https://rekor.example.com",
+                "majorApiVersion": 1,
+                "validFor": {
+                    "start": "2021-01-12T11:53:27Z"
+                }
+            },
+            {
+                "url": "https://rekor-v2.example.com",
+                "majorApiVersion": 2,
+                "validFor": {
+                    "start": "2021-01-12T11:53:27Z"
+                }
+            }
         ],
         "tsaUrls": [
-            "https://faketsa.example.com"
-        ]
+            {
+                "url": "https://timestamp.example.com/api/v1/timestamp",
+                "majorApiVersion": 1,
+                "validFor": {
+                    "start": "2025-04-09T00:00:00Z"
+                }
+            }
+        ],
+        "rekorTlogConfig": {
+            "selector": "ANY"
+        },
+        "tsaConfig": {
+            "selector": "ANY"
+        }
     }
 }

--- a/test/assets/trust_config/config.v1.json
+++ b/test/assets/trust_config/config.v1.json
@@ -114,14 +114,64 @@
             }
         ]
     },
-    "signingConfig": {
-        "caUrl": "https://fakeca.example.com",
-        "oidcUrl": "https://fakeoidc.example.com",
-        "tlogUrls": [
-            "https://fakelog.example.com"
+    "signing_config": {
+        "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
+        "caUrls": [
+            {
+                "url": "https://fulcio.example.com",
+                "majorApiVersion": 1,
+                "validFor": {
+                "start": "2023-04-14T21:38:40Z"
+                }
+            },
+            {
+                "url": "https://fulcio-old.example.com",
+                "majorApiVersion": 1,
+                "validFor": {
+                "start": "2022-04-14T21:38:40Z",
+                "end": "2023-04-14T21:38:40Z"
+                }
+            }
+        ],
+        "oidcUrls": [
+            {
+                "url": "https://oauth2.example.com/auth",
+                "majorApiVersion": 1,
+                "validFor": {
+                    "start": "2025-04-16T00:00:00Z"
+                }
+            }
+            ],
+            "rekorTlogUrls": [
+            {
+                "url": "https://rekor.example.com",
+                "majorApiVersion": 1,
+                "validFor": {
+                    "start": "2021-01-12T11:53:27Z"
+                }
+            },
+            {
+                "url": "https://rekor-v2.example.com",
+                "majorApiVersion": 2,
+                "validFor": {
+                    "start": "2021-01-12T11:53:27Z"
+                }
+            }
         ],
         "tsaUrls": [
-            "https://faketsa.example.com"
-        ]
+            {
+                "url": "https://timestamp.example.com/api/v1/timestamp",
+                "majorApiVersion": 1,
+                "validFor": {
+                    "start": "2025-04-09T00:00:00Z"
+                }
+            }
+        ],
+        "rekorTlogConfig": {
+            "selector": "ANY"
+        },
+        "tsaConfig": {
+            "selector": "ANY"
+        }
     }
 }


### PR DESCRIPTION
This is built on top of #1276: I'm fine with merging that first or closing that one and merging all the proto changes at once in this PR.

This PR upgrades us to the most recent protobuf-specs. Changes include (on top of 1276):
* A new signingconfig version is supported, and a `SigningConfig` class has been added to handle parsing the data in it
* I'm removing support for SigningConfig 0.1 since that was not actually usable: I don't think anyone will mind (staging currently has 0.1 but we do not use it and 0.2 should be available in staging by next week)

I'd like to handle followups in other PRS, mainly I'm thinking of:
* rekorclient is still a bit of a mess
* the signingconfig service selectors are not fully supported yet
* oidc provider is still hard coded when running CLI
* signingconfig from TUF is not yet used: There is still a discussion on what the specific TUF targetpath is going to be
