### PR TITLE
ci: ambient credential tests fix

### DIFF
--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -47,6 +47,8 @@ from sigstore.verify.verifier import Verifier
 _TUF_ASSETS = (Path(__file__).parent.parent / "assets" / "staging-tuf").resolve()
 assert _TUF_ASSETS.is_dir()
 
+TEST_CLIENT_ID = "sigstore"
+
 
 @pytest.fixture
 def x509_testcase(asset):
@@ -209,7 +211,7 @@ def sign_ctx_and_ident_for_env(
     token = os.getenv(f"SIGSTORE_IDENTITY_TOKEN_{env}")
     if not token:
         # If the variable is not defined, try getting an ambient token.
-        token = detect_credential()
+        token = detect_credential(TEST_CLIENT_ID)
 
     return ctx_cls, IdentityToken(token)
 
@@ -230,7 +232,7 @@ def staging() -> tuple[type[SigningContext], type[Verifier], IdentityToken]:
     token = os.getenv("SIGSTORE_IDENTITY_TOKEN_staging")
     if not token:
         # If the variable is not defined, try getting an ambient token.
-        token = detect_credential()
+        token = detect_credential(TEST_CLIENT_ID)
 
     return signer, verifier, IdentityToken(token)
 


### PR DESCRIPTION
This PR fixes the latest commit, the ambient credential tasks did not run and were skipped, leading to us missing out on some test cases running, and subsequently failing. I ran the workflow from my own fork where the tasks passed.

[success logs](https://github.com/SequeI/sigstore-python/actions/runs/15329826732/job/43133545034#step:6:113)

Apologies for this, the CI on the PR passed and I missed this issue in the original [PR](https://github.com/sigstore/sigstore-python/pull/1402)

The skipped tasks in the PR that failed during a push to main

```
test/unit/test_sign.py::test_sign_rekor_entry_consistent[staging] SKIPPED [ 44%]
test/unit/test_sign.py::test_sign_rekor_entry_consistent[production] SKIPPED [ 44%]
test/unit/test_sign.py::test_sct_verify_keyring_lookup_error[staging] SKIPPED [ 45%]
test/unit/test_sign.py::test_sct_verify_keyring_lookup_error[production] SKIPPED [ 45%]
test/unit/test_sign.py::test_sct_verify_keyring_error[staging] SKIPPED   [ 46%]
test/unit/test_sign.py::test_sct_verify_keyring_error[production] SKIPPED [ 46%]
test/unit/test_sign.py::test_identity_proof_claim_lookup[staging] SKIPPED [ 47%]
test/unit/test_sign.py::test_identity_proof_claim_lookup[production] SKIPPED [ 47%]
test/unit/test_sign.py::test_sign_prehashed SKIPPED (skipping test that
requires an ambient OIDC credential)                                     [ 48%]
test/unit/test_sign.py::test_sign_dsse SKIPPED (skipping test that
requires an ambient OIDC credential)                                     [ 48%]
```

Successful task runs from my own fork

```
test/unit/test_sign.py::test_sign_rekor_entry_consistent[staging] PASSED [ 44%]
test/unit/test_sign.py::test_sign_rekor_entry_consistent[production] PASSED [ 44%]
test/unit/test_sign.py::test_sct_verify_keyring_lookup_error[staging] PASSED [ 45%]
test/unit/test_sign.py::test_sct_verify_keyring_lookup_error[production] PASSED [ 45%]
test/unit/test_sign.py::test_sct_verify_keyring_error[staging] PASSED    [ 46%]
test/unit/test_sign.py::test_sct_verify_keyring_error[production] PASSED [ 46%]
test/unit/test_sign.py::test_identity_proof_claim_lookup[staging] PASSED [ 47%]
test/unit/test_sign.py::test_identity_proof_claim_lookup[production] PASSED [ 47%]
test/unit/test_sign.py::test_sign_prehashed PASSED                       [ 48%]
test/unit/test_sign.py::test_sign_dsse PASSED                            [ 48%]
```

I imagine it was due to the PR being from a fork and not from within the repo, not allowing the OIDC token any write access since it could be a possible attack vector and skipping the tasks. This PR should fix it.