### PR TITLE
trust: Fail less hard when unsupported keys are seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ All versions prior to 0.9.0 are untracked.
   still required.
   [#1381](https://github.com/sigstore/sigstore-python/pull/1381)
 
+* Verify: Avoid hard failure if trusted root contains unsupported keytypes (as verification
+  may succeed without that key).
+  [#1424](https://github.com/sigstore/sigstore-python/pull/1424)
+
 * CI: Timestamp Authority tests use latest release, not latest tag, of
   [sigstore/timestamp-authority](https://github.com/sigstore/timestamp-authority)
   [#1377](https://github.com/sigstore/sigstore-python/pull/1377)

--- a/test/assets/trusted_root/trustedroot.v1.json
+++ b/test/assets/trusted_root/trustedroot.v1.json
@@ -14,6 +14,20 @@
             "logId": {
                 "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
             }
+        },
+        {
+            "baseUrl": "https://example.com/unsupported_key",
+            "hashAlgorithm": "SHA2_256",
+            "publicKey": {
+                "rawBytes": "",
+                "keyDetails": "UNSPECIFIED",
+                "validFor": {
+                    "start": "2021-01-12T11:53:27.000Z"
+                }
+            },
+            "logId": {
+                "keyId": "xNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+            }
         }
     ],
     "certificateAuthorities": [

--- a/test/assets/trusted_root/trustedroot.v1.local_tlog_ed25519_rekor-tiles.json
+++ b/test/assets/trusted_root/trustedroot.v1.local_tlog_ed25519_rekor-tiles.json
@@ -14,6 +14,20 @@
             "logId": {
                 "keyId": "tAlACZWkUrif9Z9sOIrpk1ak1I8loRNufk79N6l1SNg="
             }
+        },
+        {
+            "baseUrl": "https://example.com/unsupported_key",
+            "hashAlgorithm": "SHA2_256",
+            "publicKey": {
+                "rawBytes": "",
+                "keyDetails": "UNSPECIFIED",
+                "validFor": {
+                    "start": "2021-01-12T11:53:27.000Z"
+                }
+            },
+            "logId": {
+                "keyId": "xNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+            }
         }
     ],
     "certificateAuthorities": [

--- a/test/unit/internal/test_trust.py
+++ b/test/unit/internal/test_trust.py
@@ -208,7 +208,7 @@ class TestTrustedRoot:
     )
     def test_good(self, asset, file):
         """
-        Ensures that the trusted_roots are well-formed and that the embedded keys are supported.
+        Ensures that the trusted_roots are well-formed and that the expected embedded keys are supported.
         """
         path = asset(file)
         root = TrustedRoot.from_file(path)
@@ -216,12 +216,14 @@ class TestTrustedRoot:
         assert (
             root._inner.media_type == TrustedRoot.TrustedRootType.TRUSTED_ROOT_0_1.value
         )
-        assert len(root._inner.tlogs) == 1
+        assert len(root._inner.tlogs) == 2
         assert len(root._inner.certificate_authorities) == 2
         assert len(root._inner.ctlogs) == 2
         assert len(root._inner.timestamp_authorities) == 1
-        assert root.rekor_keyring(KeyringPurpose.VERIFY) is not None
-        assert root.ct_keyring(KeyringPurpose.VERIFY) is not None
+
+        # only one of the two rekor keys is actually supported
+        assert len(root.rekor_keyring(KeyringPurpose.VERIFY)._keyring) == 1
+        assert len(root.ct_keyring(KeyringPurpose.VERIFY)._keyring) == 2
         assert root.get_fulcio_certs() is not None
         assert root.get_timestamp_authorities() is not None
 


### PR DESCRIPTION
Currently verification fails immediately if trusted root contains any unsupported keys. I think it makes more sense to warn and continue as it is possible these keys are not required for verification.

Unfortunately I missed this case when I tested the multiple log support in #1350  :( 