### PR TITLE
Return cached cert first when signing

### DIFF
--- a/sigstore/sign.py
+++ b/sigstore/sign.py
@@ -151,36 +151,35 @@ class Signer:
         the returned certificate is present in Fulcio's CT log.
         """
 
-        # Our CSR cannot possibly succeed if our underlying identity token
-        # is expired.
-        if not self._identity_token.in_validity_period():
-            raise ExpiredIdentity
-
-        # If it exists, verify if the current certificate is expired
+        # If a cached certificate exists, use it until it expires.
         if self.__cached_signing_certificate:
             not_valid_after = self.__cached_signing_certificate.not_valid_after_utc
             if datetime.now(timezone.utc) > not_valid_after:
                 raise ExpiredCertificate
             return self.__cached_signing_certificate
 
-        else:
-            _logger.debug("Retrieving signed certificate...")
+        # Our CSR cannot possibly succeed if our underlying identity token
+        # is expired.
+        if not self._identity_token.in_validity_period():
+            raise ExpiredIdentity
 
-            certificate_request = self._build_csr()
+        _logger.debug("Retrieving signed certificate...")
 
-            certificate_response = self._signing_ctx._fulcio.signing_cert.post(
-                certificate_request, self._identity_token
-            )
+        certificate_request = self._build_csr()
 
-            verify_sct(
-                certificate_response.cert,
-                certificate_response.chain,
-                self._signing_ctx._trusted_root.ct_keyring(KeyringPurpose.SIGN),
-            )
+        certificate_response = self._signing_ctx._fulcio.signing_cert.post(
+            certificate_request, self._identity_token
+        )
 
-            _logger.debug("Successfully verified SCT...")
+        verify_sct(
+            certificate_response.cert,
+            certificate_response.chain,
+            self._signing_ctx._trusted_root.ct_keyring(KeyringPurpose.SIGN),
+        )
 
-            return certificate_response.cert
+        _logger.debug("Successfully verified SCT...")
+
+        return certificate_response.cert
 
     def _finalize_sign(
         self,

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import hashlib
 import secrets
+from datetime import datetime, timedelta, timezone
 
 import cryptography.x509 as x509
 import pretend
@@ -70,6 +71,18 @@ def test_build_csr_non_ascii_identity_produces_valid_csr():
     der = csr.public_bytes(serialization.Encoding.DER)
     reparsed = x509.load_der_x509_csr(der)
     assert len(reparsed.subject) == 0
+
+
+def test_signer_uses_valid_cached_certificate_with_expired_identity():
+    cert = pretend.stub(
+        not_valid_after_utc=datetime.now(timezone.utc) + timedelta(minutes=5)
+    )
+
+    signer = Signer.__new__(Signer)
+    signer._identity_token = pretend.stub(in_validity_period=lambda: False)
+    signer._Signer__cached_signing_certificate = cert
+
+    assert signer._signing_cert() is cert
 
 
 # only check the log contents for production: staging is already on

--- a/test/unit/test_sign.py
+++ b/test/unit/test_sign.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import hashlib
 import secrets
-from datetime import datetime, timedelta, timezone
 
 import cryptography.x509 as x509
 import pretend
@@ -73,16 +72,20 @@ def test_build_csr_non_ascii_identity_produces_valid_csr():
     assert len(reparsed.subject) == 0
 
 
-def test_signer_uses_valid_cached_certificate_with_expired_identity():
-    cert = pretend.stub(
-        not_valid_after_utc=datetime.now(timezone.utc) + timedelta(minutes=5)
-    )
+@pytest.mark.staging
+@pytest.mark.ambient_oidc
+def test_signer_uses_valid_cached_certificate_with_expired_identity(staging):
+    ctx_cls, _, identity = staging
+    ctx: SigningContext = ctx_cls()
+    assert identity is not None
 
-    signer = Signer.__new__(Signer)
-    signer._identity_token = pretend.stub(in_validity_period=lambda: False)
-    signer._Signer__cached_signing_certificate = cert
-
-    assert signer._signing_cert() is cert
+    # Constructing a cached signer obtains its certificate while the token is
+    # valid. Expire the local token afterward, then perform a real signing
+    # operation: it must reuse the still-valid cached certificate.
+    with ctx.signer(identity) as signer:
+        identity._exp = 0
+        assert not signer._identity_token.in_validity_period()
+        signer.sign_artifact(secrets.token_bytes(32))
 
 
 # only check the log contents for production: staging is already on


### PR DESCRIPTION
From the discussion in https://github.com/sigstore/sigstore-python/issues/1729#issuecomment-5069835340

When signing, use the (valid) cached cert even if the identity token is already expired.

Should fix https://github.com/pypa/gh-action-pypi-publish/issues/415 once we make a release and update `pypi-attestations` with it.