### PR TITLE
workflows: Add 3.5.x to cross-version-verify test

### DIFF
--- a/.github/workflows/cross-version-verify.yaml
+++ b/.github/workflows/cross-version-verify.yaml
@@ -41,8 +41,9 @@ jobs:
         uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@4a8befcc16064dac9e97f210948d226e5c869bdc # v1.0.0
       - name: Sign 
         run: |
-          python -m sigstore --staging sign --bundle artifact-rekor2.sigstore.json --identity-token $(cat oidc-token.txt) --rekor-version=2 test/assets/a.txt
-          python -m sigstore --staging sign --bundle artifact-rekor1.sigstore.json --identity-token $(cat oidc-token.txt) --rekor-version=1 test/assets/a.txt
+          touch artifact
+          python -m sigstore --staging sign --bundle artifact-rekor2.sigstore.json --identity-token $(cat oidc-token.txt) --rekor-version=2 artifact
+          python -m sigstore --staging sign --bundle artifact-rekor1.sigstore.json --identity-token $(cat oidc-token.txt) --rekor-version=1 artifact
       - name: upload signature bundle
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
@@ -52,38 +53,31 @@ jobs:
           retention-days: 1
   verify:
     name: Verify with ${{ matrix.version }}
-    if: ${{ always() }} # don't stop some verification if one of the signing jobs failed
     needs: [sign]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false # Don't cancel other jobs if one fails
       matrix:
-        version: [v3.6.5, v4.0.0, v4.1.0]
+        version: [3.5.6, 3.6.6, 4.0.0, 4.1.0]
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
-          ref: ${{matrix.version}}
-          fetch-tags: true
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.x"
-          cache: "pip"
-          cache-dependency-path: pyproject.toml
-      - run: pip install .
+      - run: pip install sigstore==${{ matrix.version }}
       - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: bundle
+      - run: touch artifact
       - name: Verify (Rekor v2)
-        if: matrix.version != 'v3.6.5'
+        if: startsWith(matrix.version, '3.') != true
         run: |
           python -m sigstore --staging verify github --verbose \
             --cert-identity "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main" \
             --bundle artifact-rekor2.sigstore.json \
-            test/assets/a.txt
+            artifact
       - name: Verify (Rekor v1)
         run: |
           python -m sigstore --staging verify github --verbose \
             --cert-identity "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main" \
             --bundle artifact-rekor1.sigstore.json \
-            test/assets/a.txt
+            artifact


### PR DESCRIPTION
Draft until 3.5.x release happens (#1591, err #1596)

### Changes

* Test with last release in 3.5.x series, also bump the 3.6 series version to newest 3.6.6
* Install the verifying releases from pypi, not from sources (it's simpler and arguably a better test)
* Don't use a test asset as artifact: this way verify job does not need a checkout
* Remove unneeded if-clause (from copy-pasting cross-os test originally)

