### PR TITLE
chore: forward port 3.6.5

### DIFF
--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -25,4 +25,4 @@ Otherwise, here are some quick starting points:
 * `sigstore.sign`: creation of Sigstore signatures
 """
 
-__version__ = "3.6.4"
+__version__ = "3.6.5"


### PR DESCRIPTION
This is just a version number change: All changes in 3.6.5 were backported from main.

---

This makes access logs make a little more sense (as currently the user-agent in CI makes it it look like we're running tests on an old release).