### PR TITLE
Remove pyasn1 dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,9 @@ classifiers = [
   "Topic :: Security :: Cryptography",
 ]
 dependencies = [
-  "cryptography >= 42",
+  "cryptography >= 47",
   "id >= 1.1.0",
   "importlib_resources ~= 5.7; python_version < '3.11'",
-  "pyasn1 ~= 0.6",
   "pydantic >= 2,< 3",
   "pyjwt >= 2.1",
   "pyOpenSSL >= 23.0.0",
@@ -134,3 +133,6 @@ ignore = [
   "UP011",
   "UP015",
 ]
+
+[tool.uv]
+exclude-newer = "P7D"

--- a/sigstore/verify/policy.py
+++ b/sigstore/verify/policy.py
@@ -23,6 +23,7 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Protocol
 
+from cryptography.hazmat import asn1
 from cryptography.x509 import (
     Certificate,
     ExtensionNotFound,
@@ -32,8 +33,6 @@ from cryptography.x509 import (
     SubjectAlternativeName,
     UniformResourceIdentifier,
 )
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.type.char import UTF8String
 
 from sigstore.errors import VerificationError
 
@@ -131,7 +130,7 @@ class _SingleX509ExtPolicyV2(_SingleX509ExtPolicy):
 
         # NOTE(ww): mypy is confused by the `Extension[ExtensionType]` returned
         # by `get_extension_for_oid` above.
-        ext_value = der_decode(ext.value, UTF8String)[0].decode()  # type: ignore[attr-defined]
+        ext_value = asn1.decode_der(str, ext.value)  # type: ignore[attr-defined]
         if ext_value != self._value:
             raise VerificationError(
                 f"Certificate's {self.__class__.__name__} does not match "

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -1270,15 +1274,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1710,7 +1705,6 @@ dependencies = [
     { name = "id" },
     { name = "importlib-resources", marker = "python_full_version < '3.11'" },
     { name = "platformdirs" },
-    { name = "pyasn1" },
     { name = "pydantic" },
     { name = "pyjwt" },
     { name = "pyopenssl" },
@@ -1741,11 +1735,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cryptography", specifier = ">=42" },
+    { name = "cryptography", specifier = ">=47" },
     { name = "id", specifier = ">=1.1.0" },
     { name = "importlib-resources", marker = "python_full_version < '3.11'", specifier = "~=5.7" },
     { name = "platformdirs", specifier = "~=4.2" },
-    { name = "pyasn1", specifier = "~=0.6" },
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "pyjwt", specifier = ">=2.1" },
     { name = "pyopenssl", specifier = ">=23.0.0" },


### PR DESCRIPTION
We can now use `cryptography.hazmat.asn1`, thanks to the hard work of @facutuesca and @DarkaMaul 🙂 

This should be a non-breaking change.