### PR TITLE
Workflow tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,15 @@ on:
       - series/*
   pull_request:
   schedule:
-    - cron: "0 12 * * *"
+    - cron: "0 11 * * *"
   workflow_dispatch:
 
 permissions: {}
 
 jobs:
   test:
+    # Avoid scheduled runs in forks
+    if: github.event_name != 'schedule' || github.repository == 'sigstore/sigstore-python'
     permissions:
       # Needed to access the workflow's OIDC identity.
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
   schedule:
     - cron: "0 12 * * *"
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,6 +41,7 @@ jobs:
   # This is a separate job so that only actions/deploy-pages has the necessary permissions.
   deploy:
     needs: build
+    if: github.repository == 'sigstore/sigstore-python'
     runs-on: ubuntu-latest
     permissions:
       # NOTE: Needed to push to the repository.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
Some minor workflow tweaks:
* Avoid scheduled tests in forks (that happen to have workflows enabled): this is more efficient but also debugging the infra side is easier if the test suite typically only runs once and not multiple times in parallel
* Allow workflow_dispatch in tests/lint
* Try to make docs workflow not fail in forks