### PR TITLE
Specify sha256 in TSA request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All versions prior to 0.9.0 are untracked.
 ### Fixed
 
 * TSA: Changed the Timestamp Authority requests to explicitly use sha256 for message digests.
+  [#1371](https://github.com/sigstore/sigstore-python/pull/1371)
 
 * Fixed the certificate calidity period check for Timestamp Authorities (TSA).
   Certificates need not have and end date, while still requiring a start date.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All versions prior to 0.9.0 are untracked.
 
 ### Fixed
 
+* TSA: Changed the Timestamp Authority requests to explicitly use sha256 for message digests.
+
 * API: Make Rekor APIs compatible with Rekor v2 by removing trailing slashes
   from endpoints ([#1366](https://github.com/sigstore/sigstore-python/pull/1366))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All versions prior to 0.9.0 are untracked.
 ### Fixed
 
 * TSA: Changed the Timestamp Authority requests to explicitly use sha256 for message digests.
-  [#1371](https://github.com/sigstore/sigstore-python/pull/1371)
+  [#1373](https://github.com/sigstore/sigstore-python/pull/1373)
 
 * Fixed the certificate calidity period check for Timestamp Authorities (TSA).
   Certificates need not have and end date, while still requiring a start date.

--- a/sigstore/_internal/timestamp.py
+++ b/sigstore/_internal/timestamp.py
@@ -26,6 +26,7 @@ from rfc3161_client import (
     TimeStampResponse,
     decode_timestamp_response,
 )
+from rfc3161_client.base import HashAlgorithm
 
 from sigstore._internal import USER_AGENT
 
@@ -93,7 +94,11 @@ class TimestampAuthorityClient:
         # Build the timestamp request
         try:
             timestamp_request = (
-                TimestampRequestBuilder().data(signature).nonce(nonce=True).build()
+                TimestampRequestBuilder()
+                .hash_algorithm(HashAlgorithm.SHA256)
+                .data(signature)
+                .nonce(nonce=True)
+                .build()
             )
         except ValueError as error:
             msg = f"invalid request: {error}"

--- a/test/unit/internal/test_timestamping.py
+++ b/test/unit/internal/test_timestamping.py
@@ -16,7 +16,6 @@ import requests
 
 from sigstore._internal.timestamp import TimestampAuthorityClient, TimestampError
 from sigstore._utils import sha256_digest
-from cryptography.hazmat.primitives.hashes import SHA256
 
 
 @pytest.mark.timestamp_authority

--- a/test/unit/internal/test_timestamping.py
+++ b/test/unit/internal/test_timestamping.py
@@ -15,6 +15,8 @@ import pytest
 import requests
 
 from sigstore._internal.timestamp import TimestampAuthorityClient, TimestampError
+from sigstore._utils import sha256_digest
+from cryptography.hazmat.primitives.hashes import SHA256
 
 
 @pytest.mark.timestamp_authority
@@ -23,6 +25,13 @@ class TestTimestampAuthorityClient:
         tsa = TimestampAuthorityClient(tsa_url)
         response = tsa.request_timestamp(b"hello")
         assert response
+        assert (
+            response.tst_info.message_imprint.message == sha256_digest(b"hello").digest
+        )
+        assert (
+            response.tst_info.message_imprint.hash_algorithm.dotted_string
+            == "2.16.840.1.101.3.4.2.1"
+        )  # SHA256 OID
 
     def test_sign_request_invalid_url(self):
         tsa = TimestampAuthorityClient("http://fake-url")


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

[Client support for Rekor V2: sigstore-python](https://github.com/sigstore/rekor-tiles/issues/289)


#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Resolves https://github.com/sigstore/sigstore-python/issues/1372

Makes the TSA request specify sha256 for the message digest, ~~since verification currently assumes sha256.~~ Verification shouldn't assume any specific algorithm, but I think for signing requests this library should specify an algorithm, for the sake of predictability. 

#### Release Note
<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->

* TSA: Changed the Timestamp Authority requests to explicitly use sha256 for message digests.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->