### PR TITLE
fetch timestamps before submitting to rekor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ All versions prior to 0.9.0 are untracked.
   configure the used Sigstore instance [#1358]/(https://github.com/sigstore/sigstore-python/pull/1358)
 * By default (when `--trust-config` is not used) the whole trust configuration now
   comes from the TUF repository [#1363](https://github.com/sigstore/sigstore-python/pull/1363)
+* If the user provided TSA urls, rfc3161 timestamps are now fetched **before** submitting
+  entries to rekor.
 
 ### Removed
  * API:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ All versions prior to 0.9.0 are untracked.
 * By default (when `--trust-config` is not used) the whole trust configuration now
   comes from the TUF repository [#1363](https://github.com/sigstore/sigstore-python/pull/1363)
 * If the user provided TSA urls, rfc3161 timestamps are now fetched **before** submitting
-  entries to rekor.
+  entries to rekor. [#1463](https://github.com/sigstore/sigstore-python/pull/1463)
 
 ### Removed
  * API:

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -178,11 +178,6 @@ class Signer:
         """
         Perform the common "finalizing" steps in a Sigstore signing flow.
         """
-        # Submit the proposed entry to the transparency log
-        entry = self._signing_ctx._rekor.create_entry(proposed_entry)
-
-        _logger.debug(f"Transparency log entry created with index: {entry.log_index}")
-
         # If the user provided TSA urls, timestamps the response
         signed_timestamp = []
         for tsa_client in self._signing_ctx._tsa_clients:
@@ -192,6 +187,10 @@ class Signer:
                 _logger.warning(
                     f"Unable to use {tsa_client.url} to timestamp the bundle. Failed with {e}"
                 )
+
+        # Submit the proposed entry to the transparency log
+        entry = self._signing_ctx._rekor.create_entry(proposed_entry)
+        _logger.debug(f"Transparency log entry created with index: {entry.log_index}")
 
         return Bundle._from_parts(cert, content, entry, signed_timestamp)
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Fetch timestamps before submitting to rekor.

Resolves https://github.com/sigstore/sigstore-python/issues/1459

#### Release Note
<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->

* If the user provided TSA urls, rfc3161 timestamps are now fetched **before** submitting
  entries to rekor.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->