### PR TITLE
Allow setting of redirect URI port for OIDC flows

### DIFF
--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -87,9 +87,9 @@ AUTH_SUCCESS_HTML = """
       </div>
       <div class="anchor">
         <div class="links">
-          <a href="https://sigstore.dev/" class="link login"><span class="sigstore">sigstore</span> home <span class="arrow">→</span></a>
-          <a href="https://docs.sigstore.dev/" class="link login"><span class="sigstore">sigstore</span> documentation <span class="arrow">→</span></a>
-          <a href="https://blog.sigstore.dev/" class="link"><span class="sigstore">sigstore</span> blog <span class="arrow">→</span></a>
+          <a href="https://sigstore.dev/" class="link login"><span class="sigstore">sigstore</span> home <span class="arrow">&rarr;</span></a>
+          <a href="https://docs.sigstore.dev/" class="link login"><span class="sigstore">sigstore</span> documentation <span class="arrow">&rarr;</span></a>
+          <a href="https://blog.sigstore.dev/" class="link"><span class="sigstore">sigstore</span> blog <span class="arrow">&rarr;</span></a>
         </div>
       </div>
     </div>
@@ -102,12 +102,18 @@ AUTH_SUCCESS_HTML = """
 
 
 class _OAuthFlow:
-    def __init__(self, client_id: str, client_secret: str, issuer: Issuer):
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        issuer: Issuer,
+        redirect_port: int = 0,
+    ):
         self._client_id = client_id
         self._client_secret = client_secret
         self._issuer = issuer
         self._server = _OAuthRedirectServer(
-            self._client_id, self._client_secret, self._issuer
+            self._client_id, self._client_secret, self._issuer, port=redirect_port
         )
         self._server_thread = threading.Thread(
             target=lambda server: server.serve_forever(),
@@ -223,8 +229,14 @@ class _OAuthSession:
 
 
 class _OAuthRedirectServer(http.server.HTTPServer):
-    def __init__(self, client_id: str, client_secret: str, issuer: Issuer) -> None:
-        super().__init__(("localhost", 0), _OAuthRedirectHandler)
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        issuer: Issuer,
+        port: int = 0,
+    ) -> None:
+        super().__init__(("localhost", port), _OAuthRedirectHandler)
         self.oauth_session = _OAuthSession(client_id, client_secret, issuer)
         self.auth_response: dict[str, list[str]] | None = None
         self._is_out_of_band = False

--- a/sigstore/oidc.py
+++ b/sigstore/oidc.py
@@ -274,6 +274,7 @@ class Issuer:
         client_id: str = _DEFAULT_CLIENT_ID,
         client_secret: str = "",
         force_oob: bool = False,
+        redirect_port: int = 0,
     ) -> IdentityToken:
         """
         Retrieves and returns an `IdentityToken` from the current `Issuer`, via OAuth.
@@ -283,6 +284,11 @@ class Issuer:
         The `force_oob` flag controls the kind of flow performed. When `False` (the default),
         this function attempts to open the user's web browser before falling back to
         an out-of-band flow. When `True`, the out-of-band flow is always used.
+
+        The `redirect_port` parameter controls the port used for the local redirect server
+        during the OAuth flow. When `0` (the default), an ephemeral port is chosen by the OS.
+        Set this to a specific port number when your OIDC provider requires a pre-registered
+        redirect URI with a fixed port.
         """
 
         # This function and the components that it relies on are based off of:
@@ -291,7 +297,9 @@ class Issuer:
         from sigstore._internal.oidc.oauth import _OAuthFlow
 
         code: str
-        with _OAuthFlow(client_id, client_secret, self) as server:
+        with _OAuthFlow(
+            client_id, client_secret, self, redirect_port=redirect_port
+        ) as server:
             # Launch web browser
             if not force_oob and webbrowser.open(server.base_uri):
                 print("Waiting for browser interaction...", file=sys.stderr)


### PR DESCRIPTION
Fixes #1029

Adds an optional `redirect_port` parameter to `Issuer.identity_token()` that gets threaded through to the internal OAuth redirect server. This allows callers to specify a fixed port for the local redirect server instead of always using an ephemeral port (port 0).

This is useful in enterprise environments where OIDC providers require a pre-registered redirect URI with a specific port.

**Changes:**
- `Issuer.identity_token()`: new `redirect_port: int = 0` parameter (default preserves existing behavior)
- `_OAuthFlow.__init__()`: accepts and forwards `redirect_port`
- `_OAuthRedirectServer.__init__()`: accepts `port` parameter instead of hardcoded `0`

Signed-off-by: Yash Goel <yashgoel892@gmail.com>