### PR TITLE
Add timeout to Fulcio HTTP requests to prevent indefinite hangs

### DIFF
--- a/sigstore/_internal/fulcio/client.py
+++ b/sigstore/_internal/fulcio/client.py
@@ -37,6 +37,8 @@ from sigstore._internal import USER_AGENT
 from sigstore._utils import B64Str
 from sigstore.oidc import IdentityToken
 
+_CLIENT_TIMEOUT: int = 30
+
 _logger = logging.getLogger(__name__)
 
 SIGNING_CERT_ENDPOINT = "/api/v2/signingCert"
@@ -103,7 +105,7 @@ class FulcioSigningCert(_Endpoint):
             "Accept": "application/pem-certificate-chain",
         }
         resp: requests.Response = self.session.post(
-            url=self.url, data=_serialize_cert_request(req), headers=headers
+            url=self.url, data=_serialize_cert_request(req), headers=headers, timeout=_CLIENT_TIMEOUT
         )
         try:
             resp.raise_for_status()
@@ -141,7 +143,7 @@ class FulcioTrustBundle(_Endpoint):
 
     def get(self) -> FulcioTrustBundleResponse:
         """Get the certificate chains from Fulcio"""
-        resp: requests.Response = self.session.get(self.url)
+        resp: requests.Response = self.session.get(self.url, timeout=_CLIENT_TIMEOUT)
         try:
             resp.raise_for_status()
         except requests.HTTPError as http_error:


### PR DESCRIPTION
The FulcioSigningCert.post() and FulcioTrustBundle.get() methods were missing timeout parameters on their session.post() and session.get() calls, which could cause indefinite hangs if the Fulcio server is slow or unresponsive.

Added _CLIENT_TIMEOUT = 30 (consistent with other HTTP timeouts in the sigstore-python codebase) and applied it to both methods.

This mirrors the fix applied in #67 for the Rekor client and #1 for other endpoints in the codebase. Without timeouts, sigstore-python can hang indefinitely when network issues or server problems occur.