### PR TITLE
Close OAuth redirect server socket

### DIFF
--- a/sigstore/_internal/oidc/oauth.py
+++ b/sigstore/_internal/oidc/oauth.py
@@ -131,8 +131,11 @@ class _OAuthFlow:
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        self._server.shutdown()
-        self._server_thread.join()
+        try:
+            self._server.shutdown()
+            self._server_thread.join()
+        finally:
+            self._server.server_close()
 
 
 class _OAuthRedirectHandler(http.server.BaseHTTPRequestHandler):

--- a/test/unit/internal/oidc/test_oauth.py
+++ b/test/unit/internal/oidc/test_oauth.py
@@ -1,0 +1,40 @@
+# Copyright 2026 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gc
+import warnings
+from types import SimpleNamespace
+
+from sigstore._internal.oidc.oauth import _OAuthFlow
+
+
+def test_oauth_flow_closes_redirect_server_socket():
+    issuer = SimpleNamespace(
+        oidc_config=SimpleNamespace(authorization_endpoint="https://example.com/auth")
+    )
+
+    with warnings.catch_warnings(record=True) as warnings_seen:
+        warnings.simplefilter("always", ResourceWarning)
+        flow = _OAuthFlow("sigstore", "", issuer)
+        with flow as server:
+            assert server.server_port
+
+        del server
+        del flow
+        gc.collect()
+
+    resource_warnings = [
+        warning for warning in warnings_seen if warning.category is ResourceWarning
+    ]
+    assert not resource_warnings


### PR DESCRIPTION
#### Summary
Partially addresses #549.

`_OAuthFlow.__exit__` shut down the OAuth redirect HTTP server and joined its thread, but did not close the server socket. That left the listening socket to be closed by garbage collection, which emits a `ResourceWarning`. This adds `server_close()` in a `finally` block and adds a regression test that forces garbage collection after the OAuth flow exits.

This PR is deliberately scoped to the local redirect-server socket. Issue #549 also reports a separate unclosed SSL socket associated with `Issuer.session`; this PR does not change that session lifecycle, so the issue should remain open for follow-up.

Tested:
- `uv run --locked --dev pytest -q test/unit/internal/oidc/test_oauth.py` (failed before the fix, passes after)
- `uv run --locked --dev pytest -q test/unit --skip-online --skip-staging`
- `uv run --locked --dev ruff format --check sigstore test docs/scripts`
- `uv run --locked --dev ruff check sigstore test docs/scripts`
- `uv run --locked --dev mypy sigstore`
- `uv run --locked --dev bandit -c pyproject.toml -r sigstore`
- `uv run --locked --dev python docs/scripts/gen_ref_pages.py --check`

Also tried `uv run --locked --dev pytest -q test --skip-online --skip-staging`; on Windows this hits an unrelated TUF symlink privilege failure (`WinError 1314`) in `test/integration/cli/test_plumbing.py`.

#### Release Note
Fixed OAuth redirect flow cleanup so the local redirect server socket is closed after use.

#### Documentation
No documentation update needed; this is internal resource cleanup.