### PR TITLE
series/3.5.x: Actually fix the release workflow, bump version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
 
       - name: publish
-        uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597 # v1.13.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           packages-dir: built-packages/
           attestations: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+## [3.5.6]
+
+This is the last planned release in 3.5.x series: All users should upgrade to
+a newer release series.
+
+### Fixed
+
+* Release process fix for [3.5.5]
+
 ## [3.5.5]
 
 This is the last planned release in 3.5.x series: All users should upgrade to
@@ -569,7 +578,8 @@ This is a corrective release for [2.1.1].
 
 
 <!--Release URLs -->
-[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.5.5...series/3.5.x
+[Unreleased]: https://github.com/sigstore/sigstore-python/compare/v3.5.6...series/3.5.x
+[3.5.6]: https://github.com/sigstore/sigstore-python/compare/v3.5.5...v3.5.6
 [3.5.5]: https://github.com/sigstore/sigstore-python/compare/v3.5.4...v3.5.5
 [3.5.4]: https://github.com/sigstore/sigstore-python/compare/v3.5.3...v3.5.4
 [3.5.3]: https://github.com/sigstore/sigstore-python/compare/v3.5.2...v3.5.3

--- a/sigstore/__init__.py
+++ b/sigstore/__init__.py
@@ -25,4 +25,4 @@ Otherwise, here are some quick starting points:
 * `sigstore.sign`: creation of Sigstore signatures
 """
 
-__version__ = "3.5.5"
+__version__ = "3.5.6"


### PR DESCRIPTION
3.5.5 was great except it was missing the actual action hash change that it was supposed to contain -- my bad. 

Try again with 3.5.6.
