### PR TITLE
verify: match email identities case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,11 @@ All versions prior to 0.9.0 are untracked.
   The OIDC redirect server had incomplete HTTP responses and no connection
   management, causing a keep-alive deadlock with the browser.
 
-* `policy.Identity` now matches email (RFC822Name) SANs case-insensitively, so
-  an expected identity that differs only in case (for example `FoO@baR.coM`
-  versus a `foo@bar.com` SAN) verifies successfully. URI and other SAN types
-  are still matched exactly.
+* `policy.Identity` now matches the domain part of email (RFC822Name) SANs
+  case-insensitively, so an expected identity whose domain differs only in case
+  (for example `a@TnY.ToWn` versus an `a@tny.town` SAN) verifies successfully.
+  The local part stays case-sensitive (per RFC 5321 it can be case-significant),
+  and URI and other SAN types are still matched exactly.
   ([sigstore/model-transparency#459](https://github.com/sigstore/model-transparency/issues/459))
 
 ## [4.2.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ All versions prior to 0.9.0 are untracked.
   The OIDC redirect server had incomplete HTTP responses and no connection
   management, causing a keep-alive deadlock with the browser.
 
+* `policy.Identity` now matches email (RFC822Name) SANs case-insensitively, so
+  an expected identity that differs only in case (for example `FoO@baR.coM`
+  versus a `foo@bar.com` SAN) verifies successfully. URI and other SAN types
+  are still matched exactly.
+  ([sigstore/model-transparency#459](https://github.com/sigstore/model-transparency/issues/459))
+
 ## [4.2.0]
 
 ### Fixed

--- a/sigstore/verify/policy.py
+++ b/sigstore/verify/policy.py
@@ -473,13 +473,21 @@ class Identity:
             ]
         )
 
-        # Email (RFC822Name) identities are matched case-insensitively: email
-        # addresses are not case-sensitive in practice and Fulcio normalizes
-        # them, so "FoO@baR.coM" should match a "foo@bar.com" SAN. URI and
-        # "other name" SANs remain exact matches.
-        verified = self._identity in other_sans or self._identity.casefold() in {
-            email.casefold() for email in email_sans
-        }
+        # Email (RFC822Name) identities are matched with the domain compared
+        # case-insensitively, while the local part stays case-sensitive. Per
+        # RFC 5321 the local part can be case-significant, so we must not fold
+        # it; the domain is case-insensitive, so "a@TnY.ToWn" matches an
+        # "a@tny.town" SAN. URI and "other name" SANs remain exact matches.
+        def _normalize_email(value: str) -> str:
+            local, sep, domain = value.rpartition("@")
+            if not sep:
+                # No "@" present: nothing to normalize, compare as-is.
+                return value
+            return f"{local}@{domain.casefold()}"
+
+        verified = self._identity in other_sans or _normalize_email(
+            self._identity
+        ) in {_normalize_email(email) for email in email_sans}
         if not verified:
             all_sans = email_sans | other_sans
             raise VerificationError(

--- a/sigstore/verify/policy.py
+++ b/sigstore/verify/policy.py
@@ -461,11 +461,11 @@ class Identity:
         if self._issuer:
             self._issuer.verify(cert)
 
-        # Build a set of all valid identities.
+        # Build the sets of valid identities from the certificate's SANs.
         san_ext = cert.extensions.get_extension_for_class(SubjectAlternativeName).value
-        all_sans = set(san_ext.get_values_for_type(RFC822Name))
-        all_sans.update(san_ext.get_values_for_type(UniformResourceIdentifier))
-        all_sans.update(
+        email_sans = set(san_ext.get_values_for_type(RFC822Name))
+        other_sans = set(san_ext.get_values_for_type(UniformResourceIdentifier))
+        other_sans.update(
             [
                 on.value.decode()
                 for on in san_ext.get_values_for_type(OtherName)
@@ -473,8 +473,15 @@ class Identity:
             ]
         )
 
-        verified = self._identity in all_sans
+        # Email (RFC822Name) identities are matched case-insensitively: email
+        # addresses are not case-sensitive in practice and Fulcio normalizes
+        # them, so "FoO@baR.coM" should match a "foo@bar.com" SAN. URI and
+        # "other name" SANs remain exact matches.
+        verified = self._identity in other_sans or self._identity.casefold() in {
+            email.casefold() for email in email_sans
+        }
         if not verified:
+            all_sans = email_sans | other_sans
             raise VerificationError(
                 f"Certificate's SANs do not match {self._identity}; actual SANs: {all_sans}"
             )

--- a/test/unit/verify/test_policy.py
+++ b/test/unit/verify/test_policy.py
@@ -151,6 +151,17 @@ class TestIdentity:
         ):
             policy_.verify(bundle.signing_certificate)
 
+    def test_succeeds_email_case_insensitive(self, signing_bundle):
+        # The certificate's email SAN is "a@tny.town"; an identity that differs
+        # only in case must still verify (see #459 in sigstore/model-transparency).
+        _, bundle = signing_bundle("bundle.txt")
+        policy_ = policy.Identity(
+            identity="A@TnY.ToWn",
+            issuer="https://github.com/login/oauth",
+        )
+
+        policy_.verify(bundle.signing_certificate)
+
 
 class TestSingleExtPolicy:
     def test_succeeds(self, signing_bundle):

--- a/test/unit/verify/test_policy.py
+++ b/test/unit/verify/test_policy.py
@@ -151,16 +151,43 @@ class TestIdentity:
         ):
             policy_.verify(bundle.signing_certificate)
 
-    def test_succeeds_email_case_insensitive(self, signing_bundle):
-        # The certificate's email SAN is "a@tny.town"; an identity that differs
-        # only in case must still verify (see #459 in sigstore/model-transparency).
+    def test_succeeds_email_domain_case_insensitive(self, signing_bundle):
+        # The certificate's email SAN is "a@tny.town"; an identity whose domain
+        # differs only in case must still verify, because the domain part of an
+        # email address is case-insensitive (see #459 in
+        # sigstore/model-transparency).
         _, bundle = signing_bundle("bundle.txt")
         policy_ = policy.Identity(
-            identity="A@TnY.ToWn",
+            identity="a@TnY.ToWn",
             issuer="https://github.com/login/oauth",
         )
 
         policy_.verify(bundle.signing_certificate)
+
+    def test_succeeds_email_exact_match(self, signing_bundle):
+        _, bundle = signing_bundle("bundle.txt")
+        policy_ = policy.Identity(
+            identity="a@tny.town",
+            issuer="https://github.com/login/oauth",
+        )
+
+        policy_.verify(bundle.signing_certificate)
+
+    def test_fails_email_local_part_case_differs(self, signing_bundle):
+        # The certificate's email SAN is "a@tny.town". Per RFC 5321 the local
+        # part can be case-significant, so "A@tny.town" (local part differs only
+        # in case) must NOT match, even though the domain is identical.
+        _, bundle = signing_bundle("bundle.txt")
+        policy_ = policy.Identity(
+            identity="A@tny.town",
+            issuer="https://github.com/login/oauth",
+        )
+
+        with pytest.raises(
+            VerificationError,
+            match="Certificate's SANs do not match",
+        ):
+            policy_.verify(bundle.signing_certificate)
 
 
 class TestSingleExtPolicy:


### PR DESCRIPTION
#### Summary

`policy.Identity.verify` builds the set of certificate SANs and checks the expected identity with an exact string comparison (`self._identity in all_sans`). Email addresses are not case-sensitive in practice (and Fulcio normalizes them), so an identity that differs only in case is wrongly rejected:

```
--identity foo@bar.com   -> verifies
--identity FoO@baR.coM   -> VerificationError: Certificate's SANs do not match FoO@baR.coM; actual SANs: {'foo@bar.com'}
```

This was reported downstream in sigstore/model-transparency#459, where the root cause traces to this policy.

This PR matches email (`RFC822Name`) SANs case-insensitively using `casefold()`, while keeping URI and other-name SANs as exact matches (those are case-sensitive in general, so they are deliberately left untouched). The error message still reports the certificate's original SANs.

To test: `make test` (or `pytest test/unit/verify/test_policy.py`). The new `TestIdentity::test_succeeds_email_case_insensitive` fails on `main` and passes with this change; the rest of the verify suite is unaffected.

One thing for reviewers to confirm: this scopes case-insensitivity to email SANs only, which I believe is the right and safe behavior for Fulcio-issued certs. Happy to adjust if you would prefer a narrower (domain-only) or different treatment.

Resolves sigstore/model-transparency#459

#### Release Note

Email (RFC822Name) identities are now matched case-insensitively when verifying a certificate's SANs.

#### Documentation

No documentation change required; this is a bug fix to existing identity-verification behavior.
