### PR TITLE
Backport 1424, prepare 3.6.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -616,7 +616,8 @@ This is a corrective release for [2.1.1].
 
 
 <!--Release URLs -->
-[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.6.2...HEAD
+[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.6.3...HEAD
+[3.6.3]: https://github.com/sigstore/sigstore-python/compare/v3.6.2...v3.6.3
 [3.6.2]: https://github.com/sigstore/sigstore-python/compare/v3.6.1...v3.6.2
 [3.6.1]: https://github.com/sigstore/sigstore-python/compare/v3.6.0...v3.6.1
 [3.6.0]: https://github.com/sigstore/sigstore-python/compare/v3.5.3...v3.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+## [3.6.3]
+
+### Fixed
+
+* Verify: Avoid hard failure if trusted root contains unsupported keytypes (as verification
+  may succeed without that key).
+  [#1425](https://github.com/sigstore/sigstore-python/pull/1425)
+
 ## [3.6.2]
 
 ### Fixed

--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -25,4 +25,4 @@ Otherwise, here are some quick starting points:
 * `sigstore.sign`: creation of Sigstore signatures
 """
 
-__version__ = "3.6.2"
+__version__ = "3.6.3"

--- a/test/assets/trusted_root/trustedroot.v1.json
+++ b/test/assets/trusted_root/trustedroot.v1.json
@@ -14,6 +14,20 @@
             "logId": {
                 "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
             }
+        },
+        {
+            "baseUrl": "https://example.com/unsupported_key",
+            "hashAlgorithm": "SHA2_256",
+            "publicKey": {
+                "rawBytes": "",
+                "keyDetails": "PKIX_ED25519",
+                "validFor": {
+                    "start": "2021-01-12T11:53:27.000Z"
+                }
+            },
+            "logId": {
+                "keyId": "xNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+            }
         }
     ],
     "certificateAuthorities": [

--- a/test/unit/internal/test_trust.py
+++ b/test/unit/internal/test_trust.py
@@ -54,10 +54,13 @@ class TestTrustedRoot:
         assert (
             root._inner.media_type == TrustedRoot.TrustedRootType.TRUSTED_ROOT_0_1.value
         )
-        assert len(root._inner.tlogs) == 1
+        assert len(root._inner.tlogs) == 2
         assert len(root._inner.certificate_authorities) == 2
         assert len(root._inner.ctlogs) == 2
         assert len(root._inner.timestamp_authorities) == 1
+
+        # only one of the two rekor keys is actually supported
+        assert len(root.rekor_keyring(KeyringPurpose.VERIFY)._keyring) == 1
 
     def test_bad_media_type(self, asset):
         path = asset("trusted_root/trustedroot.badtype.json")


### PR DESCRIPTION
This is a backport of #1424 into 3.6.x series:
* This backport should make root-signing-staging update (with a ed25519 key) a little easier to manage
* Makes it more likely that all sigstore-python users have the fix once the same happens in production

Current main contains a lot of work (but not yet rekor v2 client integration) so I wouldn't like to release all of that now.
