### PR TITLE
Improve old version testing

### DIFF
--- a/.github/workflows/cross-version-verify.yaml
+++ b/.github/workflows/cross-version-verify.yaml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false # Don't cancel other jobs if one fails
       matrix:
         # hand crafted list of old versions we care about
-        version: [ 3.5.6, 3.6.7, 4.0.0, 4.1.0, 4.2.0 ]
+        version: [ 3.5.6, 3.6.7, 4.0.0, 4.1.0, 4.2.0, 4.3.0, 4.4.0, 4.5.0 ]
         env: [ staging, prod ]
         exclude:
           # exclude staging for versions with https://github.com/sigstore/sigstore-python/issues/1656

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "sigstore-models == 0.0.6",
   "sigstore-rekor-types == 0.0.18",
   "tuf >= 6, < 8",
+  "securesystemslib[crypto]",
   "platformdirs ~= 4.2",
 ]
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1675,6 +1675,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/29/1c560f46b3a95d8c508e1bd8c6d0bbf53c42d412ee7d19ec2a89ceced5b9/securesystemslib-1.3.1-py3-none-any.whl", hash = "sha256:2e5414bbdde33155a91805b295cbedc4ae3f12b48dccc63e1089093537f43c81", size = 871380, upload-time = "2025-09-26T13:36:54.851Z" },
 ]
 
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
 [[package]]
 name = "setuptools"
 version = "83.0.0"
@@ -1698,6 +1703,7 @@ dependencies = [
     { name = "rfc3161-client" },
     { name = "rfc8785" },
     { name = "rich" },
+    { name = "securesystemslib", extra = ["crypto"] },
     { name = "sigstore-models" },
     { name = "sigstore-rekor-types" },
     { name = "tuf" },
@@ -1730,6 +1736,7 @@ requires-dist = [
     { name = "rfc3161-client", specifier = ">=1.0.3,<1.1.0" },
     { name = "rfc8785", specifier = "~=0.1.2" },
     { name = "rich", specifier = ">=13,<16" },
+    { name = "securesystemslib", extras = ["crypto"] },
     { name = "sigstore-models", specifier = "==0.0.6" },
     { name = "sigstore-rekor-types", specifier = "==0.0.18" },
     { name = "tuf", specifier = ">=6,<8" },


### PR DESCRIPTION
This is related to #1887:
* Test all recent release versions in CI
* actually depend on `securesystemslib[crypto]` to get correct requirement versions installed

The latter of course does not fix old versions: just prevents this from happening again.

The old version tests are ok now as securesystemslib 1.5.0 was yanked