### PR TITLE
fix(models): break circular import with Rekor clients

### DIFF
--- a/sigstore/_internal/rekor/client.py
+++ b/sigstore/_internal/rekor/client.py
@@ -23,7 +23,7 @@ import json
 import logging
 from abc import ABC
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import rekor_types
 import requests
@@ -38,7 +38,9 @@ from sigstore._internal.rekor import (
 )
 from sigstore.dsse import Envelope
 from sigstore.hashes import Hashed
-from sigstore.models import TransparencyLogEntry
+
+if TYPE_CHECKING:
+    from sigstore.models import TransparencyLogEntry
 
 _logger = logging.getLogger(__name__)
 
@@ -142,6 +144,8 @@ class RekorEntries(_Endpoint):
             resp.raise_for_status()
         except requests.HTTPError as http_error:
             raise RekorClientError(http_error)
+        from sigstore.models import TransparencyLogEntry
+
         return TransparencyLogEntry._from_v1_response(resp.json())
 
     def post(
@@ -162,6 +166,8 @@ class RekorEntries(_Endpoint):
 
         integrated_entry = resp.json()
         _logger.debug(f"integrated: {integrated_entry}")
+        from sigstore.models import TransparencyLogEntry
+
         return TransparencyLogEntry._from_v1_response(integrated_entry)
 
     @property
@@ -204,6 +210,8 @@ class RekorEntriesRetrieve(_Endpoint):
         # We select the oldest entry for our actual return value,
         # since a malicious actor could conceivably spam the log with
         # newer duplicate entries.
+        from sigstore.models import TransparencyLogEntry
+
         oldest_entry: TransparencyLogEntry | None = None
         for result in results:
             entry = TransparencyLogEntry._from_v1_response(result)

--- a/sigstore/_internal/rekor/client_v2.py
+++ b/sigstore/_internal/rekor/client_v2.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
+from typing import TYPE_CHECKING
 
 import requests
 from cryptography.hazmat.primitives import serialization
@@ -38,7 +39,9 @@ from sigstore._internal.rekor import (
 )
 from sigstore.dsse import Envelope
 from sigstore.hashes import Hashed
-from sigstore.models import TransparencyLogEntry
+
+if TYPE_CHECKING:
+    from sigstore.models import TransparencyLogEntry
 
 _logger = logging.getLogger(__name__)
 
@@ -89,6 +92,8 @@ class RekorV2Client(RekorLogSubmitter):
 
         integrated_entry = resp.json()
         _logger.debug(f"integrated: {integrated_entry}")
+        from sigstore.models import TransparencyLogEntry
+
         inner = _TransparencyLogEntry.from_dict(integrated_entry)
         return TransparencyLogEntry(inner)
 

--- a/sigstore/models.py
+++ b/sigstore/models.py
@@ -53,6 +53,8 @@ from sigstore._internal.fulcio.client import FulcioClient
 from sigstore._internal.merkle import verify_merkle_inclusion
 from sigstore._internal.rekor import RekorLogSubmitter
 from sigstore._internal.rekor.checkpoint import verify_checkpoint
+from sigstore._internal.rekor.client import RekorClient
+from sigstore._internal.rekor.client_v2 import RekorV2Client
 from sigstore._internal.timestamp import TimestampAuthorityClient
 from sigstore._internal.trust import (
     CertificateAuthority,
@@ -757,12 +759,8 @@ class SigningConfig:
         result: list[RekorLogSubmitter] = []
         for tlog in self._tlogs:
             if tlog.major_api_version == 1:
-                from sigstore._internal.rekor.client import RekorClient
-
                 result.append(RekorClient(tlog.url))
             elif tlog.major_api_version == 2:
-                from sigstore._internal.rekor.client_v2 import RekorV2Client
-
                 result.append(RekorV2Client(tlog.url))
             else:
                 raise AssertionError(f"Unexpected Rekor v{tlog.major_api_version}")


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
- add [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

#### Summary
fixes: #1536
This PR fixes the circular import that required lazy imports in sigstore.models after moving additional trust/config types into models.py.

#### Release Note
<!--
Add a release note for each of the following conditions in CHANGELOG.md:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

Use past-tense.

-->
Fixed a circular import between sigstore.models and Rekor client modules, removing the need for lazy imports when constructing transparency log clients.
#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
