### PR TITLE
trust: Support operator field, support multiple services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ All versions prior to 0.9.0 are untracked.
   * ClientTrustConfig now provides methods `production()`, `staging()`and `from_tuf()`
     to get access to current client configuration (trusted keys & certificates,
     URLs and their validity periods). [#1363](https://github.com/sigstore/sigstore-python/pull/1363)
+  * SigningConfig now has methods that return actual clients (like `RekorClient`) instead of
+    just URLs. The returned clients are also filtered according to SigningConfig contents.
+    [#1407](https://github.com/sigstore/sigstore-python/pull/1407)
 * `--trust-config` now requires a file with SigningConfig v0.2, and is able to fully
   configure the used Sigstore instance [#1358]/(https://github.com/sigstore/sigstore-python/pull/1358)
 * By default (when `--trust-config` is not used) the whole trust configuration now

--- a/sigstore/_internal/trust.py
+++ b/sigstore/_internal/trust.py
@@ -424,8 +424,6 @@ class SigningConfig:
         """
         Returns timestamp authority API end points.
         """
-        if not self._tsas:
-            raise Error("No valid Rekor transparency log found in signing config")
         return [TimestampAuthorityClient(s.url) for s in self._tsas]
 
 

--- a/sigstore/_internal/trust.py
+++ b/sigstore/_internal/trust.py
@@ -405,13 +405,13 @@ class SigningConfig:
 
     def get_tlogs(self) -> list[RekorClient]:
         """
-        Returns the rekor transparency logs that client should sign with.
+        Returns the rekor transparency log clients that client should sign with.
         """
         return [RekorClient(tlog.url) for tlog in self._tlogs]
 
     def get_fulcio(self) -> FulcioClient:
         """
-        Returns url for the fulcio instance that client should use to get a
+        Returns a Fulcio instance that client should use to get a
         signing certificate from
         """
         return FulcioClient(self._fulcios[0].url)
@@ -427,7 +427,7 @@ class SigningConfig:
 
     def get_tsas(self) -> list[TimestampAuthorityClient]:
         """
-        Returns timestamp authority API end points.
+        Returns timestamp authority clients for urls configured in signing config.
         """
         return [TimestampAuthorityClient(s.url) for s in self._tsas]
 

--- a/sigstore/_internal/trust.py
+++ b/sigstore/_internal/trust.py
@@ -416,14 +416,13 @@ class SigningConfig:
 
     def get_tlogs(self) -> list[RekorClient]:
         """
-        Returns the rekor transparency log clients that client should sign with.
+        Returns the rekor transparency log clients to sign with.
         """
         return [RekorClient(tlog.url) for tlog in self._tlogs]
 
     def get_fulcio(self) -> FulcioClient:
         """
-        Returns a Fulcio instance that client should use to get a
-        signing certificate from
+        Returns a Fulcio client to get a signing certificate from
         """
         return FulcioClient(self._fulcios[0].url)
 

--- a/sigstore/_store/https%3A%2F%2Ftuf-repo-cdn.sigstore.dev/signing_config.v0.2.json
+++ b/sigstore/_store/https%3A%2F%2Ftuf-repo-cdn.sigstore.dev/signing_config.v0.2.json
@@ -34,6 +34,6 @@
     "selector": "ANY"
   },
   "tsaConfig": {
-    "selector": "ANY"
+    "selector": "ALL"
   }
 }

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -332,12 +332,10 @@ class SigningContext:
         """
         signing_config = trust_config.signing_config
         return cls(
-            fulcio=FulcioClient(signing_config.get_fulcio_url()),
-            rekor=RekorClient(signing_config.get_tlog_urls()[0]),
+            fulcio=signing_config.get_fulcio(),
+            rekor=signing_config.get_tlogs()[0],
             trusted_root=trust_config.trusted_root,
-            tsa_clients=[
-                TimestampAuthorityClient(url) for url in signing_config.get_tsa_urls()
-            ],
+            tsa_clients=signing_config.get_tsas(),
         )
 
     @contextmanager

--- a/test/unit/internal/test_trust.py
+++ b/test/unit/internal/test_trust.py
@@ -96,74 +96,82 @@ class TestSigningcconfig:
     @pytest.mark.parametrize(
         "services, versions, config, expected_result",
         [
-            (
+            pytest.param(
                 [_service_v1_op1],
                 [1],
                 ServiceConfiguration(ServiceSelector.ALL),
                 [_service_v1_op1],
+                id="base case",
             ),
-            (  # multiple services, same operator: expect 1 service in result
+            pytest.param(
                 [_service_v1_op1, _service2_v1_op1],
                 [1],
                 ServiceConfiguration(ServiceSelector.ALL),
                 [_service2_v1_op1],
+                id="multiple services, same operator: expect 1 service in result",
             ),
-            (  # 2 services, different operator: expect 2 services in result
+            pytest.param(
                 [_service_v1_op1, _service_v1_op2],
                 [1],
                 ServiceConfiguration(ServiceSelector.ALL),
                 [_service_v1_op1, _service_v1_op2],
+                id="2 services, different operator: expect 2 services in result",
             ),
-            (  # 3 services, one is not yet valid: expect 2 services in result
+            pytest.param(
                 [_service_v1_op1, _service_v1_op2, _service_v1_op4],
                 [1],
                 ServiceConfiguration(ServiceSelector.ALL),
                 [_service_v1_op1, _service_v1_op2],
+                id="3 services, one is not yet valid: expect 2 services in result",
             ),
-            (  # ANY selector: expect 1 service only in result
+            pytest.param(
                 [_service_v1_op1, _service_v1_op2],
                 [1],
                 ServiceConfiguration(ServiceSelector.ANY),
                 [_service_v1_op1],
+                id="ANY selector: expect 1 service only in result",
             ),
-            (  # EXACT selector: expect configured number of services in result
+            pytest.param(
                 [_service_v1_op1, _service_v1_op2, _service_v1_op3],
                 [1],
                 ServiceConfiguration(ServiceSelector.EXACT, 2),
                 [_service_v1_op1, _service_v1_op2],
+                id="EXACT selector: expect configured number of services in result",
             ),
-            (  # services with different version: expect highest version
+            pytest.param(
                 [_service_v1_op1, _service_v2_op1],
                 [1, 2],
                 ServiceConfiguration(ServiceSelector.ALL),
                 [_service_v2_op1],
+                id="services with different version: expect highest version",
             ),
-            (  # services with different version: expect the supported version
+            pytest.param(
                 [_service_v1_op1, _service_v2_op1],
                 [1],
                 ServiceConfiguration(ServiceSelector.ALL),
                 [_service_v1_op1],
+                id="services with different version: expect the supported version",
             ),
-            (  # No supported versions: expect no results
+            pytest.param(
                 [_service_v1_op1, _service_v1_op2],
                 [2],
                 ServiceConfiguration(ServiceSelector.ALL),
                 [],
+                id="No supported versions: expect no results",
             ),
-            (  # services without ServiceConfiguration: expect all supported
+            pytest.param(
                 [_service_v1_op1, _service_v2_op1, _service_v1_op2],
                 [1],
                 None,
                 [_service_v1_op1, _service_v1_op2],
+                id="services without ServiceConfiguration: expect all supported",
             ),
         ],
     )
     def test_get_valid_services(self, services, versions, config, expected_result):
         result = SigningConfig._get_valid_services(services, versions, config)
 
-        assert len(result) == len(expected_result)
-        for s1, s2 in zip(result, expected_result):
-            assert s1.url == s2.url
+        assert result == expected_result
 
     @pytest.mark.parametrize(
         "services, versions, config",


### PR DESCRIPTION
* Change the SigningConfig API so that it returns actual clients (like RekorClient): this may seem unusual but makes sense because SigningConfig in practice must know which service/versions this client supports, this means the code is simplest if it directly returns correct clients (e.g. when rekor has two separate clients for v1 and v2). This allows keeping version, operator, selector mode, etc as SigningConfig implementation details: Otherwise some of those have to start leaking outside
* There is one exception to previous change: get_oidc_url() still returns string, not Issuer object. I could make this change as well to be consistent, it just requires a small refactor (because currently Issuer makes a http request on construction and that seems bad in general, but especially for testing)
* Support operator field: This is used to ensure we only return one service version per operator
* Support all serviceselector modes
* There is a tweak to to the production signing config placeholder in _store: this is required since the code now considers a "ANY" selector with no services listed an error (I think that's reasonable: "ALL" could mean 0 but "ANY" can't really)

Getting `_get_valid_services()` right (and simple) was surprisingly tricky, but I think it's there now -- thanks to ramon for feedback. I think the decision to keep this code contained in trust.py is correct: it's not trivial and sign.py is complicated enough already.

@ramonpetgrave64 I think this fits your plans well:
* When rekor2 client is added, we just make sure `get_tlogs()` returns either v1 client or v2 depending on major_version
* signing code can just use the client regardless of version


