### PR TITLE
fix: resolve circular import of models.LogEntry

### DIFF
--- a/sigstore/_internal/rekor/__init__.py
+++ b/sigstore/_internal/rekor/__init__.py
@@ -19,8 +19,8 @@ APIs for interacting with Rekor.
 from __future__ import annotations
 
 import base64
+import typing
 from abc import ABC, abstractmethod
-from typing import Any, NewType
 
 import rekor_types
 import requests
@@ -29,13 +29,15 @@ from cryptography.x509 import Certificate
 from sigstore._utils import base64_encode_pem_cert
 from sigstore.dsse import Envelope
 from sigstore.hashes import Hashed
-from sigstore.models import LogEntry
+
+if typing.TYPE_CHECKING:
+    from sigstore.models import LogEntry
 
 __all__ = [
     "_hashedrekord_from_parts",
 ]
 
-EntryRequestBody = NewType("EntryRequestBody", dict[str, Any])
+EntryRequestBody = typing.NewType("EntryRequestBody", dict[str, typing.Any])
 
 
 class RekorClientError(Exception):


### PR DESCRIPTION
This PR addresses an ImportError caused by a circular dependency between sigstore.models and the sigstore._internal.rekor package, specifically in its __init__.py file. This issue prevented the successful initialization of the sigstore library at runtime.

The problem occurred because sigstore.models (during its loading) was importing verify_checkpoint from sigstore._internal.rekor.checkpoint, while sigstore._internal.rekor/__init__.py simultaneously attempted to import LogEntry from the still-loading sigstore.models.

Resolves sigstore/sigstore-python#1457