### PR TITLE
verify: raise MetadataError for trusted roots without tlogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* A `TrustedRoot` without transparency log instances now raises `MetadataError`
+  when constructing a `Verifier`, instead of leaking a raw `IndexError`
+  ([#1853](https://github.com/sigstore/sigstore-python/pull/1853))
+
 ## [4.5.0]
 
 ### Fixed

--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -52,7 +52,7 @@ from sigstore._internal.sct import (
 from sigstore._internal.timestamp import TimestampSource, TimestampVerificationResult
 from sigstore._internal.trust import KeyringPurpose
 from sigstore._utils import base64_encode_pem_cert, sha256_digest
-from sigstore.errors import CertValidationError, VerificationError
+from sigstore.errors import CertValidationError, MetadataError, VerificationError
 from sigstore.hashes import Hashed
 from sigstore.models import Bundle, ClientTrustConfig, TrustedRoot
 from sigstore.verify.policy import VerificationPolicy
@@ -79,6 +79,9 @@ class Verifier:
 
         `trusted_root` is the `TrustedRoot` object containing the root of trust
         for the verification process.
+
+        Raises `MetadataError` if `trusted_root` contains no transparency log
+        instances, since a Sigstore instance is expected to have at least one.
         """
         self._fulcio_certificate_chain: list[X509] = [
             X509.from_cryptography(parent_cert)
@@ -88,6 +91,8 @@ class Verifier:
 
         # this is an ugly hack needed for verifying "detached" materials
         # In reality we should be choosing the rekor instance based on the logid
+        if not trusted_root._inner.tlogs:
+            raise MetadataError("Transparency log instances not found in trusted root")
         url = trusted_root._inner.tlogs[0].base_url
         self._rekor = RekorClient(url)
 

--- a/test/assets/trusted_root/trustedroot.no_tlogs.json
+++ b/test/assets/trusted_root/trustedroot.no_tlogs.json
@@ -1,0 +1,99 @@
+{
+    "mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1",
+    "tlogs": [],
+    "certificateAuthorities": [
+        {
+            "subject": {
+                "organization": "sigstore.dev",
+                "commonName": "sigstore"
+            },
+            "uri": "https://fulcio.sigstore.dev",
+            "certChain": {
+                "certificates": [
+                    {
+                        "rawBytes": "MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLbuhzAKBggqhkjOPQQDAzAqMRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIxMDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSyA7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0JcastaRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6NmMGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYEFMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2uSu1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJxVe/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uupHr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ=="
+                    }
+                ]
+            },
+            "validFor": {
+                "start": "2021-03-07T03:20:29.000Z",
+                "end": "2022-12-31T23:59:59.999Z"
+            }
+        },
+        {
+            "subject": {
+                "organization": "sigstore.dev",
+                "commonName": "sigstore"
+            },
+            "uri": "https://fulcio.sigstore.dev",
+            "certChain": {
+                "certificates": [
+                    {
+                        "rawBytes": "MIICGjCCAaGgAwIBAgIUALnViVfnU0brJasmRkHrn/UnfaQwCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMjA0MTMyMDA2MTVaFw0zMTEwMDUxMzU2NThaMDcxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEeMBwGA1UEAxMVc2lnc3RvcmUtaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8RVS/ysH+NOvuDZyPIZtilgUF9NlarYpAd9HP1vBBH1U5CV77LSS7s0ZiH4nE7Hv7ptS6LvvR/STk798LVgMzLlJ4HeIfF3tHSaexLcYpSASr1kS0N/RgBJz/9jWCiXno3sweTAOBgNVHQ8BAf8EBAMCAQYwEwYDVR0lBAwwCgYIKwYBBQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0jBBgwFoAUWMAeX5FFpWapesyQoZMi0CrFxfowCgYIKoZIzj0EAwMDZwAwZAIwPCsQK4DYiZYDPIaDi5HFKnfxXx6ASSVmERfsynYBiX2X6SJRnZU84/9DZdnFvvxmAjBOt6QpBlc4J/0DxvkTCqpclvziL6BCCPnjdlIB3Pu3BxsPmygUY7Ii2zbdCdliiow="
+                    },
+                    {
+                        "rawBytes": "MIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7XeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxexX69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92jYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRYwB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQKsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCMWP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ"
+                    }
+                ]
+            },
+            "validFor": {
+                "start": "2022-04-13T20:06:15.000Z"
+            }
+        }
+    ],
+    "ctlogs": [
+        {
+            "baseUrl": "https://ctfe.sigstore.dev/test",
+            "hashAlgorithm": "SHA2_256",
+            "publicKey": {
+                "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbfwR+RJudXscgRBRpKX1XFDy3PyudDxz/SfnRi1fT8ekpfBd2O1uoz7jr3Z8nKzxA69EUQ+eFCFI3zeubPWU7w==",
+                "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+                "validFor": {
+                    "start": "2021-03-14T00:00:00.000Z",
+                    "end": "2022-10-31T23:59:59.999Z"
+                }
+            },
+            "logId": {
+                "keyId": "CGCS8ChS/2hF0dFrJ4ScRWcYrBY9wzjSbea8IgY2b3I="
+            }
+        },
+        {
+            "baseUrl": "https://ctfe.sigstore.dev/2022",
+            "hashAlgorithm": "SHA2_256",
+            "publicKey": {
+                "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEiPSlFi0CmFTfEjCUqF9HuCEcYXNKAaYalIJmBZ8yyezPjTqhxrKBpMnaocVtLJBI1eM3uXnQzQGAJdJ4gs9Fyw==",
+                "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+                "validFor": {
+                    "start": "2022-10-20T00:00:00.000Z"
+                }
+            },
+            "logId": {
+                "keyId": "3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4="
+            }
+        }
+    ],
+    "timestampAuthorities": [
+        {
+            "subject": {
+                "organization": "GitHub, Inc.",
+                "commonName": "Internal Services Root"
+            },
+            "certChain": {
+                "certificates": [
+                    {
+                        "rawBytes": "MIIB3DCCAWKgAwIBAgIUchkNsH36Xa04b1LqIc+qr9DVecMwCgYIKoZIzj0EAwMwMjEVMBMGA1UEChMMR2l0SHViLCBJbmMuMRkwFwYDVQQDExBUU0EgaW50ZXJtZWRpYXRlMB4XDTIzMDQxNDAwMDAwMFoXDTI0MDQxMzAwMDAwMFowMjEVMBMGA1UEChMMR2l0SHViLCBJbmMuMRkwFwYDVQQDExBUU0EgVGltZXN0YW1waW5nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUD5ZNbSqYMd6r8qpOOEX9ibGnZT9GsuXOhr/f8U9FJugBGExKYp40OULS0erjZW7xV9xV52NnJf5OeDq4e5ZKqNWMFQwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMIMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAUaW1RudOgVt0leqY0WKYbuPr47wAwCgYIKoZIzj0EAwMDaAAwZQIwbUH9HvD4ejCZJOWQnqAlkqURllvu9M8+VqLbiRK+zSfZCZwsiljRn8MQQRSkXEE5AjEAg+VxqtojfVfu8DhzzhCx9GKETbJHb19iV72mMKUbDAFmzZ6bQ8b54Zb8tidy5aWe"
+                    },
+                    {
+                        "rawBytes": "MIICEDCCAZWgAwIBAgIUX8ZO5QXP7vN4dMQ5e9sU3nub8OgwCgYIKoZIzj0EAwMwODEVMBMGA1UEChMMR2l0SHViLCBJbmMuMR8wHQYDVQQDExZJbnRlcm5hbCBTZXJ2aWNlcyBSb290MB4XDTIzMDQxNDAwMDAwMFoXDTI4MDQxMjAwMDAwMFowMjEVMBMGA1UEChMMR2l0SHViLCBJbmMuMRkwFwYDVQQDExBUU0EgaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvMLY/dTVbvIJYANAuszEwJnQE1llftynyMKIMhh48HmqbVr5ygybzsLRLVKbBWOdZ21aeJz+gZiytZetqcyF9WlER5NEMf6JV7ZNojQpxHq4RHGoGSceQv/qvTiZxEDKo2YwZDAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQUaW1RudOgVt0leqY0WKYbuPr47wAwHwYDVR0jBBgwFoAU9NYYlobnAG4c0/qjxyH/lq/wz+QwCgYIKoZIzj0EAwMDaQAwZgIxAK1B185ygCrIYFlIs3GjswjnwSMG6LY8woLVdakKDZxVa8f8cqMs1DhcxJ0+09w95QIxAO+tBzZk7vjUJ9iJgD4R6ZWTxQWKqNm74jO99o+o9sv4FI/SZTZTFyMn0IJEHdNmyA=="
+                    },
+                    {
+                        "rawBytes": "MIIB9DCCAXqgAwIBAgIUa/JAkdUjK4JUwsqtaiRJGWhqLSowCgYIKoZIzj0EAwMwODEVMBMGA1UEChMMR2l0SHViLCBJbmMuMR8wHQYDVQQDExZJbnRlcm5hbCBTZXJ2aWNlcyBSb290MB4XDTIzMDQxNDAwMDAwMFoXDTMzMDQxMTAwMDAwMFowODEVMBMGA1UEChMMR2l0SHViLCBJbmMuMR8wHQYDVQQDExZJbnRlcm5hbCBTZXJ2aWNlcyBSb290MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEf9jFAXxz4kx68AHRMOkFBhflDcMTvzaXz4x/FCcXjJ/1qEKon/qPIGnaURskDtyNbNDOpeJTDDFqt48iMPrnzpx6IZwqemfUJN4xBEZfza+pYt/iyod+9tZr20RRWSv/o0UwQzAOBgNVHQ8BAf8EBAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBAjAdBgNVHQ4EFgQU9NYYlobnAG4c0/qjxyH/lq/wz+QwCgYIKoZIzj0EAwMDaAAwZQIxALZLZ8BgRXzKxLMMN9VIlO+e4hrBnNBgF7tz7Hnrowv2NetZErIACKFymBlvWDvtMAIwZO+ki6ssQ1bsZo98O8mEAf2NZ7iiCgDDU0Vwjeco6zyeh0zBTs9/7gV6AHNQ53xD"
+                    }
+                ]
+            },
+            "validFor": {
+                "start": "2023-04-14T00:00:00.000Z"
+            }
+        }
+    ]
+}

--- a/test/unit/verify/test_verifier.py
+++ b/test/unit/verify/test_verifier.py
@@ -24,8 +24,8 @@ import rfc3161_client
 
 from sigstore._internal.trust import CertificateAuthority
 from sigstore.dsse import StatementBuilder, Subject
-from sigstore.errors import VerificationError
-from sigstore.models import Bundle
+from sigstore.errors import MetadataError, VerificationError
+from sigstore.models import Bundle, TrustedRoot
 from sigstore.verify import policy
 from sigstore.verify.verifier import Verifier
 
@@ -40,6 +40,18 @@ def test_verifier_production():
 def test_verifier_staging():
     verifier = Verifier.staging()
     assert verifier is not None
+
+
+def test_verifier_no_tlogs(asset):
+    """A trusted root without transparency logs is rejected with a sigstore error."""
+    trusted_root = TrustedRoot.from_file(
+        str(asset("trusted_root/trustedroot.no_tlogs.json"))
+    )
+
+    with pytest.raises(
+        MetadataError, match="Transparency log instances not found in trusted root"
+    ):
+        Verifier(trusted_root=trusted_root)
 
 
 @pytest.mark.staging


### PR DESCRIPTION
#### Summary

`Verifier.__init__` picks the Rekor instance for "detached" materials by indexing the trusted root's transparency log list:

https://github.com/sigstore/sigstore-python/blob/2c74d8f38701bcaee4613091efc5c5ea463b87af/sigstore/verify/verifier.py#L89-L91

If the trusted root has no `tlogs`, that raises a bare `IndexError`, so a caller that handles `sigstore`'s own error types still gets an unhandled builtin exception:

```pycon
>>> tr = TrustedRoot.from_file("no_tlogs.json")   # trustedroot.v1.json with "tlogs": []
>>> Verifier(trusted_root=tr)
Traceback (most recent call last):
  ...
  File "sigstore/verify/verifier.py", line 91, in __init__
    url = trusted_root._inner.tlogs[0].base_url
IndexError: list index out of range
```

As @woodruffw noted in #1822, requiring at least one tlog is intentional — this only turns the crash into a structured error. After this change:

```pycon
>>> Verifier(trusted_root=tr)
sigstore.errors.MetadataError: Transparency log instances not found in trusted root
```

`MetadataError` is the type `models.py` already uses for the same class of problem, so this stays consistent with the existing messages:

* `"Did not find any Rekor keys in trusted root"`
* `"CTFE keys not found in trusted root"`
* `"Fulcio certificates not found in trusted root"`

It also means the CLI reports it through `Error.log_and_exit` like any other trusted-root problem rather than printing a traceback. No verification logic changes and nothing is loosened — a trusted root without tlogs is still rejected, just with a usable error.

I picked `MetadataError` over `VerificationError` because the failure is in constructing the verifier from trusted root metadata rather than in verifying a bundle, and because it keeps the three messages above consistent. Happy to switch it to `VerificationError` if you'd rather the entire `sigstore.verify` surface raise only that.

##### How to test

```console
$ make test TESTS=test_verifier_no_tlogs
```

Or the offline suite:

```console
$ python -m pytest test/unit -q --skip-staging --skip-online
167 passed, 37 skipped, 1 xpassed
```

That is `166 passed` on an unmodified checkout; the extra pass is the new test. `test_verifier_no_tlogs` fails without the fix with `IndexError: list index out of range`. It uses a new offline asset, `test/assets/trusted_root/trustedroot.no_tlogs.json`, which is `trustedroot.v1.json` with `"tlogs": []` — the certificate authorities are kept, since `get_fulcio_certs()` runs before the tlog lookup.

Lint is clean: `ruff format --check` (64 files already formatted), `ruff check` (all checks passed), `mypy sigstore` (no issues in 30 source files), `bandit -c pyproject.toml -r sigstore` (no issues), `docs/scripts/gen_ref_pages.py --check` (exit 0).

Closes #1822

#### Release Note

A `TrustedRoot` without transparency log instances now raises `MetadataError` when constructing a `Verifier`, instead of leaking a raw `IndexError`.

#### Documentation

No documentation change needed. The new failure mode is recorded in `Verifier.__init__`'s docstring, which is what the generated API reference renders.
