### PR TITLE
workflows: Bump conformance

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -27,7 +27,7 @@ jobs:
           uv pip install .
           echo "$(pwd)/.venv/bin" >> ${GITHUB_PATH}
 
-      - uses: sigstore/sigstore-conformance@e2cc8e51870bb9af4e4ae3342e97cf5f7ea2cdd8 # v0.0.28
+      - uses: sigstore/sigstore-conformance@21533cde107c734ebc153c3e3a24d75fc9811a36 # v0.0.29
         with:
           entrypoint: ${{ github.workspace }}/test/integration/sigstore-python-conformance
           xfail: "test_verify*intoto-with-custom-trust-root]


### PR DESCRIPTION

This verifies the DSSE-as-hashedrekord changes in current release


(This would get a dependabot update sooner or later but I wanted to see the results now)
