### PR TITLE
Backport verified time changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed verified time handling so that additional timestamps cannot break
+  otherwise valid signature bundles ([#1492](https://github.com/sigstore/sigstore-python/pull/1492))
+
 ## [3.6.4]
 
 ### Fixed

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -236,12 +236,6 @@ class Verifier:
         if (
             timestamp := bundle.log_entry.integrated_time
         ) and bundle.log_entry.inclusion_promise:
-            kv = bundle.log_entry._kind_version
-            if not (kv.kind in ["dsse", "hashedrekord"] and kv.version == "0.0.1"):
-                raise VerificationError(
-                    "Integrated time only supported for dsse/hashedrekord 0.0.1 types"
-                )
-
             verified_timestamps.append(
                 TimestampVerificationResult(
                     source=TimestampSource.TRANSPARENCY_SERVICE,

--- a/test/unit/verify/test_verifier.py
+++ b/test/unit/verify/test_verifier.py
@@ -205,7 +205,11 @@ class TestVerifierWithTimestamp:
         verifier._trusted_root._inner.timestamp_authorities = [authority._inner]
         return verifier
 
-    def test_verifier_verify_timestamp(self, verifier, asset, null_policy):
+    def test_verifier_verify_timestamp(self, verifier, asset, null_policy, monkeypatch):
+        # asset is a rekor v1 bundle: set threshold to 2 so both integrated time and the
+        # TSA timestamp are required
+        monkeypatch.setattr("sigstore.verify.verifier.VERIFIED_TIME_THRESHOLD", 2)
+
         verifier.verify_artifact(
             asset("tsa/bundle.txt").read_bytes(),
             Bundle.from_json(asset("tsa/bundle.txt.sigstore").read_bytes()),
@@ -260,15 +264,21 @@ class TestVerifierWithTimestamp:
         )
 
     def test_verifier_outside_validity_range(
-        self, caplog, verifier, asset, null_policy
+        self, caplog, verifier, asset, null_policy, monkeypatch
     ):
+        # asset is a rekor v1 bundle: set threshold to 2 so both integrated time and the
+        # TSA timestamp are required
+        monkeypatch.setattr("sigstore.verify.verifier.VERIFIED_TIME_THRESHOLD", 2)
+
         # Set a date before the timestamp range
         verifier._trusted_root.get_timestamp_authorities()[
             0
         ]._inner.valid_for.end = datetime(2024, 10, 31, tzinfo=timezone.utc)
 
         with caplog.at_level(logging.DEBUG, logger="sigstore.verify.verifier"):
-            with pytest.raises(VerificationError, match="not enough timestamps"):
+            with pytest.raises(
+                VerificationError, match="not enough sources of verified time"
+            ):
                 verifier.verify_artifact(
                     asset("tsa/bundle.txt").read_bytes(),
                     Bundle.from_json(asset("tsa/bundle.txt.sigstore").read_bytes()),
@@ -283,13 +293,19 @@ class TestVerifierWithTimestamp:
     def test_verifier_rfc3161_error(
         self, verifier, asset, null_policy, caplog, monkeypatch
     ):
+        # asset is a rekor v1 bundle: set threshold to 2 so both integrated time and the
+        # TSA timestamp are required
+        monkeypatch.setattr("sigstore.verify.verifier.VERIFIED_TIME_THRESHOLD", 2)
+
         def verify_function(*args):
             raise rfc3161_client.VerificationError()
 
         monkeypatch.setattr(rfc3161_client.verify._Verifier, "verify", verify_function)
 
         with caplog.at_level(logging.DEBUG, logger="sigstore.verify.verifier"):
-            with pytest.raises(VerificationError, match="not enough timestamps"):
+            with pytest.raises(
+                VerificationError, match="not enough sources of verified time"
+            ):
                 verifier.verify_artifact(
                     asset("tsa/bundle.txt").read_bytes(),
                     Bundle.from_json(asset("tsa/bundle.txt.sigstore").read_bytes()),
@@ -309,7 +325,7 @@ class TestVerifierWithTimestamp:
                 null_policy,
             )
 
-    def test_late_timestamp(self, caplog, verifier, asset, null_policy):
+    def test_late_timestamp(self, caplog, verifier, asset, null_policy, monkeypatch):
         """
         Ensures that verifying the signing certificate fails because the timestamp
         is outside the certificate's validity window. The sample bundle
@@ -317,7 +333,13 @@ class TestVerifierWithTimestamp:
         into `sigstore.sign.Signer._finalize_sign()`, just after the entry is posted to Rekor
         but before the timestamp is requested.
         """
-        with pytest.raises(VerificationError, match="not enough timestamps"):
+        # asset is a rekor v1 bundle: set threshold to 2 so both integrated time and the
+        # TSA timestamp are required
+        monkeypatch.setattr("sigstore.verify.verifier.VERIFIED_TIME_THRESHOLD", 2)
+
+        with pytest.raises(
+            VerificationError, match="not enough sources of verified time"
+        ):
             verifier.verify_artifact(
                 asset("tsa/bundle.txt").read_bytes(),
                 Bundle.from_json(
@@ -334,8 +356,12 @@ class TestVerifierWithTimestamp:
     def test_verifier_not_enough_timestamp(
         self, verifier, asset, null_policy, monkeypatch
     ):
-        monkeypatch.setattr("sigstore.verify.verifier.VERIFY_TIMESTAMP_THRESHOLD", 2)
-        with pytest.raises(VerificationError, match="not enough timestamps"):
+        # asset is a rekor v1 bundle: set threshold to 3 so integrated time and one
+        # TSA timestamp are not enough
+        monkeypatch.setattr("sigstore.verify.verifier.VERIFIED_TIME_THRESHOLD", 3)
+        with pytest.raises(
+            VerificationError, match="not enough sources of verified time"
+        ):
             verifier.verify_artifact(
                 asset("tsa/bundle.txt").read_bytes(),
                 Bundle.from_json(asset("tsa/bundle.txt.sigstore").read_bytes()),


### PR DESCRIPTION
This backports #1489 into 3.6.x: the point is to make sure that sigstore-python 3.6.x can verify a bundle created by sigstore-python 4.0 (if that bundle contains a rekor v1 entry and an additional timestamp). Currently the verification fails on staging  because
* signing code in 4.0 will include a timestamp in the bundle
* the timestamp certificate happens to use a keytype we do not support in 3.6.x (meaning the timestamp in the bundle is not considered valid).
* the verification code currently requires at least one timestamp to be valid (if any timestamps are included in the bundle) even if the integrated time should suffice 

This PR changes the last point: integrated time is enough.

I can add the release changes in this PR as well if there's nothing else for 3.6.5