### PR TITLE
Release 3.6.5 prep and allow cryptography45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,18 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+## [3.6.5]
+
 ### Fixed
 
 * Fixed verified time handling so that additional timestamps cannot break
   otherwise valid signature bundles ([#1492](https://github.com/sigstore/sigstore-python/pull/1492))
+
+### Changed
+
+* Added cryptography 45 to list of compatible cryptography releases
+  ([#1498](https://github.com/sigstore/sigstore-python/pull/1498))
+
 
 ## [3.6.4]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Security :: Cryptography",
 ]
 dependencies = [
-  "cryptography >= 42, < 45",
+  "cryptography >= 42, < 46",
   "id >= 1.1.0",
   "importlib_resources ~= 5.7; python_version < '3.11'",
   "pyasn1 ~= 0.6",

--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -25,4 +25,4 @@ Otherwise, here are some quick starting points:
 * `sigstore.sign`: creation of Sigstore signatures
 """
 
-__version__ = "3.6.4"
+__version__ = "3.6.5"


### PR DESCRIPTION
This contains
* fix for #1433: Allow cryptography 45
* release prep for 3.6.5

@woodruffw let me know if you have opinions on the cryptography change -- I realize it has not really been tested: I've checked the git log on main and don't see any related changes so I feel like it should be safe.