### PR TITLE
Improve case of possible wrong instance on verify

### DIFF
--- a/sigstore/_cli.py
+++ b/sigstore/_cli.py
@@ -46,7 +46,7 @@ from sigstore.dsse._predicate import (
     SLSAPredicateV0_2,
     SLSAPredicateV1_0,
 )
-from sigstore.errors import Error, VerificationError
+from sigstore.errors import CertValidationError, Error, VerificationError
 from sigstore.hashes import Hashed
 from sigstore.models import Bundle, InvalidBundle
 from sigstore.oidc import (
@@ -1091,6 +1091,11 @@ def _verify_identity(args: argparse.Namespace) -> None:
             print(f"OK: {file_or_digest}", file=sys.stderr)
             if statement is not None:
                 print(statement._contents.decode())
+        except CertValidationError:
+            _logger.warning(
+                "A certificate chain was not valid, are you using the correct Sigstore instance?"
+            )
+            _logger.error(f"FAIL: {file_or_digest}")
         except Error as exc:
             _logger.error(f"FAIL: {file_or_digest}")
             exc.log_and_exit(_logger, args.verbose >= 1)
@@ -1139,6 +1144,11 @@ def _verify_github(args: argparse.Namespace) -> None:
             print(f"OK: {file_or_digest}", file=sys.stderr)
             if statement is not None:
                 print(statement._contents)
+        except CertValidationError:
+            _logger.warning(
+                "A certificate chain was not valid, are you using the correct Sigstore instance?"
+            )
+            _logger.error(f"FAIL: {file_or_digest}")
         except Error as exc:
             _logger.error(f"FAIL: {file_or_digest}")
             exc.log_and_exit(_logger, args.verbose >= 1)

--- a/sigstore/errors.py
+++ b/sigstore/errors.py
@@ -125,3 +125,9 @@ class VerificationError(Error):
     """
     Raised whenever any phase or subcomponent of Sigstore verification fails.
     """
+
+
+class CertValidationError(VerificationError):
+    """
+    Raised when a TSA certificate chain fails to validate during Sigstore verification.
+    """

--- a/test/unit/verify/test_verifier.py
+++ b/test/unit/verify/test_verifier.py
@@ -385,11 +385,6 @@ class TestVerifierWithTimestamp:
                 null_policy,
             )
 
-        assert (
-            "Error while verifying certificates: Unable to verify pkcs7 signature"
-            in caplog.records[0].message
-        )
-
     def test_verifier_not_enough_timestamp(
         self, verifier, asset, null_policy, monkeypatch
     ):


### PR DESCRIPTION
Fixes #1487
* moves rfc3161-client exception details to debug log level
* Offers a hint if TSA cert chain verification fails: this is a sign that possible the bundle uses a different sigstore instance than the verification expects 