### PR TITLE
Conformance client update

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -27,4 +27,4 @@ jobs:
       - uses: sigstore/sigstore-conformance@fd90e6b0f3046f2276a6659481de6df495dea3b9 # v0.0.18
         with:
           entrypoint: ${{ github.workspace }}/test/integration/sigstore-python-conformance
-          xfail: "test_verify_with_trust_root test_verify_dsse_bundle_with_trust_root" # see issue 821
+          xfail: "test_verify_dsse_bundle_with_trust_root" # see issue 1442

--- a/test/integration/sigstore-python-conformance
+++ b/test/integration/sigstore-python-conformance
@@ -4,9 +4,27 @@
 A wrapper to convert `sigstore-conformance` CLI protocol invocations to match `sigstore-python`.
 """
 
-
+import json
 import os
 import sys
+from contextlib import suppress
+from string import Template
+from tempfile import NamedTemporaryFile
+
+# The signing config in this trust_config is not used: it's just here
+# so the built trustconfig is complete
+trust_config = {
+    "mediaType": "application/vnd.dev.sigstore.clienttrustconfig.v0.1+json",
+    "signingConfig": {
+        "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
+        "caUrls": [{ "url": "https://fulcio.example.com" }],
+        "oidcUrls": [],
+        "rekorTlogUrls": [{ "url": "https://rekor.example.com" }],
+        "tsaUrls": [],
+        "rekorTlogConfig": {"selector": "ANY"},
+        "tsaConfig": {"selector": "ANY"}
+    }
+}
 
 SUBCMD_REPLACEMENTS = {
     "sign-bundle": "sign",
@@ -32,17 +50,39 @@ if "--staging" in fixed_args:
     command.append("--staging")
     fixed_args.remove("--staging")
 
-# Fix-up the subcommand: the conformance suite uses `verify`, but
-# `sigstore` requires `verify identity` for identity based verifications.
-subcommand, *fixed_args = fixed_args
-if subcommand == "sign":
-    command.append("sign")
-elif subcommand == "verify":
-    command.extend(["verify", "identity"])
-else:
-    raise ValueError(f"unsupported subcommand: {subcommand}")
+# We may get "--trusted-root" as argument but sigstore-python wants "--trust-config":
+trusted_root_path = None
+with suppress(ValueError):
+    i = fixed_args.index("--trusted-root")
+    trusted_root_path = fixed_args[i+1]
+    fixed_args.pop(i)
+    fixed_args.pop(i)
 
-# Replace incompatible flags.
-command.extend(ARG_REPLACEMENTS[arg] if arg in ARG_REPLACEMENTS else arg for arg in fixed_args)
+# If we did get a trustedroot, write a matching trustconfig into a temp file
+with NamedTemporaryFile(mode="wt") as temp_file:
+    if trusted_root_path is not None:
+        with open(trusted_root_path) as f:
+            trusted_root=json.load(f)
+        trust_config["trustedRoot"] = trusted_root
 
-os.execvp("sigstore", command)
+        json.dump(trust_config, temp_file)
+        temp_file.flush()
+
+        command.extend(["--trust-config", temp_file.name])
+
+    # Fix-up the subcommand: the conformance suite uses `verify`, but
+    # `sigstore` requires `verify identity` for identity based verifications.
+    subcommand, *fixed_args = fixed_args
+    if subcommand == "sign":
+        command.append("sign")
+    elif subcommand == "verify":
+        command.extend(["verify", "identity"])
+    else:
+        raise ValueError(f"unsupported subcommand: {subcommand}")
+
+    # Replace incompatible flags.
+    command.extend(
+        ARG_REPLACEMENTS[arg] if arg in ARG_REPLACEMENTS else arg for arg in fixed_args
+    )
+
+    os.execvp("sigstore", command)

--- a/test/integration/sigstore-python-conformance
+++ b/test/integration/sigstore-python-conformance
@@ -4,6 +4,7 @@
 A wrapper to convert `sigstore-conformance` CLI protocol invocations to match `sigstore-python`.
 """
 
+
 import os
 import sys
 
@@ -25,19 +26,23 @@ subcmd = fixed_args[0]
 if subcmd in SUBCMD_REPLACEMENTS:
     fixed_args[0] = SUBCMD_REPLACEMENTS[subcmd]
 
-# Replace incompatible flags.
-fixed_args = [
-    ARG_REPLACEMENTS[arg] if arg in ARG_REPLACEMENTS else arg for arg in fixed_args
-]
+# Build base command with optional staging argument
+command = ["sigstore"]
+if "--staging" in fixed_args:
+    command.append("--staging")
+    fixed_args.remove("--staging")
 
 # Fix-up the subcommand: the conformance suite uses `verify`, but
 # `sigstore` requires `verify identity` for identity based verifications.
 subcommand, *fixed_args = fixed_args
 if subcommand == "sign":
-    fixed_args = ["sigstore", "sign", *fixed_args]
+    command.append("sign")
 elif subcommand == "verify":
-    fixed_args = ["sigstore", "verify", "identity", *fixed_args]
+    command.extend(["verify", "identity"])
 else:
     raise ValueError(f"unsupported subcommand: {subcommand}")
 
-os.execvp("sigstore", fixed_args)
+# Replace incompatible flags.
+command.extend(ARG_REPLACEMENTS[arg] if arg in ARG_REPLACEMENTS else arg for arg in fixed_args)
+
+os.execvp("sigstore", command)

--- a/test/integration/sigstore-python-conformance
+++ b/test/integration/sigstore-python-conformance
@@ -8,7 +8,6 @@ import json
 import os
 import sys
 from contextlib import suppress
-from string import Template
 from tempfile import NamedTemporaryFile
 
 # The signing config in this trust_config is not used: it's just here
@@ -17,13 +16,13 @@ trust_config = {
     "mediaType": "application/vnd.dev.sigstore.clienttrustconfig.v0.1+json",
     "signingConfig": {
         "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
-        "caUrls": [{ "url": "https://fulcio.example.com" }],
+        "caUrls": [{"url": "https://fulcio.example.com"}],
         "oidcUrls": [],
-        "rekorTlogUrls": [{ "url": "https://rekor.example.com" }],
+        "rekorTlogUrls": [{"url": "https://rekor.example.com"}],
         "tsaUrls": [],
         "rekorTlogConfig": {"selector": "ANY"},
-        "tsaConfig": {"selector": "ANY"}
-    }
+        "tsaConfig": {"selector": "ANY"},
+    },
 }
 
 SUBCMD_REPLACEMENTS = {
@@ -54,7 +53,7 @@ if "--staging" in fixed_args:
 trusted_root_path = None
 with suppress(ValueError):
     i = fixed_args.index("--trusted-root")
-    trusted_root_path = fixed_args[i+1]
+    trusted_root_path = fixed_args[i + 1]
     fixed_args.pop(i)
     fixed_args.pop(i)
 
@@ -62,7 +61,7 @@ with suppress(ValueError):
 with NamedTemporaryFile(mode="wt") as temp_file:
     if trusted_root_path is not None:
         with open(trusted_root_path) as f:
-            trusted_root=json.load(f)
+            trusted_root = json.load(f)
         trust_config["trustedRoot"] = trusted_root
 
         json.dump(trust_config, temp_file)


### PR DESCRIPTION
Fixes #821 by adding support for `--trusted-root` into our conformance client.

Annoyingly this requires writing a temporary (trust config) file on disk since that is what sigstore-python CLI needs instead of the provided trustedroot file.

This revealed a new issue #1442
