### PR TITLE
Release process fix for series/3.5.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
 
       - name: publish
-        uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597 # v1.10.3
+        uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597 # v1.13.0
         with:
           packages-dir: built-packages/
           attestations: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+## [3.5.5]
+
+This is the last planned release in 3.5.x series: All users should upgrade to
+a newer release series.
+
+### Fixed
+
+* Release process fix for [3.5.4]
+
 ## [3.5.4]
 
 ### Fixed
@@ -560,7 +569,9 @@ This is a corrective release for [2.1.1].
 
 
 <!--Release URLs -->
-[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.5.3...HEAD
+[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.5.5...series/3.5.x
+[3.5.5]: https://github.com/sigstore/sigstore-python/compare/v3.5.4...v3.5.5
+[3.5.4]: https://github.com/sigstore/sigstore-python/compare/v3.5.3...v3.5.4
 [3.5.3]: https://github.com/sigstore/sigstore-python/compare/v3.5.2...v3.5.3
 [3.5.2]: https://github.com/sigstore/sigstore-python/compare/v3.5.1...v3.5.2
 [3.5.1]: https://github.com/sigstore/sigstore-python/compare/v3.5.0...v3.5.1

--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -25,4 +25,4 @@ Otherwise, here are some quick starting points:
 * `sigstore.sign`: creation of Sigstore signatures
 """
 
-__version__ = "3.5.4"
+__version__ = "3.5.5"


### PR DESCRIPTION
The 3.5.4 release failed when running pypa/gh-action-pypi-publish. I believe this is https://github.com/pypa/gh-action-pypi-publish/issues/354 -- the series/3.5.x branch is using an old release action version that has broken in the mean time.

Upgrade the action, bump release version for another attempt