### PR TITLE
Post 3.6.3 fixes

### DIFF
--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -76,7 +76,10 @@ jobs:
           cache: "pip"
           cache-dependency-path: pyproject.toml
 
-      - run: pip install pip-tools
+      - name: Install dependencies
+        run: |
+          pip install "pip < 25.1" # workaround issue 1426
+          pip install pip-tools
 
       - name: Compute version from tag
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,6 @@ All versions prior to 0.9.0 are untracked.
   still required.
   [#1381](https://github.com/sigstore/sigstore-python/pull/1381)
 
-* Verify: Avoid hard failure if trusted root contains unsupported keytypes (as verification
-  may succeed without that key).
-  [#1424](https://github.com/sigstore/sigstore-python/pull/1424)
-
 * CI: Timestamp Authority tests use latest release, not latest tag, of
   [sigstore/timestamp-authority](https://github.com/sigstore/timestamp-authority)
   [#1377](https://github.com/sigstore/sigstore-python/pull/1377)
@@ -79,6 +75,13 @@ All versions prior to 0.9.0 are untracked.
     Use `SigningContext.from_trust_config()` instead.
     [#1363](https://github.com/sigstore/sigstore-python/pull/1363)
 
+## [3.6.3]
+
+### Fixed
+
+* Verify: Avoid hard failure if trusted root contains unsupported keytypes (as verification
+  may succeed without that key).
+  [#1425](https://github.com/sigstore/sigstore-python/pull/1425)
 
 ## [3.6.2]
 
@@ -680,7 +683,8 @@ This is a corrective release for [2.1.1].
 
 
 <!--Release URLs -->
-[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.6.2...HEAD
+[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.6.3...HEAD
+[3.6.3]: https://github.com/sigstore/sigstore-python/compare/v3.6.2...v3.6.3
 [3.6.2]: https://github.com/sigstore/sigstore-python/compare/v3.6.1...v3.6.2
 [3.6.1]: https://github.com/sigstore/sigstore-python/compare/v3.6.0...v3.6.1
 [3.6.0]: https://github.com/sigstore/sigstore-python/compare/v3.5.3...v3.6.0

--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -25,4 +25,4 @@ Otherwise, here are some quick starting points:
 * `sigstore.sign`: creation of Sigstore signatures
 """
 
-__version__ = "3.6.2"
+__version__ = "3.6.3"


### PR DESCRIPTION
* Merge changelog and version changes from 3.6.x branch
* workaround  the requirements pinning issue that was found in 3.6.3 release (#1426). I've tested this in my fork, looks ok

I'll file an issue to remove the workaround once pip-tools is fixed.