### PR TITLE
chore: forward port changelog from 3.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,13 @@ All versions prior to 0.9.0 are untracked.
     Use `SigningContext.from_trust_config()` instead.
     [#1363](https://github.com/sigstore/sigstore-python/pull/1363)
 
+## [3.6.4]
+
+### Fixed
+
+* Bumped the `rfc3161-client` dependency to `>=1.0.3` to fix a security
+  vulnerability ([#1451](https://github.com/sigstore/sigstore-python/pull/1451))
+
 ## [3.6.3]
 
 ### Fixed
@@ -686,7 +693,8 @@ This is a corrective release for [2.1.1].
 
 
 <!--Release URLs -->
-[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.6.3...HEAD
+[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.6.4...HEAD
+[3.6.4]: https://github.com/sigstore/sigstore-python/compare/v3.6.3...v3.6.4
 [3.6.3]: https://github.com/sigstore/sigstore-python/compare/v3.6.2...v3.6.3
 [3.6.2]: https://github.com/sigstore/sigstore-python/compare/v3.6.1...v3.6.2
 [3.6.1]: https://github.com/sigstore/sigstore-python/compare/v3.6.0...v3.6.1

--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -25,4 +25,4 @@ Otherwise, here are some quick starting points:
 * `sigstore.sign`: creation of Sigstore signatures
 """
 
-__version__ = "3.6.3"
+__version__ = "3.6.4"


### PR DESCRIPTION
picks 3b1902666a06ac72d1f331138bfa8510d4f0b853

This is the last piece of the dependency/backport jigsaw 🙂 