### PR TITLE
Remove upper bound on cryptography

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Security :: Cryptography",
 ]
 dependencies = [
-  "cryptography >= 42, < 49",
+  "cryptography >= 42",
   "id >= 1.1.0",
   "importlib_resources ~= 5.7; python_version < '3.11'",
   "pyasn1 ~= 0.6",

--- a/uv.lock
+++ b/uv.lock
@@ -1672,7 +1672,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cryptography", specifier = ">=42,<49" },
+    { name = "cryptography", specifier = ">=42" },
     { name = "id", specifier = ">=1.1.0" },
     { name = "importlib-resources", marker = "python_full_version < '3.11'", specifier = "~=5.7" },
     { name = "platformdirs", specifier = "~=4.2" },


### PR DESCRIPTION
This upper bound is pretty disruptive to integrators/downstream packagers. I _think_ we originally added it for strict semver reasons, but:

1. cryptography ~~does not use semver~~ uses the one true versioning scheme (of making regular semantically breaking releases);
2. Our use of their APIs is not high-risk for breakage;
3. cryptography _itself_ integrates sigstore-python's tests as an integration signal, meaning it won't break us unexpectedly.

See https://github.com/Homebrew/homebrew-core/pull/287851 for context.

Closes #1809 