### PR TITLE
Preserve the validation error when parsing a malformed statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Parsing a malformed in-toto statement now includes the underlying validation
+  error, instead of discarding it. `StatementBuilder.build()` already did this;
+  `Statement(contents=...)` did not, so a rejected digest algorithm, a missing
+  field and a bad `_type` were indistinguishable.
+
 ## [4.5.0]
 
 ### Fixed

--- a/sigstore/dsse/__init__.py
+++ b/sigstore/dsse/__init__.py
@@ -95,8 +95,8 @@ class Statement:
             self._contents = contents
             try:
                 self._inner = _Statement.model_validate_json(contents)
-            except ValidationError:
-                raise Error("malformed in-toto statement")
+            except ValidationError as e:
+                raise Error(f"malformed in-toto statement: {e}") from e
         else:
             self._contents = contents.model_dump_json(by_alias=True).encode()
             self._inner = contents

--- a/test/unit/test_dsse.py
+++ b/test/unit/test_dsse.py
@@ -18,7 +18,7 @@ import json
 import pytest
 
 from sigstore import dsse
-from sigstore.dsse import InvalidEnvelope
+from sigstore.dsse import Error, InvalidEnvelope
 
 
 class TestEnvelope:
@@ -84,3 +84,26 @@ class TestEnvelope:
 
         with pytest.raises(InvalidEnvelope, match="one signature"):
             dsse.Envelope._from_json(raw)
+
+
+class TestStatement:
+    def test_malformed_statement_reports_why(self):
+        # An unsupported digest algorithm is rejected by design, but the caller
+        # is left guessing: the same message covers a missing field, a bad
+        # _type, and a rejected digest. StatementBuilder.build() already
+        # surfaces the underlying validation error; parsing should too.
+        raw = json.dumps(
+            {
+                "_type": "https://in-toto.io/Statement/v1",
+                "subject": [{"name": "foo", "digest": {"gitCommit": "a" * 40}}],
+                "predicateType": "https://example.com/predicate/v1",
+                "predicate": {},
+            }
+        )
+
+        with pytest.raises(Error, match="malformed in-toto statement") as exc:
+            dsse.Statement(raw.encode())
+
+        # the cause is preserved, and names the offending field
+        assert exc.value.__cause__ is not None
+        assert "digest" in str(exc.value)


### PR DESCRIPTION
`Statement(contents=...)` discards the pydantic `ValidationError`, so callers get `malformed in-toto statement` with no indication of what was malformed — a rejected digest algorithm, a missing field and a bad `_type` are indistinguishable, and `__cause__` is `None`.

`StatementBuilder.build()` in the same module already surfaces it:

```python
except ValidationError as e:
    raise Error(f"invalid statement: {e}")
```

This makes the parsing path match.

Found while parsing a statement whose subject used `gitCommit`. That rejection is deliberate per #1018 and this doesn't change it — only what the caller is told about it.

The test asserts the cause is preserved and that the message names the offending field; it fails without the change:

```
AssertionError: assert None is not None
 +  where None = Error('malformed in-toto statement').__cause__
```
