### PR TITLE
Raise VerificationError on malformed checkpoint text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* A malformed checkpoint in a bundle's inclusion proof now raises
+  `VerificationError` during verification, instead of leaking a raw
+  `ValueError` or `binascii.Error`
+  ([#1826](https://github.com/sigstore/sigstore-python/pull/1826))
+
 ## [4.4.0]
 
 ### Changed

--- a/sigstore/_internal/rekor/checkpoint.py
+++ b/sigstore/_internal/rekor/checkpoint.py
@@ -19,6 +19,7 @@ Rekor Checkpoint machinery.
 from __future__ import annotations
 
 import base64
+import binascii
 import re
 import struct
 import typing
@@ -80,8 +81,15 @@ class LogCheckpoint(BaseModel):
         if len(origin) == 0:
             raise VerificationError("malformed LogCheckpoint: empty origin")
 
-        log_size = int(lines[1])
-        root_hash = base64.b64decode(lines[2]).hex()
+        try:
+            log_size = int(lines[1])
+        except ValueError:
+            raise VerificationError("malformed LogCheckpoint: invalid log size")
+
+        try:
+            root_hash = base64.b64decode(lines[2]).hex()
+        except binascii.Error:
+            raise VerificationError("malformed LogCheckpoint: invalid root hash")
 
         return LogCheckpoint(
             origin=origin,

--- a/test/unit/internal/rekor/test_checkpoint.py
+++ b/test/unit/internal/rekor/test_checkpoint.py
@@ -1,0 +1,47 @@
+# Copyright 2025 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+
+import pytest
+
+from sigstore._internal.rekor.checkpoint import LogCheckpoint
+from sigstore.errors import VerificationError
+
+
+class TestLogCheckpoint:
+    def test_from_text_roundtrip(self):
+        root_hash = base64.b64encode(b"\x00" * 32).decode()
+        text = f"rekor.example - 123\n42\n{root_hash}\nTimestamp: 1\n"
+        checkpoint = LogCheckpoint.from_text(text)
+        assert checkpoint.origin == "rekor.example - 123"
+        assert checkpoint.log_size == 42
+        assert checkpoint.log_hash == (b"\x00" * 32).hex()
+        assert checkpoint.other_content == ["Timestamp: 1"]
+
+    def test_from_text_too_few_lines(self):
+        with pytest.raises(VerificationError, match="too few items"):
+            LogCheckpoint.from_text("rekor.example - 123\n42\n")
+
+    def test_from_text_invalid_log_size(self):
+        # A non-integer log size must surface as a VerificationError rather than
+        # leaking a raw ValueError to callers that only expect VerificationError.
+        root_hash = base64.b64encode(b"\x00" * 32).decode()
+        with pytest.raises(VerificationError, match="invalid log size"):
+            LogCheckpoint.from_text(f"rekor.example - 123\nNOTANINT\n{root_hash}\n")
+
+    def test_from_text_invalid_root_hash(self):
+        # An undecodable base64 root hash must also surface as a VerificationError.
+        with pytest.raises(VerificationError, match="invalid root hash"):
+            LogCheckpoint.from_text("rekor.example - 123\n42\n!!!notbase64!!!\n")


### PR DESCRIPTION
#### Summary

While reading through the checkpoint parser I noticed that `LogCheckpoint.from_text` calls `int(lines[1])` for the log size and `base64.b64decode(lines[2])` for the root hash without guarding either one. If a bundle's inclusion-proof checkpoint has a log-size line that isn't an integer, or a root-hash line that isn't valid base64, those calls raise `ValueError` / `binascii.Error`.

This is reachable during verification: `verify_checkpoint` runs `SignedCheckpoint.from_text` on the (attacker-controlled) checkpoint envelope, and the verifier only expects `VerificationError` there, so a malformed bundle surfaces an unexpected exception type instead of a clean verification failure. The rest of the parser already reports malformed input as `VerificationError`, so this just makes those two conversions consistent. It's a robustness fix, not a verification bypass: the malformed input still fails, just with the right error type.

To reproduce before the fix: `LogCheckpoint.from_text("rekor.example - 123\nNOTANINT\nYWJjZA==\n")` raises a bare `ValueError`. I added a unit test covering both the non-integer size and the bad-base64 hash, and confirmed it fails on the old code and passes with the guard. The rest of the offline unit suite still passes.

#### Release Note

Fixed: a malformed checkpoint in a bundle now raises `VerificationError` during verification instead of a raw `ValueError` / `binascii.Error`.

#### Documentation

No documentation changes needed.