### PR TITLE
ci: run conformance tests against staging

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -34,6 +34,13 @@ jobs:
             test_verify*managed-key-happy-path]
             test_verify*managed-key-and-trusted-root]" # see issues 1442, 1244
 
+      - uses: sigstore/sigstore-conformance@21533cde107c734ebc153c3e3a24d75fc9811a36 # v0.0.29
+        with:
+          entrypoint: ${{ github.workspace }}/test/integration/sigstore-python-conformance
+          environment: staging
+          xfail: "test_verify*intoto-with-custom-trust-root]
+            test_verify*managed-key-happy-path]
+            test_verify*managed-key-and-trusted-root]" # see issues 1442, 1244
   file-issue-on-failure:
     needs: [ conformance ]
     if: failure() && github.event_name == 'schedule' && github.repository ==


### PR DESCRIPTION
Closes #942.

The current conformance client already supports the `--staging` argument. This completes the remaining workflow side of #942 by adding a second `sigstore-conformance` invocation with `environment: staging`, matching the usage documented by `sigstore-conformance`.

The staging run uses the same existing `xfail` configuration as the production run.

Validation:
- `git diff --check`
- workflow-only change; no application code changed