### PR TITLE
verify: raise MetadataError instead of IndexError for trusted roots with no tlogs (#1822)

### DIFF
--- a/sigstore/verify/verifier.py
+++ b/sigstore/verify/verifier.py
@@ -59,7 +59,7 @@ from sigstore._internal.sct import (
 from sigstore._internal.timestamp import TimestampSource, TimestampVerificationResult
 from sigstore._internal.trust import KeyringPurpose
 from sigstore._utils import base64_encode_pem_cert, sha256_digest
-from sigstore.errors import CertValidationError, VerificationError
+from sigstore.errors import CertValidationError, MetadataError, VerificationError
 from sigstore.hashes import Hashed
 from sigstore.models import Bundle, ClientTrustConfig, TrustedRoot
 from sigstore.verify.policy import VerificationPolicy
@@ -92,6 +92,8 @@ class Verifier:
 
         # this is an ugly hack needed for verifying "detached" materials
         # In reality we should be choosing the rekor instance based on the logid
+        if not trusted_root._inner.tlogs:
+            raise MetadataError("No transparency logs found in trusted root")
         url = trusted_root._inner.tlogs[0].base_url
         self._rekor = RekorClient(url)
 

--- a/test/unit/verify/test_verifier.py
+++ b/test/unit/verify/test_verifier.py
@@ -24,10 +24,41 @@ import rfc3161_client
 
 from sigstore._internal.trust import CertificateAuthority
 from sigstore.dsse import StatementBuilder, Subject
-from sigstore.errors import CertValidationError, VerificationError
+from sigstore.errors import CertValidationError, MetadataError, VerificationError
 from sigstore.models import Bundle
 from sigstore.verify import policy
 from sigstore.verify.verifier import Verifier
+
+
+def test_verifier_init_no_transparency_logs():
+    """
+    `Verifier.__init__` raises a structured `MetadataError` (rather than an
+    unhandled `IndexError`) when given a `trusted_root` with no
+    transparency logs. See #1822.
+    """
+    trusted_root = pretend.stub(
+        get_fulcio_certs=pretend.call_recorder(lambda: []),
+        _inner=pretend.stub(tlogs=[]),
+    )
+
+    with pytest.raises(MetadataError, match="No transparency logs"):
+        Verifier(trusted_root=trusted_root)
+
+
+def test_verifier_init_with_transparency_logs():
+    """
+    `Verifier.__init__` succeeds and picks the first transparency log's
+    `base_url` when `trusted_root` has at least one, proving the new
+    `MetadataError` guard doesn't affect the happy path.
+    """
+    tlog = pretend.stub(base_url="https://rekor.example.com")
+    trusted_root = pretend.stub(
+        get_fulcio_certs=pretend.call_recorder(lambda: []),
+        _inner=pretend.stub(tlogs=[tlog]),
+    )
+
+    verifier = Verifier(trusted_root=trusted_root)
+    assert verifier._rekor.url == "https://rekor.example.com/api/v1"
 
 
 @pytest.mark.production


### PR DESCRIPTION
## Bug

`Verifier.__init__` raises an unhandled `IndexError` when given a `trusted_root` with no transparency logs, instead of a documented `sigstore.errors` exception.

Fixes #1822

## Context

Per @woodruffw's comment on the issue: this is intentional (a Sigstore instance is expected to have at least one tlog), but "we could turn that into a more structured error." `Verifier` documents its failures as `VerificationError` (or subclasses), so a caller catching only that gets an unhandled crash.

## Fix

`TrustedRoot` already has an established pattern for this exact situation -- `rekor_keyring()`, `ct_keyring()`, and `get_fulcio_certs()` all raise `MetadataError` when required data is missing from the trusted root (e.g. `"Did not find any Rekor keys in trusted root"`, `"Fulcio certificates not found in trusted root"`). This PR applies the same pattern to `Verifier.__init__`: check `trusted_root._inner.tlogs` before indexing into it, and raise `MetadataError("No transparency logs found in trusted root")` instead of letting the `IndexError` propagate.

## Testing

Added two unit tests to `test/unit/verify/test_verifier.py`, using `pretend.stub` for `trusted_root` to avoid any network dependency (matching the file's existing style for non-network tests):

- `test_verifier_init_no_transparency_logs` -- a `trusted_root` with an empty `tlogs` list raises `MetadataError`.
- `test_verifier_init_with_transparency_logs` -- a `trusted_root` with a `tlogs` entry still constructs successfully and picks its `base_url`, proving the new guard doesn't affect the happy path.

Verified: `pytest test/unit --skip-staging -m "not production"` passes 177/177 (175 existing + 2 new), 28 skipped (network-marked). Reverting just `sigstore/verify/verifier.py` reproduces the exact reported `IndexError` in the new negative test while the positive test still passes, confirming this is a genuine regression guard. `ruff format --check`, `ruff check`, and `mypy sigstore/verify/verifier.py` (the project's actual `make lint` gate) are all clean.
