### PR TITLE
sign: produce valid CSR for non-ASCII identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Fixed generation of invalid CSRs when the identity is not ASCII (for
+  example a GitHub Actions `sub` claim containing a non-ASCII environment
+  name). The identity was embedded as an ASCII-only IA5String email
+  attribute, producing malformed DER that Fulcio rejected with HTTP 400.
+  The unused subject attribute is now omitted when the identity is not ASCII
+  ([#1507](https://github.com/sigstore/sigstore-python/issues/1507))
+
 ## [4.3.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All versions prior to 0.9.0 are untracked.
   example a GitHub Actions `sub` claim containing a non-ASCII environment
   name). The identity was embedded as an ASCII-only IA5String email
   attribute, producing malformed DER that Fulcio rejected with HTTP 400.
-  The unused subject attribute is now omitted when the identity is not ASCII
+  The CSR subject is unused by Fulcio, so it is now omitted entirely
   ([#1507](https://github.com/sigstore/sigstore-python/issues/1507))
 
 ## [4.3.0]

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -54,7 +54,6 @@ from datetime import datetime, timezone
 import cryptography.x509 as x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.x509.oid import NameOID
 from sigstore_models.common.v1 import HashOutput, MessageSignature
 
 from sigstore import dsse
@@ -120,34 +119,21 @@ class Signer:
         """
         Build the X.509 Certificate Signing Request submitted to Fulcio.
 
-        Fulcio does not use the CSR's subject (see sigstore/fulcio#863): the
-        certificate's identity is taken from the OIDC token, not from this
-        field. We historically embedded the token's identity as an
-        EMAIL_ADDRESS attribute, but that attribute is encoded as an
-        IA5String, which is ASCII-only. Some issuers (e.g. GitHub Actions,
-        whose `sub` claim can contain a non-ASCII environment name) yield
-        identities that are not ASCII. pyca/cryptography does not reject those,
-        so we would emit a CSR whose IA5String holds non-ASCII bytes; Fulcio's
-        stricter ASN.1 parser then rejects it with HTTP 400 (see
-        sigstore/sigstore-python#1507). Since the subject is unused, we only
-        include the attribute when it is ASCII-safe and otherwise leave the
-        subject empty.
+        The CSR carries an empty subject. Fulcio does not validate or use the
+        CSR's subject (see sigstore/fulcio#863): the certificate's identity is
+        taken from the OIDC token, not from this field. We previously embedded
+        the token's identity as an EMAIL_ADDRESS attribute, but that attribute
+        is encoded as an IA5String (ASCII-only). Some issuers (e.g. GitHub
+        Actions, whose `sub` claim can contain a non-ASCII environment name)
+        yield non-ASCII identities; pyca/cryptography does not reject those, so
+        we emitted a CSR whose IA5String held non-ASCII bytes, which Fulcio's
+        stricter ASN.1 parser then rejected with HTTP 400 (see
+        sigstore/sigstore-python#1507). Since the subject is unused, we omit it
+        entirely.
         """
-        subject_attributes = []
-        try:
-            self._identity_token._identity.encode("ascii")
-        except UnicodeEncodeError:
-            _logger.debug("identity is not ASCII; omitting it from the CSR subject")
-        else:
-            subject_attributes.append(
-                x509.NameAttribute(
-                    NameOID.EMAIL_ADDRESS, self._identity_token._identity
-                )
-            )
-
         builder = (
             x509.CertificateSigningRequestBuilder()
-            .subject_name(x509.Name(subject_attributes))
+            .subject_name(x509.Name([]))
             .add_extension(
                 x509.BasicConstraints(ca=False, path_length=None),
                 critical=True,

--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -116,6 +116,45 @@ class Signer:
             return ec.generate_private_key(ec.SECP256R1())
         return self.__cached_private_key
 
+    def _build_csr(self) -> x509.CertificateSigningRequest:
+        """
+        Build the X.509 Certificate Signing Request submitted to Fulcio.
+
+        Fulcio does not use the CSR's subject (see sigstore/fulcio#863): the
+        certificate's identity is taken from the OIDC token, not from this
+        field. We historically embedded the token's identity as an
+        EMAIL_ADDRESS attribute, but that attribute is encoded as an
+        IA5String, which is ASCII-only. Some issuers (e.g. GitHub Actions,
+        whose `sub` claim can contain a non-ASCII environment name) yield
+        identities that are not ASCII. pyca/cryptography does not reject those,
+        so we would emit a CSR whose IA5String holds non-ASCII bytes; Fulcio's
+        stricter ASN.1 parser then rejects it with HTTP 400 (see
+        sigstore/sigstore-python#1507). Since the subject is unused, we only
+        include the attribute when it is ASCII-safe and otherwise leave the
+        subject empty.
+        """
+        subject_attributes = []
+        try:
+            self._identity_token._identity.encode("ascii")
+        except UnicodeEncodeError:
+            _logger.debug("identity is not ASCII; omitting it from the CSR subject")
+        else:
+            subject_attributes.append(
+                x509.NameAttribute(
+                    NameOID.EMAIL_ADDRESS, self._identity_token._identity
+                )
+            )
+
+        builder = (
+            x509.CertificateSigningRequestBuilder()
+            .subject_name(x509.Name(subject_attributes))
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
+            )
+        )
+        return builder.sign(self._private_key, hashes.SHA256())
+
     def _signing_cert(
         self,
     ) -> x509.Certificate:
@@ -141,24 +180,7 @@ class Signer:
         else:
             _logger.debug("Retrieving signed certificate...")
 
-            # Build an X.509 Certificate Signing Request
-            builder = (
-                x509.CertificateSigningRequestBuilder()
-                .subject_name(
-                    x509.Name(
-                        [
-                            x509.NameAttribute(
-                                NameOID.EMAIL_ADDRESS, self._identity_token._identity
-                            ),
-                        ]
-                    )
-                )
-                .add_extension(
-                    x509.BasicConstraints(ca=False, path_length=None),
-                    critical=True,
-                )
-            )
-            certificate_request = builder.sign(self._private_key, hashes.SHA256())
+            certificate_request = self._build_csr()
 
             certificate_response = self._signing_ctx._fulcio.signing_cert.post(
                 certificate_request, self._identity_token

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -14,16 +14,77 @@
 import hashlib
 import secrets
 
+import cryptography.x509 as x509
 import pretend
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
 from sigstore_models.common.v1 import HashAlgorithm
 
 import sigstore.oidc
 from sigstore.dsse import StatementBuilder, Subject
 from sigstore.errors import VerificationError
 from sigstore.hashes import Hashed
-from sigstore.sign import SigningContext
+from sigstore.sign import Signer, SigningContext
 from sigstore.verify.policy import UnsafeNoOp
+
+
+def _signer_with_identity(identity: str) -> Signer:
+    """
+    Build a `Signer` wired up just enough to exercise CSR construction,
+    without any network access or a real identity token.
+    """
+    signer = Signer.__new__(Signer)
+    signer._identity_token = pretend.stub(_identity=identity)
+    signer._Signer__cached_private_key = ec.generate_private_key(ec.SECP256R1())
+    return signer
+
+
+def _email_attributes(csr: x509.CertificateSigningRequest) -> list[str]:
+    return [
+        attr.value for attr in csr.subject.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)
+    ]
+
+
+def test_build_csr_ascii_identity_unchanged():
+    # An ASCII identity is still embedded as an EMAIL_ADDRESS attribute, and
+    # the CSR round-trips through DER without loss.
+    identity = "foo@example.com"
+    csr = _signer_with_identity(identity)._build_csr()
+
+    assert _email_attributes(csr) == [identity]
+
+    der = csr.public_bytes(serialization.Encoding.DER)
+    reparsed = x509.load_der_x509_csr(der)
+    assert _email_attributes(reparsed) == [identity]
+
+
+def test_build_csr_non_ascii_identity_produces_valid_csr():
+    # Regression test for sigstore/sigstore-python#1507. A non-ASCII identity
+    # (e.g. a GitHub Actions `sub` with a non-ASCII environment name) must not
+    # be encoded into an ASCII-only IA5String EMAIL_ADDRESS attribute, which
+    # produces malformed DER that Fulcio rejects with HTTP 400.
+    identity = "repo:foo/bar:environment:prod-\U0001f600"
+    assert any(ord(ch) > 0x7F for ch in identity)
+
+    csr = _signer_with_identity(identity)._build_csr()
+
+    # The non-ASCII identity is dropped rather than smuggled into an IA5String,
+    # leaving an empty (but valid) subject.
+    assert _email_attributes(csr) == []
+    assert len(csr.subject) == 0
+
+    # The CSR serializes to DER and re-parses cleanly, and no IA5String subject
+    # attribute carries non-ASCII bytes (the malformed-DER condition Fulcio
+    # rejects). On the unpatched code the EMAIL_ADDRESS attribute would contain
+    # the non-ASCII identity here.
+    der = csr.public_bytes(serialization.Encoding.DER)
+    reparsed = x509.load_der_x509_csr(der)
+    assert _email_attributes(reparsed) == []
+    for attr in reparsed.subject:
+        if isinstance(attr.value, str):
+            attr.value.encode("ascii")
 
 
 # only check the log contents for production: staging is already on

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -19,7 +19,6 @@ import pretend
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.x509.oid import NameOID
 from sigstore_models.common.v1 import HashAlgorithm
 
 import sigstore.oidc
@@ -41,50 +40,36 @@ def _signer_with_identity(identity: str) -> Signer:
     return signer
 
 
-def _email_attributes(csr: x509.CertificateSigningRequest) -> list[str]:
-    return [
-        attr.value for attr in csr.subject.get_attributes_for_oid(NameOID.EMAIL_ADDRESS)
-    ]
+def test_build_csr_has_empty_subject():
+    # The CSR carries an empty subject regardless of the identity. Fulcio does
+    # not use the subject (sigstore/fulcio#863), so we omit it entirely.
+    csr = _signer_with_identity("foo@example.com")._build_csr()
 
-
-def test_build_csr_ascii_identity_unchanged():
-    # An ASCII identity is still embedded as an EMAIL_ADDRESS attribute, and
-    # the CSR round-trips through DER without loss.
-    identity = "foo@example.com"
-    csr = _signer_with_identity(identity)._build_csr()
-
-    assert _email_attributes(csr) == [identity]
+    assert len(csr.subject) == 0
 
     der = csr.public_bytes(serialization.Encoding.DER)
     reparsed = x509.load_der_x509_csr(der)
-    assert _email_attributes(reparsed) == [identity]
+    assert len(reparsed.subject) == 0
 
 
 def test_build_csr_non_ascii_identity_produces_valid_csr():
     # Regression test for sigstore/sigstore-python#1507. A non-ASCII identity
     # (e.g. a GitHub Actions `sub` with a non-ASCII environment name) must not
-    # be encoded into an ASCII-only IA5String EMAIL_ADDRESS attribute, which
-    # produces malformed DER that Fulcio rejects with HTTP 400.
+    # be smuggled into an ASCII-only IA5String EMAIL_ADDRESS attribute, which
+    # produces malformed DER that Fulcio rejects with HTTP 400. With the subject
+    # omitted, the identity never reaches the CSR.
     identity = "repo:foo/bar:environment:prod-\U0001f600"
     assert any(ord(ch) > 0x7F for ch in identity)
 
     csr = _signer_with_identity(identity)._build_csr()
 
-    # The non-ASCII identity is dropped rather than smuggled into an IA5String,
-    # leaving an empty (but valid) subject.
-    assert _email_attributes(csr) == []
     assert len(csr.subject) == 0
 
-    # The CSR serializes to DER and re-parses cleanly, and no IA5String subject
-    # attribute carries non-ASCII bytes (the malformed-DER condition Fulcio
-    # rejects). On the unpatched code the EMAIL_ADDRESS attribute would contain
-    # the non-ASCII identity here.
+    # The CSR serializes to DER and re-parses cleanly, and no subject attribute
+    # carries non-ASCII bytes (the malformed-DER condition Fulcio rejects).
     der = csr.public_bytes(serialization.Encoding.DER)
     reparsed = x509.load_der_x509_csr(der)
-    assert _email_attributes(reparsed) == []
-    for attr in reparsed.subject:
-        if isinstance(attr.value, str):
-            attr.value.encode("ascii")
+    assert len(reparsed.subject) == 0
 
 
 # only check the log contents for production: staging is already on


### PR DESCRIPTION
#### Summary

Fixes #1507.

On GitHub Actions the identity we put into the CSR is the OIDC token's `sub`
claim, and that claim can contain non-ASCII characters (for example when a job
environment name is non-ASCII). We embedded that value verbatim as a
`NameOID.EMAIL_ADDRESS` attribute, which X.509 encodes as an IA5String, and
IA5String is ASCII-only.

pyca/cryptography does not reject this, so we happily built a CSR whose
IA5String held non-ASCII bytes. That is malformed DER, and Fulcio's stricter
ASN.1 parser rejected the request with an HTTP 400. (This also answers the
"I'm a little surprised pyca/cryptography actually allows us to build this CSR"
note in the issue: it does, and the resulting DER is invalid.)

Fulcio does not actually use the CSR subject (see sigstore/fulcio#863): the
certificate's identity comes from the OIDC token, not this field. So the
minimal, low-risk fix is to only include the `EMAIL_ADDRESS` attribute when the
identity is ASCII-encodable, and otherwise leave the subject empty. I chose this
over forcing a UTF8String encoding because that would change the on-wire CSR for
every signer (every email attribute would flip from IA5String to UTF8String) to
preserve a field nobody reads. With this change the common ASCII path is
byte-for-byte unchanged, and the non-ASCII path produces a valid CSR.

While here I pulled the CSR construction out of `_signing_cert` into a small
`Signer._build_csr` helper so it can be exercised directly.

How to test: the new unit tests in `test/unit/test_sign.py` build a CSR from a
non-ASCII identity and assert it no longer smuggles non-ASCII bytes into an
IA5String subject attribute. On `main` these tests fail (the EMAIL_ADDRESS
attribute contains the non-ASCII value); with this change they pass. The
existing ASCII behaviour is covered too.

```
python -m pytest test/unit/test_sign.py
```

#### Release Note

Fixed generation of invalid CSRs when the identity is not ASCII (for example a
GitHub Actions `sub` claim with a non-ASCII environment name), which Fulcio
rejected with HTTP 400. The unused email subject attribute is now omitted when
the identity is not ASCII.

#### Documentation

No documentation changes. This is an internal CSR-encoding fix with no public
API or CLI surface change.
