### PR TITLE
Bump cryptography maximum version in 3.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All versions prior to 0.9.0 are untracked.
 
 * Improved error message when verifying bundles with rekor v2 entries
   ([#1565](https://github.com/sigstore/sigstore-python/pull/1565))
+* Added cryptography 46 to list of compatible cryptography releases
+  ([#1566](https://github.com/sigstore/sigstore-python/pull/1566))
 
 ## [3.6.5]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Security :: Cryptography",
 ]
 dependencies = [
-  "cryptography >= 42, < 46",
+  "cryptography >= 42, < 47",
   "id >= 1.1.0",
   "importlib_resources ~= 5.7; python_version < '3.11'",
   "pyasn1 ~= 0.6",


### PR DESCRIPTION
like I mentioned in previous pr, I don't think this absolutely necessary but if we're doing a 3.6.x release I think it's nice.