### PR TITLE
workflows: Remove pip-tools workaround

### DIFF
--- a/.github/workflows/pin-requirements.yml
+++ b/.github/workflows/pin-requirements.yml
@@ -77,9 +77,7 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
-        run: |
-          pip install "pip < 25.1" # workaround issue 1426
-          pip install pip-tools
+        run: pip install pip-tools
 
       - name: Compute version from tag
         run: |


### PR DESCRIPTION
pip-tools is now compatible with current pip

fixes #1428 