### PR TITLE
Fix #1448: rekorv2: request timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All versions prior to 0.9.0 are untracked.
 
 ## [Unreleased]
 
+### Fixed
+
+* Added a default request timeout to the Rekor v1 and v2 clients to prevent
+  requests from hanging indefinitely.
+
 ## [4.5.0]
 
 ### Fixed

--- a/sigstore/_internal/rekor/__init__.py
+++ b/sigstore/_internal/rekor/__init__.py
@@ -39,6 +39,13 @@ __all__ = [
 
 EntryRequestBody = typing.NewType("EntryRequestBody", dict[str, typing.Any])
 
+# The (connect, read) timeout used for every Rekor request: a short connect
+# timeout so that an unreachable log fails fast, and a generous read timeout
+# because `create_entry` only responds once the entry has been included in
+# the log.
+# See: https://github.com/sigstore/rekor-tiles/blob/main/CLIENTS.md#handling-longer-requests
+DEFAULT_REKOR_TIMEOUT = (5, 60)
+
 
 class RekorClientError(Exception):
     """

--- a/sigstore/_internal/rekor/client.py
+++ b/sigstore/_internal/rekor/client.py
@@ -33,6 +33,7 @@ from cryptography.x509 import Certificate
 
 from sigstore._internal import USER_AGENT
 from sigstore._internal.rekor import (
+    DEFAULT_REKOR_TIMEOUT,
     EntryRequestBody,
     RekorClientError,
     RekorLogSubmitter,
@@ -90,7 +91,9 @@ class RekorLog(_Endpoint):
         """
         Returns information about the Rekor instance's log.
         """
-        resp: requests.Response = self.session.get(self.url)
+        resp: requests.Response = self.session.get(
+            self.url, timeout=DEFAULT_REKOR_TIMEOUT
+        )
         try:
             resp.raise_for_status()
         except requests.HTTPError as http_error:
@@ -125,9 +128,13 @@ class RekorEntries(_Endpoint):
         resp: requests.Response
 
         if uuid is not None:
-            resp = self.session.get(f"{self.url}/{uuid}")
+            resp = self.session.get(f"{self.url}/{uuid}", timeout=DEFAULT_REKOR_TIMEOUT)
         else:
-            resp = self.session.get(self.url, params={"logIndex": log_index})
+            resp = self.session.get(
+                self.url,
+                params={"logIndex": log_index},
+                timeout=DEFAULT_REKOR_TIMEOUT,
+            )
 
         try:
             resp.raise_for_status()
@@ -145,7 +152,9 @@ class RekorEntries(_Endpoint):
 
         _logger.debug(f"proposed: {json.dumps(payload)}")
 
-        resp: requests.Response = self.session.post(self.url, json=payload)
+        resp: requests.Response = self.session.post(
+            self.url, json=payload, timeout=DEFAULT_REKOR_TIMEOUT
+        )
         try:
             resp.raise_for_status()
         except requests.HTTPError as http_error:
@@ -181,7 +190,9 @@ class RekorEntriesRetrieve(_Endpoint):
         """
         data = {"entries": [expected_entry.model_dump(mode="json", by_alias=True)]}
 
-        resp: requests.Response = self.session.post(self.url, json=data)
+        resp: requests.Response = self.session.post(
+            self.url, json=data, timeout=DEFAULT_REKOR_TIMEOUT
+        )
         try:
             resp.raise_for_status()
         except requests.HTTPError as http_error:

--- a/sigstore/_internal/rekor/client_v2.py
+++ b/sigstore/_internal/rekor/client_v2.py
@@ -33,6 +33,7 @@ from sigstore_models.rekor.v1 import TransparencyLogEntry as _TransparencyLogEnt
 from sigstore._internal import USER_AGENT
 from sigstore._internal.key_details import _get_key_details, _get_prehash
 from sigstore._internal.rekor import (
+    DEFAULT_REKOR_TIMEOUT,
     EntryRequestBody,
     RekorClientError,
     RekorLogSubmitter,
@@ -90,6 +91,7 @@ class RekorV2Client(RekorLogSubmitter):
         resp = self._session.post(
             f"{self.url}/log/entries",
             json=payload,
+            timeout=DEFAULT_REKOR_TIMEOUT,
         )
 
         try:

--- a/test/unit/internal/rekor/test_client.py
+++ b/test/unit/internal/rekor/test_client.py
@@ -1,0 +1,76 @@
+# Copyright 2026 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest.mock
+
+import pytest
+
+from sigstore._internal.rekor import DEFAULT_REKOR_TIMEOUT, EntryRequestBody
+from sigstore._internal.rekor.client import RekorClient
+
+
+def _client_with_mock_session():
+    client = RekorClient("http://fake")
+    session = unittest.mock.MagicMock()
+    client._thread_local.session = session
+    return client, session
+
+
+def test_log_get_passes_timeout():
+    client, session = _client_with_mock_session()
+
+    # Hide exceptions: the mocked response is not a valid API response, and we
+    # only care about how the request itself was made.
+    try:
+        client.log.get()
+    except Exception:
+        pass
+
+    assert session.get.call_args.kwargs["timeout"] == DEFAULT_REKOR_TIMEOUT
+
+
+@pytest.mark.parametrize(
+    "kwargs", [{"uuid": "deadbeef"}, {"log_index": 1}], ids=["uuid", "log_index"]
+)
+def test_entries_get_passes_timeout(kwargs):
+    client, session = _client_with_mock_session()
+
+    try:
+        client.log.entries.get(**kwargs)
+    except Exception:
+        pass
+
+    assert session.get.call_args.kwargs["timeout"] == DEFAULT_REKOR_TIMEOUT
+
+
+def test_entries_post_passes_timeout():
+    client, session = _client_with_mock_session()
+
+    try:
+        client.create_entry(EntryRequestBody({}))
+    except Exception:
+        pass
+
+    assert session.post.call_args.kwargs["timeout"] == DEFAULT_REKOR_TIMEOUT
+
+
+def test_entries_retrieve_post_passes_timeout():
+    client, session = _client_with_mock_session()
+
+    try:
+        client.log.entries.retrieve.post(unittest.mock.MagicMock())
+    except Exception:
+        pass
+
+    assert session.post.call_args.kwargs["timeout"] == DEFAULT_REKOR_TIMEOUT

--- a/test/unit/internal/rekor/test_client_v2.py
+++ b/test/unit/internal/rekor/test_client_v2.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 import hashlib
+import unittest.mock
 
 import pytest
 
 from sigstore import dsse
+from sigstore._internal.rekor import DEFAULT_REKOR_TIMEOUT, EntryRequestBody
+from sigstore._internal.rekor.client_v2 import RekorV2Client
 from sigstore.models import TransparencyLogEntry
 
 
@@ -64,3 +67,19 @@ def test_rekor_v2_create_entry_hashed_rekord(staging):
         bundle = signer.sign_artifact(b"")
 
     assert isinstance(bundle.log_entry, TransparencyLogEntry)
+
+
+def test_rekor_v2_create_entry_passes_timeout():
+    """`create_entry` passes the default timeout to the underlying session."""
+    client = RekorV2Client("http://fake")
+    session = unittest.mock.MagicMock()
+    client._thread_local.session = session
+
+    # Hide exceptions: the mocked response is not a valid log entry, and we
+    # only care about how the request itself was made.
+    try:
+        client.create_entry(EntryRequestBody({}))
+    except Exception:
+        pass
+
+    assert session.post.call_args.kwargs["timeout"] == DEFAULT_REKOR_TIMEOUT


### PR DESCRIPTION
Give both Rekor clients a connect and read timeout so a hung log cannot hang the caller

Resolves #1448.

---
**AI disclosure.** Claude Code (Anthropic) was used to write the change: it edited the repository directly under my review, and the target's own test suite was run before I approved this PR. AI-generated: the code in `CHANGELOG.md`, `sigstore/_internal/rekor/__init__.py`, `sigstore/_internal/rekor/client.py`, `sigstore/_internal/rekor/client_v2.py`, `test/unit/internal/rekor/test_client_v2.py`, `test/unit/internal/rekor/test_client.py`. Written by me: this description and the review of the change, which I understand and can explain.